### PR TITLE
Add RpcConfig, BlockchainConfig::Rpc, and Auth

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,6 +108,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
+name = "base64-compat"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a8d4d2746f89841e49230dd26917df1876050f95abafafbe34f47cb534b88d7"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "bdk"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -118,6 +127,7 @@ dependencies = [
  "bdk-macros",
  "bip39",
  "bitcoin",
+ "bitcoincore-rpc",
  "electrum-client",
  "esplora-client",
  "getrandom",
@@ -216,6 +226,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90064b8dee6815a6470d60bad07bbbaee885c0e12d04177138fa3291a01b7bc4"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "bitcoincore-rpc"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0261b2bb7617e0c91b452a837bbd1291fd34ad6990cb8e3ffc28239cc045b5ca"
+dependencies = [
+ "bitcoincore-rpc-json",
+ "jsonrpc",
+ "log",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "bitcoincore-rpc-json"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c231bea28e314879c5aef240f6052e8a72a369e3c9f9b20d9bfbb33ad18029b2"
+dependencies = [
+ "bitcoin",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -565,6 +599,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
 dependencies = [
  "wasm-bindgen",
+]
+
+[[package]]
+name = "jsonrpc"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f8423b78fc94d12ef1a4a9d13c348c9a78766dda0cc18817adf0faf77e670c8"
+dependencies = [
+ "base64-compat",
+ "serde",
+ "serde_derive",
+ "serde_json",
 ]
 
 [[package]]

--- a/api-docs/kotlin/src/main/kotlin/org/bitcoindevkit/bdk.kt
+++ b/api-docs/kotlin/src/main/kotlin/org/bitcoindevkit/bdk.kt
@@ -123,7 +123,7 @@ data class SledDbConfiguration(
  *
  * @sample org.bitcoindevkit.electrumBlockchainConfigSample
  */
-data class ElectrumConfig (
+data class ElectrumConfig(
     var url: String,
     var socks5: String?,
     var retry: UByte,
@@ -142,12 +142,62 @@ data class ElectrumConfig (
  *
  * @sample org.bitcoindevkit.esploraBlockchainConfigSample
  */
-data class EsploraConfig (
+data class EsploraConfig(
     var baseUrl: String,
     var proxy: String?,
     var concurrency: UByte?,
     var stopGap: ULong,
     var timeout: ULong?
+)
+
+/**
+ * Authentication mechanism for RPC connection to full node
+ */
+sealed class Auth {
+    /** No authentication */
+    object None: Auth()
+
+    /** Authentication with username and password, usually [Auth.Cookie] should be preferred */
+    data class UserPass(val username: String, val password: String): Auth()
+
+    /** Authentication with a cookie file */
+    data class Cookie(val file: String): Auth()
+}
+
+/**
+ * Sync parameters for Bitcoin Core RPC.
+ *
+ * In general, BDK tries to sync `scriptPubKey`s cached in `Database` with
+ * `scriptPubKey`s imported in the Bitcoin Core Wallet. These parameters are used for determining
+ * how the `importdescriptors` RPC calls are to be made.
+ *
+ * @property startScriptCount The minimum number of scripts to scan for on initial sync.
+ * @property startTime Time in unix seconds in which initial sync will start scanning from (0 to start from genesis).
+ * @property forceStartTime Forces every sync to use `start_time` as import timestamp.
+ * @property pollRateSec RPC poll rate (in seconds) to get state updates.
+ */
+data class RcpSyncParams(
+    val startScriptCount: ULong,
+    val startTime: Ulong,
+    val forceStartTime: Boolean,
+    val pollRateSec: ULong,
+)
+
+/**
+ * RpcBlockchain configuration options
+ *
+ * @property url The bitcoin node url.
+ * @property auth The bicoin node authentication mechanism.
+ * @property network The network we are using (it will be checked the bitcoin node network matches this).
+ * @property walletName The wallet name in the bitcoin node.
+ * @property syncParams Sync parameters.
+ */
+data class RpcConfig(
+    val url: String,
+    val auth: Auth,
+    val network: Network,
+    val walletName: String,
+    val syncParams: RcpSyncParams?,
 )
 
 /**
@@ -161,6 +211,9 @@ sealed class BlockchainConfig {
 
     /** Esplora client. */
     data class Esplora(val config: EsploraConfig) : BlockchainConfig()
+
+    /** Bitcoin Core RPC client. */
+    data class Rpc(val config: RpcConfig) : BlockchainConfig()
 }
 
 /**

--- a/bdk-ffi/Cargo.toml
+++ b/bdk-ffi/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["staticlib", "cdylib"]
 name = "bdkffi"
 
 [dependencies]
-bdk = { version = "0.25", features = ["all-keys", "use-esplora-ureq", "sqlite-bundled"] }
+bdk = { version = "0.25", features = ["all-keys", "use-esplora-ureq", "sqlite-bundled", "rpc"] }
 
 uniffi_macros = { version = "0.21.0", features = ["builtin-bindgen"] }
 uniffi = { version = "0.21.0", features = ["builtin-bindgen"] }

--- a/bdk-ffi/src/bdk.udl
+++ b/bdk-ffi/src/bdk.udl
@@ -45,6 +45,7 @@ enum BdkError {
   "Esplora",
   "Sled",
   "Rusqlite",
+  "Rpc",
 };
 
 dictionary AddressInfo {
@@ -127,9 +128,32 @@ dictionary EsploraConfig {
 };
 
 [Enum]
+interface Auth {
+  None();
+  UserPass(string username, string password);
+  Cookie(string file);
+};
+
+dictionary RpcSyncParams {
+    u64 start_script_count;
+    u64 start_time;
+    boolean force_start_time;
+    u64 poll_rate_sec;
+};
+
+dictionary RpcConfig {
+    string url;
+    Auth auth;
+    Network network;
+    string wallet_name;
+    RpcSyncParams? sync_params;
+};
+
+[Enum]
 interface BlockchainConfig {
   Electrum(ElectrumConfig config);
   Esplora(EsploraConfig config);
+  Rpc(RpcConfig config);
 };
 
 interface Blockchain {


### PR DESCRIPTION
Fixes #117. This adds the RPC blockchain config but I don't currently have a way to test it as part of the `bdk-kotlin` or `bdk-swift` automated testing, which would need to be able to spin up a local regtest bitcoind for the tests. 

For now this will only be manually tested. 