### PR TITLE
Add address index to return type of get_address

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ testdb
 xcuserdata
 .lsp
 .clj-kondo
+.idea/

--- a/src/bdk.udl
+++ b/src/bdk.udl
@@ -49,9 +49,14 @@ enum BdkError {
   "Rusqlite",
 };
 
-dictionary AddressInformation {
+dictionary AddressInfo {
   u32 index;
   string address;
+};
+
+enum AddressIndex {
+  "New",
+  "LastUnused",
 };
 
 enum Network {
@@ -131,8 +136,7 @@ callback interface Progress {
 interface Wallet {
   [Throws=BdkError]
   constructor(string descriptor, string? change_descriptor, Network network, DatabaseConfig database_config);
-  string get_new_address();
-  AddressInformation get_last_unused_address();
+  AddressInfo get_address(AddressIndex address_index);
   [Throws=BdkError]
   u64 get_balance();
   [Throws=BdkError]

--- a/src/bdk.udl
+++ b/src/bdk.udl
@@ -136,6 +136,7 @@ callback interface Progress {
 interface Wallet {
   [Throws=BdkError]
   constructor(string descriptor, string? change_descriptor, Network network, DatabaseConfig database_config);
+  [Throws=BdkError]
   AddressInfo get_address(AddressIndex address_index);
   [Throws=BdkError]
   u64 get_balance();

--- a/src/bdk.udl
+++ b/src/bdk.udl
@@ -49,6 +49,11 @@ enum BdkError {
   "Rusqlite",
 };
 
+dictionary AddressInformation {
+  u32 index;
+  string address;
+};
+
 enum Network {
   "Bitcoin",
   "Testnet",
@@ -127,7 +132,7 @@ interface Wallet {
   [Throws=BdkError]
   constructor(string descriptor, string? change_descriptor, Network network, DatabaseConfig database_config);
   string get_new_address();
-  string get_last_unused_address();
+  AddressInformation get_last_unused_address();
   [Throws=BdkError]
   u64 get_balance();
   [Throws=BdkError]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ use bdk::keys::bip39::{Language, Mnemonic, WordCount};
 use bdk::keys::{DerivableKey, ExtendedKey, GeneratableKey, GeneratedKey};
 use bdk::miniscript::BareCtx;
 use bdk::wallet::AddressIndex;
+use bdk::wallet::AddressInfo;
 use bdk::{
     BlockTime, Error, FeeRate, SignOptions, SyncOptions as BdkSyncOptions, Wallet as BdkWallet,
 };
@@ -25,6 +26,11 @@ use std::sync::{Arc, Mutex, MutexGuard};
 uniffi_macros::include_scaffolding!("bdk");
 
 type BdkError = Error;
+
+pub struct AddressInformation {
+    pub index: u32,
+    pub address: String,
+}
 
 pub enum DatabaseConfig {
     Memory,
@@ -243,12 +249,22 @@ impl Wallet {
             .to_string()
     }
 
-    fn get_last_unused_address(&self) -> String {
-        self.get_wallet()
+    // fn get_last_unused_address(&self) -> String {
+    //     self.get_wallet()
+    //         .get_address(AddressIndex::LastUnused)
+    //         .unwrap()
+    //         .address
+    //         .to_string()
+    // }
+
+    fn get_last_unused_address(&self) -> AddressInformation {
+        let address_info = self.get_wallet()
             .get_address(AddressIndex::LastUnused)
-            .unwrap()
-            .address
-            .to_string()
+            .unwrap();
+        return AddressInformation {
+            index: address_info.index,
+            address: address_info.address.to_string()
+        }
     }
 
     fn get_balance(&self) -> Result<u64, Error> {


### PR DESCRIPTION
This is my first stab at adding an API from bdk into to bdk-ffi. Looking for feedback. In particular, I found I had to create a brand new struct in `lib.rs` (`AddressInformation`) whose purpose was mostly just to mirror the `AddressInfo` struct coming from bdk. I assume there is a better way and I should be able to use the type from bdk directly; please let me know if so.

This PR is marked as draft because if the approach is agreed upon I'd still need to change the `get_new_address()` method to follow the same API. I assume also worthy of discussion is whether we might as well bring the whole of `AddressInfo` into bdk-ffi, which would add the `KeychainKind` field (and associated type) to `AddressInfo`/`AddressInformation`.

This PR fixes #130.

### Notes to reviewers
This PR changes the return type of `get_last_unused_address()` from `String` to `AddressInfo`.

```rust
pub struct AddressInfo {
    pub index: u32,
    pub address: String,
}
```