### PR TITLE
Fix method names to mirror Rust bdk API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Rename `get_transactions()` method on `Wallet` interface to `list_transactions()` [#185]
   - Remove `generate_extended_key`, returned ExtendedKeyInfo [#154]
   - Remove `restore_extended_key`, returned ExtendedKeyInfo [#154]
+  - Remove dictionary `ExtendedKeyInfo {mnenonic, xprv, fingerprint}` [#154]
 - APIs Added [#154]
   - `generate_mnemonic()`, returns string mnemonic
   - `interface DescriptorSecretKey`
@@ -27,8 +28,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `DescriptorSecretKey`
   - `DescriptorPublicKey`
   - `DerivationPath`
-- Dictionary Removed [#154]
-  - `ExtendedKeyInfo {mnenonic, xprv, fingerprint}`
 
 [#154]: https://github.com/bitcoindevkit/bdk-ffi/pull/154
 [#184]: https://github.com/bitcoindevkit/bdk-ffi/pull/184

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Breaking Changes
+  - Rename `get_network()` method on `Wallet` interface to `network()` [#185]
+  - Rename `get_transactions()` method on `Wallet` interface to `list_transactions()` [#185]
+  - Remove `generate_extended_key`, returned ExtendedKeyInfo [#154]
+  - Remove `restore_extended_key`, returned ExtendedKeyInfo [#154]
 - APIs Added [#154]
   - `generate_mnemonic()`, returns string mnemonic
   - `interface DescriptorSecretKey`
@@ -23,13 +28,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `DescriptorPublicKey`
   - `DerivationPath`
 - Dictionary Removed [#154]
-  - `ExtendedKeyInfo {mnenonic, xprv, fingerprint}` 
-- APIs Removed [#154]
-  - `generate_extended_key`, returned ExtendedKeyInfo
-  - `restore_extended_key`, returned ExtendedKeyInfo
+  - `ExtendedKeyInfo {mnenonic, xprv, fingerprint}`
 
 [#154]: https://github.com/bitcoindevkit/bdk-ffi/pull/154
 [#184]: https://github.com/bitcoindevkit/bdk-ffi/pull/184
+[#185]: https://github.com/bitcoindevkit/bdk-ffi/pull/185
 
 ## [v0.8.0]
 - Update BDK to version 0.20.0 [#169]

--- a/src/bdk.udl
+++ b/src/bdk.udl
@@ -182,9 +182,9 @@ interface Wallet {
   boolean sign([ByRef] PartiallySignedBitcoinTransaction psbt);
 
   [Throws=BdkError]
-  sequence<Transaction> get_transactions();
+  sequence<Transaction> list_transactions();
 
-  Network get_network();
+  Network network();
 
   [Throws=BdkError]
   void sync([ByRef] Blockchain blockchain, Progress? progress);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -319,7 +319,7 @@ impl Wallet {
         self.wallet_mutex.lock().expect("wallet")
     }
 
-    fn get_network(&self) -> Network {
+    fn network(&self) -> Network {
         self.get_wallet().network()
     }
 
@@ -354,7 +354,7 @@ impl Wallet {
         self.get_wallet().sign(&mut psbt, SignOptions::default())
     }
 
-    fn get_transactions(&self) -> Result<Vec<Transaction>, Error> {
+    fn list_transactions(&self) -> Result<Vec<Transaction>, Error> {
         let transactions = self.get_wallet().list_transactions(true)?;
         Ok(transactions.iter().map(Transaction::from).collect())
     }
@@ -363,7 +363,7 @@ impl Wallet {
         let unspents = self.get_wallet().list_unspent()?;
         Ok(unspents
             .iter()
-            .map(|u| LocalUtxo::from_utxo(u, self.get_network()))
+            .map(|u| LocalUtxo::from_utxo(u, self.network()))
             .collect())
     }
 }


### PR DESCRIPTION
Fixes #181.

1. `get_network()` is now `network()`
2.  `get_transactions()` is now `list_transactions()`