### PR TITLE
Add `get_height` and `get_block_hash` methods on blockchain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add `get_height()` and `get_block_hash()` methods on blockchain [#184]
+
+[#184]: https://github.com/bitcoindevkit/bdk-ffi/pull/184
 
 ## [v0.8.0]
 - Update BDK to version 0.20.0 [#169]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - `derive(DerivationPath)` derives and returns child DescriptorPublicKey
     - `extend(DerivationPath)` extends and returns DescriptorPublicKey
     - `as_string()` returns DescriptorPublicKey as String
-    - Add `get_height()` and `get_block_hash()` methods on blockchain [#184]
+  - Add to `interface Blockchain` the `get_height()` and `get_block_hash()` methods [#184]
 - Interfaces Added [#154]
   - `DescriptorSecretKey`
   - `DescriptorPublicKey`

--- a/src/bdk.udl
+++ b/src/bdk.udl
@@ -143,6 +143,12 @@ interface Blockchain {
 
   [Throws=BdkError]
   void broadcast([ByRef] PartiallySignedBitcoinTransaction psbt);
+
+  [Throws=BdkError]
+  u32 get_height();
+
+  [Throws=BdkError]
+  string get_block_hash(u32 height);
 };
 
 callback interface Progress {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,8 @@ use bdk::bitcoin::secp256k1::Secp256k1;
 use bdk::bitcoin::util::psbt::PartiallySignedTransaction;
 use bdk::bitcoin::{Address, Network, OutPoint as BdkOutPoint, Script, Txid};
 use bdk::blockchain::any::{AnyBlockchain, AnyBlockchainConfig};
+use bdk::blockchain::GetBlockHash;
+use bdk::blockchain::GetHeight;
 use bdk::blockchain::{
     electrum::ElectrumBlockchainConfig, esplora::EsploraBlockchainConfig, ConfigurableBlockchain,
 };
@@ -168,6 +170,16 @@ impl Blockchain {
     fn broadcast(&self, psbt: &PartiallySignedBitcoinTransaction) -> Result<(), Error> {
         let tx = psbt.internal.lock().unwrap().clone().extract_tx();
         self.get_blockchain().broadcast(&tx)
+    }
+
+    fn get_height(&self) -> Result<u32, Error> {
+        self.get_blockchain().get_height()
+    }
+
+    fn get_block_hash(&self, height: u32) -> Result<String, Error> {
+        self.get_blockchain()
+            .get_block_hash(u64::from(height))
+            .map(|hash| hash.to_string())
     }
 }
 


### PR DESCRIPTION
Fixes #151.

### Description
This PR adds the `get_height()` and `get_block_hash()` methods to the `blockchain`.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:
* [x] I've updated `CHANGELOG.md`
