### PR TITLE
Add binary to remove the need for uniffi-bindgen cli tool

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,14 +15,15 @@ uniffi_macros = { version = "0.16.0", features = ["builtin-bindgen"] }
 uniffi = { version = "0.16.0", features = ["builtin-bindgen"] }
 thiserror = "1.0"
 anyhow = "=1.0.45" # remove after upgrading to next version of uniffi
+uniffi_bindgen = "0.16.0"
 
-uniffi_bindgen = { version = "0.16.0", optional = true }
+#uniffi_bindgen = { version = "0.16.0", optional = true }
 
 [build-dependencies]
 uniffi_build = { version = "0.16.0", features = ["builtin-bindgen"] }
 
 [features]
-generate-python = ["uniffi_bindgen"]
+#generate-python = ["uniffi_bindgen"]
 
 [[bin]]
 name = "generate"

--- a/src/bin/generate-bindings.rs
+++ b/src/bin/generate-bindings.rs
@@ -1,0 +1,67 @@
+use uniffi_bindgen;
+
+pub const BDK_UDL: &str = "src/bdk.udl";
+
+#[derive(Debug)]
+#[derive(PartialEq)]
+pub enum Language {
+    KOTLIN,
+    // PYTHON,
+    // SWIFT,
+    UNSUPPORTED,
+}
+
+impl Language {
+    fn to_string(self) -> &'static str {
+        if self == Language::KOTLIN { "kotlin" }
+        // else if self == Language::PYTHON { "python" }
+        // else if self == Language::SWIFT { "swift" }
+        else { panic!("Not a supported language") }
+    }
+}
+
+fn parse_language(language_argument: &str) -> Language {
+   match language_argument {
+       "kotlin" => Language::KOTLIN,
+       // "python" => Language::PYTHON,
+       // "swift" => Language::SWIFT,
+       _ => panic!("Unsupported language")
+   }
+}
+
+fn generate_bindings() -> Result<(), Box<dyn std::error::Error>> {
+    use std::env;
+    let args: Vec<String> = env::args().collect();
+    let language: Language;
+    let output_directory: &String;
+
+    if &args[1] != "--language" {
+        panic!("Please provide the --language option");
+    } else {
+        language = parse_language(&args[2]);
+    }
+
+    if &args[3] != "--out-dir" {
+        panic!("Please provide the --out-dir option");
+    } else {
+        output_directory = &args[4]
+    }
+
+    println!("Chosen language is {:?}", language);
+    println!("Output directory is {:?}", output_directory);
+
+    uniffi_bindgen::generate_bindings(
+        &format!("{}/{}", env!("CARGO_MANIFEST_DIR"), BDK_UDL),
+        None,
+        vec![language.to_string()],
+        Some(&output_directory),
+        false,
+    )?;
+
+    Ok(())
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    generate_bindings()?;
+    Ok(())
+}


### PR DESCRIPTION
WIP; I'm not as confident in my Rust as I am in my Kotlin. Feel free to tear apart my implementation or let me know where to improve.

This adds a binary called `generate-bindings`, which intends to be a drop-in replacement for the `uniffi-bindgen` tool from the perspective of the language bindings repos `bdk-kotlin` and `bdk-swift`.

In short, as part of the new Gradle plugin proposed in bitcoindevkit/bdk-kotlin#32 or simply in the `build.sh` file, we should be able to replace the line 
```shell
uniffi-bindgen generate src/bdk.udl --no-format --out-dir ../jvm/src/main/kotlin --language kotlin
```
by the line
```shell
cargo run --bin generate-bindings -- --language kotlin --out-dir ../jvm/src/main/kotlin
```

This will ensure we're always using the same version of uniffi-rs for building the native libs as the version used to generate the bindings files.