### PR TITLE
Match bdk API and return a boolean when signing a PSBT

### DIFF
--- a/src/bdk.udl
+++ b/src/bdk.udl
@@ -160,7 +160,7 @@ interface Wallet {
   u64 get_balance();
 
   [Throws=BdkError]
-  void sign([ByRef] PartiallySignedBitcoinTransaction psbt);
+  boolean sign([ByRef] PartiallySignedBitcoinTransaction psbt);
 
   [Throws=BdkError]
   sequence<Transaction> get_transactions();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,13 +11,13 @@ use bdk::database::any::{AnyDatabase, SledDbConfiguration, SqliteDbConfiguration
 use bdk::database::{AnyDatabaseConfig, ConfigurableDatabase};
 use bdk::keys::bip39::{Language, Mnemonic, WordCount};
 use bdk::keys::{DerivableKey, ExtendedKey, GeneratableKey, GeneratedKey};
-use bdk::wallet::AddressInfo as BdkAddressInfo;
-use bdk::wallet::AddressIndex as BdkAddressIndex;
 use bdk::miniscript::BareCtx;
-use std::convert::{TryFrom, From};
+use bdk::wallet::AddressIndex as BdkAddressIndex;
+use bdk::wallet::AddressInfo as BdkAddressInfo;
 use bdk::{
     BlockTime, Error, FeeRate, SignOptions, SyncOptions as BdkSyncOptions, Wallet as BdkWallet,
 };
+use std::convert::{From, TryFrom};
 use std::fmt;
 use std::ops::Deref;
 use std::str::FromStr;
@@ -36,7 +36,7 @@ impl From<BdkAddressInfo> for AddressInfo {
     fn from(x: bdk::wallet::AddressInfo) -> AddressInfo {
         AddressInfo {
             index: x.index,
-            address: x.address.to_string()
+            address: x.address.to_string(),
         }
     }
 }
@@ -50,7 +50,7 @@ impl From<AddressIndex> for BdkAddressIndex {
     fn from(x: AddressIndex) -> BdkAddressIndex {
         match x {
             AddressIndex::New => BdkAddressIndex::New,
-            AddressIndex::LastUnused => BdkAddressIndex::LastUnused
+            AddressIndex::LastUnused => BdkAddressIndex::LastUnused,
         }
     }
 }
@@ -274,16 +274,9 @@ impl Wallet {
         self.get_wallet().get_balance()
     }
 
-    fn sign(&self, psbt: &PartiallySignedBitcoinTransaction) -> Result<(), Error> {
+    fn sign(&self, psbt: &PartiallySignedBitcoinTransaction) -> Result<bool, Error> {
         let mut psbt = psbt.internal.lock().unwrap();
-        let finalized = self.get_wallet().sign(&mut psbt, SignOptions::default())?;
-        match finalized {
-            true => Ok(()),
-            false => Err(BdkError::Generic(format!(
-                "transaction signing not finalized {:?}",
-                psbt
-            ))),
-        }
+        self.get_wallet().sign(&mut psbt, SignOptions::default())
     }
 
     fn get_transactions(&self) -> Result<Vec<Transaction>, Error> {


### PR DESCRIPTION
This is a fix for #160.

I was looking at the `get_transactions()` method just below and I'm not sure which syntax is best (let me know if you have opinions on this) between

What I have:
```rust
fn sign(&self, psbt: &PartiallySignedBitcoinTransaction) -> Result<bool, Error> {
    let mut psbt = psbt.internal.lock().unwrap();
    self.get_wallet().sign(&mut psbt, SignOptions::default())
}
```

If I mirrored `get_transactions()`:
```rust
fn sign(&self, psbt: &PartiallySignedBitcoinTransaction) -> Result<bool, Error> {
    let mut psbt = psbt.internal.lock().unwrap();
    let finalized = self.get_wallet().sign(&mut psbt, SignOptions::default())?;
    Ok(finalized)
}
```