### PR TITLE
Add tx builder set recipients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
 - Breaking Changes
   - Rename `get_network()` method on `Wallet` interface to `network()` [#185]
   - Rename `get_transactions()` method on `Wallet` interface to `list_transactions()` [#185]
@@ -24,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - `extend(DerivationPath)` extends and returns DescriptorPublicKey
     - `as_string()` returns DescriptorPublicKey as String
   - Add to `interface Blockchain` the `get_height()` and `get_block_hash()` methods [#184]
+  - Add to `interface TxBuilder`  the `set_recipients(recipient: Vec<AddressAmount>)` method [#186] 
 - Interfaces Added [#154]
   - `DescriptorSecretKey`
   - `DescriptorPublicKey`

--- a/src/bdk.udl
+++ b/src/bdk.udl
@@ -168,6 +168,11 @@ dictionary LocalUtxo {
   boolean is_spent;
 };
 
+dictionary AddressAmount {
+  string address;
+  u64 amount;
+};
+
 interface Wallet {
   [Throws=BdkError]
   constructor(string descriptor, string? change_descriptor, Network network, DatabaseConfig database_config);
@@ -234,6 +239,8 @@ interface TxBuilder {
   TxBuilder enable_rbf_with_sequence(u32 nsequence);
 
   TxBuilder add_data(sequence<u8> data);
+  
+  TxBuilder set_recipients(sequence<AddressAmount> recipients);
   
   [Throws=BdkError]
   PartiallySignedBitcoinTransaction finish([ByRef] Wallet wallet);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,11 @@ uniffi_macros::include_scaffolding!("bdk");
 
 type BdkError = Error;
 
+pub struct AddressAmount {
+    pub address: String,
+    pub amount: u64,
+}
+
 pub struct AddressInfo {
     pub index: u32,
     pub address: String,
@@ -415,6 +420,17 @@ impl TxBuilder {
     fn add_recipient(&self, recipient: String, amount: u64) -> Arc<Self> {
         let mut recipients = self.recipients.to_vec();
         recipients.append(&mut vec![(recipient, amount)]);
+        Arc::new(TxBuilder {
+            recipients,
+            ..self.clone()
+        })
+    }
+
+    fn set_recipients(&self, recipients: Vec<AddressAmount>) -> Arc<Self> {
+        let recipients = recipients
+            .iter()
+            .map(|address_amount| (address_amount.address.clone(), address_amount.amount))
+            .collect();
         Arc::new(TxBuilder {
             recipients,
             ..self.clone()


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description
I just started working on #168 which enables the `tx_builder` to add a list of recipients instead of iterating over the `add_recipient` method multiple times.
- The `set_recipients()` method replaces the precedent list and overwrites it with the new one. 
- You can always use `add_recipient()` to append to the list.



<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature
* [x] I've updated `CHANGELOG.md`

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
