### PR TITLE
Fix fee parameter typo in TransactionDetails

### DIFF
--- a/src/bdk.udl
+++ b/src/bdk.udl
@@ -73,7 +73,7 @@ interface DatabaseConfig {
 };
 
 dictionary TransactionDetails {
-    u64? fees;
+    u64? fee;
     u64 received;
     u64 sent;
     string txid;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@ pub enum BlockchainConfig {
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct TransactionDetails {
-    pub fees: Option<u64>,
+    pub fee: Option<u64>,
     pub received: u64,
     pub sent: u64,
     pub txid: String,
@@ -71,7 +71,7 @@ pub enum Transaction {
 impl From<&bdk::TransactionDetails> for TransactionDetails {
     fn from(x: &bdk::TransactionDetails) -> TransactionDetails {
         TransactionDetails {
-            fees: x.fee,
+            fee: x.fee,
             txid: x.txid.to_string(),
             received: x.received,
             sent: x.sent,


### PR DESCRIPTION
Solves issue #136 
Generated Kotlin file now have "fee" in TransactionDetails as parameter instead of "fees"
```
data class TransactionDetails (
    var fee: ULong?, 
    var received: ULong, 
    var sent: ULong, 
    var txid: String 
) {
    // ...
}
```

