### PR TITLE
Add PSBT deserialize and serialize functions, remove details

### DIFF
--- a/src/bdk.udl
+++ b/src/bdk.udl
@@ -131,6 +131,9 @@ interface Wallet {
 interface PartiallySignedBitcoinTransaction {
   [Throws=BdkError]
   constructor([ByRef] Wallet wallet, string recipient, u64 amount, float? fee_rate);
+  [Name=deserialize,Throws=BdkError]
+  constructor(string psbt_base64);
+  string serialize();
 };
 
 dictionary ExtendedKeyInfo {

--- a/src/bin/generate.rs
+++ b/src/bin/generate.rs
@@ -45,7 +45,13 @@ fn generate_python() -> Result<(), Box<dyn std::error::Error>> {
 
     let out_path = env::var("GENERATE_PYTHON_BINDINGS_OUT")
         .map_err(|_| String::from("`GENERATE_PYTHON_BINDINGS_OUT` env variable missing"))?;
-    uniffi_bindgen::generate_bindings(&format!("{}/{}", env!("CARGO_MANIFEST_DIR"), BDK_UDL), None, vec!["python"], Some(&out_path), false)?;
+    uniffi_bindgen::generate_bindings(
+        &format!("{}/{}", env!("CARGO_MANIFEST_DIR"), BDK_UDL),
+        None,
+        vec!["python"],
+        Some(&out_path),
+        false,
+    )?;
 
     if let Some(name) = env::var("GENERATE_PYTHON_BINDINGS_FIXUP_LIB_PATH").ok() {
         fixup_python_lib_path(&out_path, &name)?;

--- a/src/bin/generate.rs
+++ b/src/bin/generate.rs
@@ -1,14 +1,13 @@
-use std::env;
-use std::fs;
-use std::io::Write;
-use std::path::Path;
+pub const BDK_UDL: &str = "src/bdk.udl";
 
-const BDK_UDL: &str = "src/bdk.udl";
-
-fn fixup_python_lib_path<O: AsRef<Path>>(
+#[cfg(feature = "generate-python")]
+fn fixup_python_lib_path<O: AsRef<std::path::Path>>(
     out_dir: O,
     lib_name: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    use std::fs;
+    use std::io::Write;
+
     const LOAD_INDIRECT_DEF: &str = "def loadIndirect():";
 
     let bindings_file = out_dir.as_ref().join("bdk.py");
@@ -40,7 +39,10 @@ def _loadIndirectOld():"#,
     Ok(())
 }
 
+#[cfg(feature = "generate-python")]
 fn generate_python() -> Result<(), Box<dyn std::error::Error>> {
+    use std::env;
+
     let out_path = env::var("GENERATE_PYTHON_BINDINGS_OUT")
         .map_err(|_| String::from("`GENERATE_PYTHON_BINDINGS_OUT` env variable missing"))?;
     uniffi_bindgen::generate_bindings(&format!("{}/{}", env!("CARGO_MANIFEST_DIR"), BDK_UDL), None, vec!["python"], Some(&out_path), false)?;
@@ -53,5 +55,7 @@ fn generate_python() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    generate_python()
+    #[cfg(feature = "generate-python")]
+    generate_python()?;
+    Ok(())
 }


### PR DESCRIPTION
1. Fix bin/generate with no features
2. Add `PartiallySignedBitcoinTransaction::deserialize` function as named constructor to decode from a string per [BIP 0174]
3. Add `PartiallySignedBitcoinTransaction::serialize` function to encode to a string per [BIP 0174]
4. Remove `PartiallySignedBitcoinTransaction.details` struct field

[BIP 0174]:https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki#encoding

Fixes #103 