### PR TITLE
Refactor transaction 'id' property to 'txid'

### DIFF
--- a/bindings/bdk-kotlin/demo/src/main/kotlin/Main.kt
+++ b/bindings/bdk-kotlin/demo/src/main/kotlin/Main.kt
@@ -18,8 +18,8 @@ fun getTransaction(wallet: OnlineWalletInterface, transactionId: String): Option
             .stream()
             .filter({
                 when (it) {
-                    is Transaction.Confirmed -> it.details.id.equals(transactionId)
-                    is Transaction.Unconfirmed -> it.details.id.equals(transactionId)
+                    is Transaction.Confirmed -> it.details.txid.equals(transactionId)
+                    is Transaction.Unconfirmed -> it.details.txid.equals(transactionId)
                 }
             })
             .findFirst()
@@ -32,7 +32,7 @@ val unconfirmedFirstThenByTimestampDescending =
                 (a is Transaction.Confirmed && b is Transaction.Confirmed) -> {
                     val comparison = b.confirmation.timestamp.compareTo(a.confirmation.timestamp)
                     when {
-                        comparison == 0 -> b.details.id.compareTo(a.details.id)
+                        comparison == 0 -> b.details.txid.compareTo(a.details.txid)
                         else -> comparison
                     }
                 }

--- a/examples/ios/IOSBdkAppSample/TransactionsView.swift
+++ b/examples/ios/IOSBdkAppSample/TransactionsView.swift
@@ -31,12 +31,12 @@ struct TransactionView: View {
         VStack(alignment: .leading) {
             switch transaction {
             case .unconfirmed(let details):
-                Text("id: \(details.id)")
+                Text("txid: \(details.txid)")
                 Text("sent: \(details.sent)")
                 Text("received: \(details.received)")
                 Text("fees: \(details.fees ?? 0)")
             case .confirmed(let details, let confirmation):
-                Text("id: \(details.id)")
+                Text("txid: \(details.txid)")
                 Text("sent: \(details.sent)")
                 Text("received: \(details.received)")
                 Text("fees: \(details.fees ?? 0)")
@@ -70,6 +70,6 @@ struct TransactionsView: View {
 
 struct TransactionsView_Previews: PreviewProvider {
     static var previews: some View {
-        TransactionsView(transactions: [Transaction.unconfirmed(details: TransactionDetails(fees: nil, received: 1000, sent: 10000, id: "some-tx-id")), Transaction.confirmed(details: TransactionDetails(fees: nil, received: 1000, sent: 10000, id: "some-other-tx-id"), confirmation: Confirmation(height: 20087, timestamp: 1635863544))])
+        TransactionsView(transactions: [Transaction.unconfirmed(details: TransactionDetails(fees: nil, received: 1000, sent: 10000, txid: "some-txid")), Transaction.confirmed(details: TransactionDetails(fees: nil, received: 1000, sent: 10000, txid: "some-other-txid"), confirmation: Confirmation(height: 20087, timestamp: 1635863544))])
     }
 }

--- a/src/bdk.udl
+++ b/src/bdk.udl
@@ -70,7 +70,7 @@ dictionary TransactionDetails {
     u64? fees;
     u64 received;
     u64 sent;
-    string id;
+    string txid;
 };
 
 dictionary Confirmation {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,7 +66,7 @@ pub struct TransactionDetails {
     pub fees: Option<u64>,
     pub received: u64,
     pub sent: u64,
-    pub id: String,
+    pub txid: String,
 }
 
 type Confirmation = ConfirmationTime;
@@ -86,7 +86,7 @@ impl From<&bdk::TransactionDetails> for TransactionDetails {
     fn from(x: &bdk::TransactionDetails) -> TransactionDetails {
         TransactionDetails {
             fees: x.fee,
-            id: x.txid.to_string(),
+            txid: x.txid.to_string(),
             received: x.received,
             sent: x.sent,
         }


### PR DESCRIPTION
This is a small refactor of the `TransactionDetails` object, renaming the `id` property to `txid`.

- [x] I have PGP signed my commit.

I ran the Android demo and the tests and everything works well. I couldn't test the iOS side however, but all mentions of `id` have been changed to `txid` in the iOS demo as well.
