### PR TITLE
Add flush method to wallet

### DIFF
--- a/src/bdk.udl
+++ b/src/bdk.udl
@@ -126,6 +126,8 @@ interface Wallet {
   void sync(BdkProgress progress_update, u32? max_address_param);
   [Throws=BdkError]
   Transaction broadcast([ByRef] PartiallySignedBitcoinTransaction psbt);
+  [Throws=BdkError]
+  void flush();
 };
 
 interface PartiallySignedBitcoinTransaction {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -263,6 +263,13 @@ impl Wallet {
             .sync(BdkProgressHolder { progress_update }, max_address_param)
     }
 
+    fn flush(
+        &self,
+    ) -> Result<(), Error> {
+        self.get_wallet()
+            .flush()
+    }
+
     fn broadcast(&self, psbt: &PartiallySignedBitcoinTransaction) -> Result<Transaction, Error> {
         let tx = psbt.internal.lock().unwrap().clone().extract_tx();
         self.get_wallet().broadcast(&tx)?;


### PR DESCRIPTION
This PR cannot be merged before the `flush()` method is added to bdk (see upcoming PR)

This fixes #114. Took @notmandatory and I half a day to do it all, but we fully tested the new flush method and it did resolve the bug.

Note that at the moment the `database()` method on the wallet returns an immutable reference, hence why we cannot simply do:
```rust
fn flush(
    &self,
) -> Result<(), Error> {
    self.get_wallet().database().borrow().flush()
}
```
directly in bdk-ffi to trigger the flush.