### PR TITLE
Add Wallet list_unspent method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- APIs Added
+  - `TxBuilder.add_data(data: Vec<u8>)`
+  - `Wallet.list_unspent()` returns `Vec<LocalUtxo>`
+
 ## [v0.7.0]
 
 - Update BDK to version 0.19.0

--- a/src/bdk.udl
+++ b/src/bdk.udl
@@ -149,6 +149,27 @@ callback interface Progress {
   void update(f32 progress, string? message);
 };
 
+dictionary OutPoint {
+  string txid;
+  u32 vout;
+};
+
+dictionary TxOut {
+  u64 value;
+  string address;
+};
+
+enum KeychainKind {
+  "External",
+  "Internal",
+};
+
+dictionary LocalUtxo {
+  OutPoint outpoint;
+  TxOut txout;
+  KeychainKind keychain;
+};
+
 interface Wallet {
   [Throws=BdkError]
   constructor(string descriptor, string? change_descriptor, Network network, DatabaseConfig database_config);
@@ -169,6 +190,9 @@ interface Wallet {
 
   [Throws=BdkError]
   void sync([ByRef] Blockchain blockchain, Progress? progress);
+
+  [Throws=BdkError]
+  sequence<LocalUtxo> list_unspent();
 };
 
 interface PartiallySignedBitcoinTransaction {

--- a/src/bdk.udl
+++ b/src/bdk.udl
@@ -168,6 +168,7 @@ dictionary LocalUtxo {
   OutPoint outpoint;
   TxOut txout;
   KeychainKind keychain;
+  boolean is_spent;
 };
 
 interface Wallet {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -190,7 +190,8 @@ pub struct LocalUtxo {
     is_spent: bool,
 }
 
-/// Trait used to convert a script to an address using the wallet network
+// This trait is used to convert the bdk TxOut type with field `script_pubkey: Script`
+// into the bdk-ffi TxOut type which has a field `address: String` instead
 trait NetworkLocalUtxo {
     fn from_utxo(x: &bdk::LocalUtxo, network: Network) -> LocalUtxo;
 }


### PR DESCRIPTION
Here is my attempt at implementing the `list_unspent` method.

In order to test this I've updated the `bdk-ffi` submodule in the `bdk-kotlin` project, ran commands to build and publish the android library to a local maven repository and finally imported the library on an Android project written in Kotlin.

The list seems to work fine, except for a strange behaviour I've noticed when calling the method multiple times.

So, in order to exclude bugs from my side, I've wrote a minimal Rust project that directly uses bdk 0.18 to list the unspents of an existing wallet.

From this test I've understood that creating a wallet using a `bdk::database::SqliteDatabase` database and calling the wallet `sync` method leads to each UTXO getting re-inserted in the database even if already present.

Here's a minimal piece of code that shows how to reproduce the bug:

```rust
let blockchain = ElectrumBlockchain::from(Client::new("ssl://electrum.blockstream.info:60002")?);
let database = bdk::database::SqliteDatabase::new("./testdb.sqlite".to_string());
let wallet = Wallet::new(
    "wpkh(tprv8ZgxMBicQKsPdqrqwQmJsdw7Sbt36hJPJyoCQ5BhFwfLcfVHQEwiwPykQPLT9AxUYS26BPQ4yrqTYYGG4HPg4UwJzLJCnK5L8YC6VAUb8nZ/84'/1'/0'/0/*)",
    Some("wpkh(tprv8ZgxMBicQKsPdqrqwQmJsdw7Sbt36hJPJyoCQ5BhFwfLcfVHQEwiwPykQPLT9AxUYS26BPQ4yrqTYYGG4HPg4UwJzLJCnK5L8YC6VAUb8nZ/84'/1'/0'/1/*)"),
    Network::Testnet,
    database,
)?;

wallet.sync(&blockchain, SyncOptions::default())?;

println!("Num unspents: {}", wallet.list_unspent()?.len());

>> Num unspents: 1

wallet.sync(&blockchain, SyncOptions::default())?;

println!("Num unspents: {}", wallet.list_unspent()?.len());

>> Num unspents: 2

println!("Num unspents: {}", wallet.list_unspent()?.len());

>> Num unspents: 2

wallet.sync(&blockchain, SyncOptions::default())?;

println!("Num unspents: {}", wallet.list_unspent()?.len());

>> Num unspents: 3

println!("Num unspents: {}", wallet.list_unspent()?.len());

>> Num unspents: 3
```

Inspecting the sqlite database shows that the UTXO actually gets re-inserted at each sync.

The error does not arise when the database is defined as `MemoryDatabase::default()`.
