### PR TITLE
Fix a few minor issues

### DIFF
--- a/bdk-ffi-bindgen/src/main.rs
+++ b/bdk-ffi-bindgen/src/main.rs
@@ -2,7 +2,6 @@ use std::fmt;
 use std::path::PathBuf;
 use std::str::FromStr;
 use structopt::StructOpt;
-use uniffi_bindgen;
 
 #[derive(Debug, PartialEq)]
 pub enum Language {
@@ -89,7 +88,7 @@ def _loadIndirectOld():"#,
         .write(true)
         .truncate(true)
         .open(&bindings_file)?;
-    file.write(data.as_bytes())?;
+    file.write_all(data.as_bytes())?;
 
     Ok(())
 }

--- a/bdk-ffi-bindgen/src/main.rs
+++ b/bdk-ffi-bindgen/src/main.rs
@@ -67,10 +67,9 @@ fn fixup_python_lib_path(
     let bindings_file = out_dir.join("bdk.py");
     let mut data = fs::read_to_string(&bindings_file)?;
 
-    let pos = data.find(LOAD_INDIRECT_DEF).expect(&format!(
-        "loadIndirect not found in `{}`",
-        bindings_file.display()
-    ));
+    let pos = data
+        .find(LOAD_INDIRECT_DEF)
+        .unwrap_or_else(|| panic!("loadIndirect not found in `{}`", bindings_file.display()));
     let range = pos..pos + LOAD_INDIRECT_DEF.len();
 
     let replacement = format!(

--- a/bdk-ffi-bindgen/src/main.rs
+++ b/bdk-ffi-bindgen/src/main.rs
@@ -6,17 +6,17 @@ use uniffi_bindgen;
 
 #[derive(Debug, PartialEq)]
 pub enum Language {
-    KOTLIN,
-    PYTHON,
-    SWIFT,
+    Kotlin,
+    Python,
+    Swift,
 }
 
 impl fmt::Display for Language {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Language::KOTLIN => write!(f, "kotlin"),
-            Language::SWIFT => write!(f, "swift"),
-            Language::PYTHON => write!(f, "python"),
+            Language::Kotlin => write!(f, "kotlin"),
+            Language::Swift => write!(f, "swift"),
+            Language::Python => write!(f, "python"),
         }
     }
 }
@@ -36,9 +36,9 @@ impl FromStr for Language {
     type Err = Error;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "kotlin" => Ok(Language::KOTLIN),
-            "python" => Ok(Language::PYTHON),
-            "swift" => Ok(Language::SWIFT),
+            "kotlin" => Ok(Language::Kotlin),
+            "python" => Ok(Language::Python),
+            "swift" => Ok(Language::Swift),
             _ => Err(Error::UnsupportedLanguage),
         }
     }
@@ -126,7 +126,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     generate_bindings(&opt)?;
 
-    if opt.language == Language::PYTHON {
+    if opt.language == Language::Python {
         if let Some(path) = opt.python_fixup_path {
             println!("Fixing up python lib path, {:?}", &path);
             fixup_python_lib_path(&opt.out_dir, &path)?;

--- a/bdk-ffi-bindgen/src/main.rs
+++ b/bdk-ffi-bindgen/src/main.rs
@@ -1,5 +1,5 @@
 use std::fmt;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use structopt::StructOpt;
 
@@ -56,8 +56,8 @@ fn generate_bindings(opt: &Opt) -> anyhow::Result<(), anyhow::Error> {
 }
 
 fn fixup_python_lib_path(
-    out_dir: &PathBuf,
-    lib_name: &PathBuf,
+    out_dir: &Path,
+    lib_name: &Path,
 ) -> Result<(), Box<dyn std::error::Error>> {
     use std::fs;
     use std::io::Write;


### PR DESCRIPTION
Fixes a few minor issues:

* Renames enum members to follow [rust naming conventions](https://rust-lang.github.io/api-guidelines/naming.html)
* Fixes a few clippy issues
  * [Use `write_all` instead of `write` when not attempting to write prefix](https://rust-lang.github.io/rust-clippy/master/index.html#unused_io_amount)
  * [Stop using a function call inside `.expect()`](https://rust-lang.github.io/rust-clippy/master/index.html#expect_fun_call)
  * [Stop using `&PathBuf` when `&Path` will suffice](https://rust-lang.github.io/rust-clippy/master/index.html#ptr_arg)
  * [Remove single component import (`uniffi_bindgen`)](https://rust-lang.github.io/rust-clippy/master/index.html#single_component_path_imports)