### PR TITLE
Pin version of uniffi-bindgen in bdk-ffi-bindgen tool

### DIFF
--- a/bdk-ffi-bindgen/Cargo.toml
+++ b/bdk-ffi-bindgen/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2021"
 [dependencies]
 anyhow = "=1.0.45" # remove after upgrading to next version of uniffi
 structopt = "0.3"
-uniffi_bindgen = "0.19.3"
+uniffi_bindgen = "=0.19.3"
 camino = "1.0.9"


### PR DESCRIPTION
### Description
This fixes a CI issue that appears in bdk-kotlin because of a breaking change in uniffi-bindgen `0.19.5`.

### Checklists

* [x] I've signed all my commits
