### PR TITLE
Add coin selection methods

### DIFF
--- a/src/bdk.udl
+++ b/src/bdk.udl
@@ -210,7 +210,23 @@ interface TxBuilder {
 
   TxBuilder add_recipient(string address, u64 amount);
 
+  TxBuilder add_unspendable(OutPoint unspendable);
+
+  TxBuilder add_utxo(OutPoint outpoint);
+
+  TxBuilder add_utxos(sequence<OutPoint> outpoints);
+
+  TxBuilder do_not_spend_change();
+
+  TxBuilder manually_selected_only();
+
+  TxBuilder only_spend_change();
+
+  TxBuilder unspendable(sequence<OutPoint> unspendable);
+
   TxBuilder fee_rate(float sat_per_vbyte);
+
+  TxBuilder fee_absolute(u64 fee_amount);
 
   TxBuilder drain_wallet();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@ use bdk::{
     Wallet as BdkWallet,
 };
 use std::collections::HashSet;
-use std::convert::{From, TryFrom, TryInto};
+use std::convert::{From, TryFrom};
 use std::fmt;
 use std::ops::Deref;
 use std::str::FromStr;
@@ -552,7 +552,7 @@ impl TxBuilder {
         tx_builder.change_policy(self.change_policy);
         if !self.utxos.is_empty() {
             let bdk_utxos: Vec<BdkOutPoint> = self.utxos.iter().map(BdkOutPoint::from).collect();
-            let utxos: &[BdkOutPoint] = bdk_utxos[..].try_into().unwrap();
+            let utxos: &[BdkOutPoint] = &bdk_utxos;
             tx_builder.add_utxos(utxos)?;
         }
         if !self.unspendable.is_empty() {


### PR DESCRIPTION
closes #131 

please note this PR contains a commit adding the `list_unspent` method for which a [PR](https://github.com/bitcoindevkit/bdk-ffi/pull/158) has already been opened, I'll rebase this once that has been merged.