### PR TITLE
Create patch `0.8.1` that pins the uniffi-bindgen dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk-ffi"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Steve Myers <steve@notmandatory.org>", "Sudarsan Balaji <sudarsan.balaji@artfuldev.com>"]
 edition = "2018"
 

--- a/bdk-ffi-bindgen/Cargo.toml
+++ b/bdk-ffi-bindgen/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2021"
 [dependencies]
 anyhow = "=1.0.45" # remove after upgrading to next version of uniffi
 structopt = "0.3"
-uniffi_bindgen = "0.19.3"
+uniffi_bindgen = "=0.19.3"
 camino = "1.0.9"


### PR DESCRIPTION
This PR pins the version of uniffi-bindgen to `0.19.3` and tags a patch release `0.8.1` which will enable us to update the submodules in the bindings repositories in order to fix CI issues.