### PR TITLE
Add Wallet and TxBuilder tests using test funded wallet

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ crate-type = ["staticlib", "cdylib"]
 name = "bdkffi"
 
 [dependencies]
-bdk = { version = "0.18", features = ["all-keys", "use-esplora-ureq", "sqlite-bundled"] }
+bdk = { version = "0.19", features = ["all-keys", "use-esplora-ureq", "sqlite-bundled"] }
 
 uniffi_macros = { version = "0.16.0", features = ["builtin-bindgen"] }
 uniffi = { version = "0.16.0", features = ["builtin-bindgen"] }


### PR DESCRIPTION
This PR adds an example test using the `bdk` test funded wallet.  The example test makes sure the `bdk-ffi` `TxBuilder` is able to drain a single wallet UTXO to a single address.  More tests can be added as we need them in future PRs.

Required to complete #141 