### PR TITLE
Remove hard coded sync progress value

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -259,7 +259,6 @@ impl Wallet {
         progress_update: Box<dyn BdkProgress>,
         max_address_param: Option<u32>,
     ) -> Result<(), BdkError> {
-        progress_update.update(21.0, Some("message".to_string()));
         self.get_wallet()
             .sync(BdkProgressHolder { progress_update }, max_address_param)
     }


### PR DESCRIPTION
Fixes #108 

When `bdk-ffi` was only a prototype a value was added to test that the `wallet.sync` `progress_update` callback was working. This PR removes that hard coded value (21.0). Some bdk blockchains do not return a progress update and will never call the `progress_update` callback.  

The blockchain clients that update progress are: `compact_filters` and `rpc`. And the ones that don't are: `electrum` and `esplora`. Since right now only `electrum` and `esplora` are supported for `bdk-ffi` the `progress_update` call back isn't that useful, all calls to `wallet.sync` should sync return right away without reporting any progress.