### PR TITLE
Add an initial version of TxBuilder

### DIFF
--- a/src/bdk.udl
+++ b/src/bdk.udl
@@ -142,6 +142,14 @@ interface PartiallySignedBitcoinTransaction {
   string serialize();
 };
 
+interface TxBuilder {
+  constructor();
+  TxBuilder add_recipient(string address, u64 amount);
+  TxBuilder fee_rate(float sat_per_vbyte);
+  [Throws=BdkError]
+  PartiallySignedBitcoinTransaction build([ByRef] Wallet wallet);
+};
+
 dictionary ExtendedKeyInfo {
   string mnemonic;
   string xprv;

--- a/src/bdk.udl
+++ b/src/bdk.udl
@@ -136,8 +136,6 @@ interface Wallet {
 
 interface PartiallySignedBitcoinTransaction {
   [Throws=BdkError]
-  constructor([ByRef] Wallet wallet, string recipient, u64 amount, float? fee_rate);
-  [Name=deserialize,Throws=BdkError]
   constructor(string psbt_base64);
   string serialize();
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -310,7 +310,7 @@ impl TxBuilder {
         let wallet = wallet.get_wallet();
         let mut tx_builder = wallet.build_tx();
         for (address, amount) in &self.recipients {
-            let address = Address::from_str(address).expect("recipient address parsing failed");
+            let address = Address::from_str(address).map_err(|e| BdkError::Generic(e.to_string()))?;
             tx_builder.add_recipient(address.script_pubkey(), *amount);
         }
         if let Some(sat_per_vb) = self.fee_rate {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -322,7 +322,6 @@ impl TxBuilder {
                 internal: Mutex::new(psbt),
             })
             .map(Arc::new)
-            .map_err(|_| BdkError::Generic("Failed to build transaction".to_string()))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -194,7 +194,7 @@ impl Wallet {
         let blockchain = AnyBlockchain::from_config(&any_blockchain_config)?;
         let wallet_mutex = Mutex::new(BdkWallet::new(
             &descriptor,
-            change_descriptor.to_owned().as_ref(),
+            change_descriptor.as_ref(),
             network,
             database,
             blockchain,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,32 +118,14 @@ struct PartiallySignedBitcoinTransaction {
 }
 
 impl PartiallySignedBitcoinTransaction {
-    fn new(
-        wallet: &Wallet,
-        recipient: String,
-        amount: u64,
-        fee_rate: Option<f32>, // satoshis per vbyte
-    ) -> Result<Self, Error> {
-        let mut tx_builder = TxBuilder::new().add_recipient(recipient, amount);
-        if let Some(sat_per_vb) = fee_rate {
-            tx_builder = tx_builder.fee_rate(sat_per_vb);
-        }
-        tx_builder
-            .build(wallet)
-            .map(|a| {
-                Arc::<PartiallySignedBitcoinTransaction>::try_unwrap(a).expect("unwrap Arc failed")
-            })
-            .map_err(|_| BdkError::Generic("failed to create PSBT".to_string()))
-    }
-
-    pub fn deserialize(psbt_base64: String) -> Result<Self, Error> {
+    fn new(psbt_base64: String) -> Result<Self, Error> {
         let psbt: PartiallySignedTransaction = PartiallySignedTransaction::from_str(&psbt_base64)?;
         Ok(PartiallySignedBitcoinTransaction {
             internal: Mutex::new(psbt),
         })
     }
 
-    pub fn serialize(&self) -> String {
+    fn serialize(&self) -> String {
         let psbt = self.internal.lock().unwrap().clone();
         psbt.to_string()
     }


### PR DESCRIPTION
Fixes #24 

* Adds an initial version of TxBuilder
* Removes PSBT constructor (we needed this because that was the only way to create a PSBT
* Removes unnecessary `pub` keywords in PSBT `impl`
* Removes a `.to_owned()` call due to `cargo clippy` complaints
* We can add another commit to add functionality related to #86 