### PR TITLE
Update BDK to version 0.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Update BDK to version 0.19.0
+  - fixes sqlite-db issue causing wrong balance
+  - adds experimental taproot descriptor and PSBT support
+
 ## [v0.6.0]
 
 - Update BDK to version 0.18.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ crate-type = ["staticlib", "cdylib"]
 name = "bdkffi"
 
 [dependencies]
-bdk = { version = "0.18", features = ["all-keys", "use-esplora-ureq", "sqlite-bundled"] }
+bdk = { version = "0.19", features = ["all-keys", "use-esplora-ureq", "sqlite-bundled"] }
 
 uniffi_macros = { version = "0.16.0", features = ["builtin-bindgen"] }
 uniffi = { version = "0.16.0", features = ["builtin-bindgen"] }


### PR DESCRIPTION
Update BDK to version 0.19.0
  - fixes #155, sqlite-db issue causing wrong balance 
  - adds experimental taproot descriptor and PSBT support
  