### PR TITLE
Fix bdk-python link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ cargo run -p bdk-ffi-bindgen -- --help
 
 [bdk-kotlin]: https://github.com/bitcoindevkit/bdk-kotlin
 [bdk-swift]: https://github.com/bitcoindevkit/bdk-swift
-[bdk-python]: https://github.com/thunderbiscuit/bdk-python
+[bdk-python]: https://github.com/bitcoindevkit/bdk-python
 
 ## Contributing
 


### PR DESCRIPTION
The bdk-python link in the readme was pointing to my personal fork of the repository. This updates the link to the official bitcoindevkit org repo.