### PR TITLE
Pin anyhow version to "=1.0.45"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ bdk = { version = "0.13", features = ["all-keys", "use-esplora-ureq"] }
 uniffi_macros = "0.14.1"
 uniffi = "0.14.1"
 thiserror = "1.0"
+anyhow = "=1.0.45" # remove after upgrading to next version of uniffi
 
 [build-dependencies]
 uniffi_build = "0.14.1"


### PR DESCRIPTION
This change can be removed after upgrading to the next version of `uniffi-rs`.

See: https://github.com/mozilla/uniffi-rs/issues/1109