### PR TITLE
Set project MSRV to 1.57.0

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -12,7 +12,7 @@ jobs:
         rust:
           - version: 1.60.0 # STABLE
             clippy: true
-          - version: 1.56.1 # MSRV
+          - version: 1.57.0 # MSRV
     steps:
       - name: checkout
         uses: actions/checkout@v2

--- a/bdk-ffi-bindgen/src/main.rs
+++ b/bdk-ffi-bindgen/src/main.rs
@@ -1,8 +1,8 @@
+use camino::Utf8Path;
 use std::fmt;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use structopt::StructOpt;
-use camino::Utf8Path;
 
 #[derive(Debug, PartialEq)]
 pub enum Language {


### PR DESCRIPTION
### Description

The `master` branch is currently not passing the new github checks. 

A required dependency of `bdk-ffi-bindgen` is `uniffi_bindgen` and it depends on `os_str_bytes` v6.2.0 which has a MSRV of 1.57.0. I therefore had to make the MSRV of `bdk-ffi` also 1.57.0 and update the github actions. This PR also fixes a small `cargo fmt` warning.

### Notes to the reviewers

```shell
% cargo +1.56.1 build  
error: package `os_str_bytes v6.2.0` cannot be built because it requires rustc 1.57.0 or newer, while the currently active rustc version is 1.56.1
```

```shell
% cargo tree -i os_str_bytes
os_str_bytes v6.2.0
└── clap_lex v0.2.4
    └── clap v3.1.18
        └── uniffi_bindgen v0.19.3
            └── bdk-ffi-bindgen v0.2.0 (/Users/steve/git/notmandatory/bdk-ffi/bdk-ffi-bindgen)
```

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
