### PR TITLE
List both confirmed and unconfirmed transactions

### DIFF
--- a/src/bdk.udl
+++ b/src/bdk.udl
@@ -63,13 +63,22 @@ interface DatabaseConfig {
   Sled(SledDbConfiguration config);
 };
 
-dictionary ConfirmedTransaction {
+dictionary TransactionDetails {
     u64? fees;
-    u32 height;
-    u64 timestamp;
     u64 received;
     u64 sent;
     string id;
+};
+
+dictionary Confirmation {
+    u32 height;
+    u64 timestamp;
+};
+
+[Enum]
+interface Transaction {
+  Unconfirmed(TransactionDetails details);
+  Confirmed(TransactionDetails details, Confirmation confirmation);
 };
 
 interface OfflineWallet {
@@ -83,7 +92,7 @@ interface OfflineWallet {
   [Throws=BdkError]
   void sign([ByRef] PartiallySignedBitcoinTransaction psbt);
   [Throws=BdkError]
-  sequence<ConfirmedTransaction> get_transactions();
+  sequence<Transaction> get_transactions();
 };
 
 dictionary ElectrumConfig {
@@ -123,7 +132,7 @@ interface OnlineWallet {
   [Throws=BdkError]
   void sign([ByRef] PartiallySignedBitcoinTransaction psbt);
   [Throws=BdkError]
-  sequence<ConfirmedTransaction> get_transactions();
+  sequence<Transaction> get_transactions();
 
   // OnlineWalletInterface
   Network get_network();


### PR DESCRIPTION
In `Wallet::getTransactions` we used to filter out unconfirmed transactions. We no longer do that as per [comment](https://github.com/notmandatory/bdk-ffi/pull/18#issuecomment-945018006) in #18 .

![image](https://user-images.githubusercontent.com/3091087/137726586-1e442fe7-c9ce-4dfc-a631-7b14cae68ca1.png)
