### PR TITLE
Add sign / verify for arbitrary messages

### DIFF
--- a/src/bdk.udl
+++ b/src/bdk.udl
@@ -144,6 +144,16 @@ interface EcdsaMessageSigner {
   string sign(string msg);
 };
 
+interface EcdsaMessageSignatureVerifier {
+  [Throws=BdkError, Name=from_pub]
+  constructor(string pubkey);
+  [Throws=BdkError, Name=from_xpub]
+  constructor(string xpub);
+  [Throws=BdkError, Name=from_address]
+  constructor(string address);
+  boolean verify(string sig, string msg);
+};
+
 interface PartiallySignedBitcoinTransaction {
   [Throws=BdkError]
   constructor(string psbt_base64);

--- a/src/bdk.udl
+++ b/src/bdk.udl
@@ -173,6 +173,7 @@ interface TxBuilder {
 dictionary ExtendedKeyInfo {
   string mnemonic;
   string xprv;
+  string xpub;
   string fingerprint;
 };
 

--- a/src/bdk.udl
+++ b/src/bdk.udl
@@ -134,6 +134,16 @@ interface Wallet {
   string broadcast([ByRef] PartiallySignedBitcoinTransaction psbt);
 };
 
+interface EcdsaMessageSigner {
+  [Throws=BdkError, Name=from_wif]
+  constructor(string wif);
+  [Throws=BdkError, Name=from_prv]
+  constructor(string prv);
+  [Throws=BdkError, Name=from_xprv]
+  constructor(string xprv);
+  string sign(string msg);
+};
+
 interface PartiallySignedBitcoinTransaction {
   [Throws=BdkError]
   constructor(string psbt_base64);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -243,6 +243,7 @@ impl Wallet {
 pub struct ExtendedKeyInfo {
     mnemonic: String,
     xprv: String,
+    xpub: String,
     fingerprint: String,
 }
 
@@ -256,10 +257,13 @@ fn generate_extended_key(
     let mnemonic = mnemonic.into_key();
     let xkey: ExtendedKey = (mnemonic.clone(), password).into_extended_key()?;
     let xprv = xkey.into_xprv(network).unwrap();
-    let fingerprint = xprv.fingerprint(&Secp256k1::new());
+    let secp = Secp256k1::new();
+    let xpub = ExtendedPubKey::from_private(&secp, &xprv);
+    let fingerprint = xprv.fingerprint(&secp);
     Ok(ExtendedKeyInfo {
         mnemonic: mnemonic.to_string(),
         xprv: xprv.to_string(),
+        xpub: xpub.to_string(),
         fingerprint: fingerprint.to_string(),
     })
 }
@@ -272,10 +276,13 @@ fn restore_extended_key(
     let mnemonic = Mnemonic::parse_in(Language::English, mnemonic).unwrap();
     let xkey: ExtendedKey = (mnemonic.clone(), password).into_extended_key()?;
     let xprv = xkey.into_xprv(network).unwrap();
-    let fingerprint = xprv.fingerprint(&Secp256k1::new());
+    let secp = Secp256k1::new();
+    let xpub = ExtendedPubKey::from_private(&secp, &xprv);
+    let fingerprint = xprv.fingerprint(&secp);
     Ok(ExtendedKeyInfo {
         mnemonic: mnemonic.to_string(),
         xprv: xprv.to_string(),
+        xpub: xpub.to_string(),
         fingerprint: fingerprint.to_string(),
     })
 }


### PR DESCRIPTION
This PR adds support for the creation of signatures of arbitrary messages and their verification. A PR for bdk-kotlin will follow.

Signatures can be created using a given `wif`, `prv` or `xprv`. They can be verified using a `pub`, `xpub` or `address`. 

Since these are my very first steps with Rust, please take a closer look at the coding style as well.