### PR TITLE
Add RBF methods to TxBuilder

### DIFF
--- a/src/bdk.udl
+++ b/src/bdk.udl
@@ -146,6 +146,8 @@ interface TxBuilder {
   TxBuilder fee_rate(float sat_per_vbyte);
   TxBuilder drain_wallet();
   TxBuilder drain_to(string address);
+  TxBuilder enable_rbf();
+  TxBuilder enable_rbf_with_sequence(u32 nsequence);
   [Throws=BdkError]
   PartiallySignedBitcoinTransaction build([ByRef] Wallet wallet);
 };


### PR DESCRIPTION
Fix #133 

We need to create another `RbfValue` enum because the actual type is only visible within the crate in `bdk`.