### PR TITLE
Add sweep/spend-all to TxBuilder

### DIFF
--- a/src/bdk.udl
+++ b/src/bdk.udl
@@ -145,6 +145,7 @@ interface TxBuilder {
   TxBuilder add_recipient(string address, u64 amount);
   TxBuilder fee_rate(float sat_per_vbyte);
   TxBuilder drain_wallet();
+  TxBuilder drain_to(string address);
   [Throws=BdkError]
   PartiallySignedBitcoinTransaction build([ByRef] Wallet wallet);
 };

--- a/src/bdk.udl
+++ b/src/bdk.udl
@@ -144,6 +144,7 @@ interface TxBuilder {
   constructor();
   TxBuilder add_recipient(string address, u64 amount);
   TxBuilder fee_rate(float sat_per_vbyte);
+  TxBuilder drain_wallet();
   [Throws=BdkError]
   PartiallySignedBitcoinTransaction build([ByRef] Wallet wallet);
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -280,6 +280,7 @@ fn restore_extended_key(
 struct TxBuilder {
     recipients: Vec<(String, u64)>,
     fee_rate: Option<f32>,
+    drain_wallet: bool,
 }
 
 impl TxBuilder {
@@ -287,6 +288,7 @@ impl TxBuilder {
         TxBuilder {
             recipients: Vec::new(),
             fee_rate: None,
+            drain_wallet: false,
         }
     }
 
@@ -296,6 +298,7 @@ impl TxBuilder {
         Arc::new(TxBuilder {
             recipients,
             fee_rate: self.fee_rate,
+            drain_wallet: self.drain_wallet,
         })
     }
 
@@ -303,6 +306,15 @@ impl TxBuilder {
         Arc::new(TxBuilder {
             recipients: self.recipients.to_vec(),
             fee_rate: Some(sat_per_vb),
+            drain_wallet: self.drain_wallet,
+        })
+    }
+
+    fn drain_wallet(&self) -> Arc<Self> {
+        Arc::new(TxBuilder {
+            recipients: self.recipients.to_vec(),
+            fee_rate: self.fee_rate,
+            drain_wallet: true,
         })
     }
 
@@ -315,6 +327,9 @@ impl TxBuilder {
         }
         if let Some(sat_per_vb) = self.fee_rate {
             tx_builder.fee_rate(FeeRate::from_sat_per_vb(sat_per_vb));
+        }
+        if self.drain_wallet {
+            tx_builder.drain_wallet();
         }
         tx_builder
             .finish()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -336,7 +336,8 @@ impl TxBuilder {
         let wallet = wallet.get_wallet();
         let mut tx_builder = wallet.build_tx();
         for (address, amount) in &self.recipients {
-            let address = Address::from_str(address).map_err(|e| BdkError::Generic(e.to_string()))?;
+            let address =
+                Address::from_str(address).map_err(|e| BdkError::Generic(e.to_string()))?;
             tx_builder.add_recipient(address.script_pubkey(), *amount);
         }
         if let Some(sat_per_vb) = self.fee_rate {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -336,9 +336,10 @@ impl TxBuilder {
         let wallet = wallet.get_wallet();
         let mut tx_builder = wallet.build_tx();
         for (address, amount) in &self.recipients {
-            let address =
-                Address::from_str(address).map_err(|e| BdkError::Generic(e.to_string()))?;
-            tx_builder.add_recipient(address.script_pubkey(), *amount);
+            let script_pubkey = Address::from_str(address)
+                .map(|x| x.script_pubkey())
+                .map_err(|e| BdkError::Generic(e.to_string()))?;
+            tx_builder.add_recipient(script_pubkey, *amount);
         }
         if let Some(sat_per_vb) = self.fee_rate {
             tx_builder.fee_rate(FeeRate::from_sat_per_vb(sat_per_vb));
@@ -347,9 +348,10 @@ impl TxBuilder {
             tx_builder.drain_wallet();
         }
         if let Some(address) = &self.drain_to {
-            let drain_to =
-                Address::from_str(address).map_err(|e| BdkError::Generic(e.to_string()))?;
-            tx_builder.drain_to(drain_to.script_pubkey());
+            let script_pubkey = Address::from_str(address)
+                .map(|a| a.script_pubkey())
+                .map_err(|e| BdkError::Generic(e.to_string()))?;
+            tx_builder.drain_to(script_pubkey);
         }
         tx_builder
             .finish()


### PR DESCRIPTION
Fixes #86 

* Adds `TxBuilder::drain_wallet`
* Adds `TxBuilder::drain_to`
* Introduces a `to_script_pubkey` helper
* Simplifies `TxBuilder::add_recipient` to use `to_script_pubkey` helper