### PR TITLE
Update uniffi-bindgen to 0.19.5

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -10,9 +10,9 @@ jobs:
     strategy:
       matrix:
         rust:
-          - version: 1.60.0 # STABLE
+          - version: 1.63.0 # STABLE
             clippy: true
-          - version: 1.57.0 # MSRV
+          - version: 1.61.0 # MSRV
     steps:
       - name: checkout
         uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # Native language bindings for BDK
 
+<p>
+    <a href="https://github.com/bitcoindevkit/bdk-ffi/blob/master/LICENSE"><img alt="MIT or Apache-2.0 Licensed" src="https://img.shields.io/badge/license-MIT%2FApache--2.0-blue.svg"/></a>
+    <a href="https://github.com/bitcoindevkit/bdk-ffi/actions?query=workflow%3ACI"><img alt="CI Status" src="https://github.com/bitcoindevkit/bdk-ffi/workflows/CI/badge.svg"></a>
+    <a href="https://blog.rust-lang.org/2022/05/19/Rust-1.61.0.html"><img alt="Rustc Version 1.61.0+" src="https://img.shields.io/badge/rustc-1.61.0%2B-lightgrey.svg"/></a>
+    <a href="https://discord.gg/d7NkDKm"><img alt="Chat on Discord" src="https://img.shields.io/discord/753336465005608961?logo=discord"></a>
+  </p>
+
 The workspace in this repository creates the `libbdkffi` multi-language library for the rust based 
 [bdk] library from the [Bitcoin Dev Kit] project. The `bdk-ffi-bindgen` package builds a tool for 
 generating the actual language binding code used to access the `libbdkffi` library.

--- a/bdk-ffi-bindgen/Cargo.toml
+++ b/bdk-ffi-bindgen/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2021"
 [dependencies]
 anyhow = "=1.0.45" # remove after upgrading to next version of uniffi
 structopt = "0.3"
-uniffi_bindgen = "=0.19.3"
+uniffi_bindgen = "0.19.5"
 camino = "1.0.9"

--- a/bdk-ffi-bindgen/src/main.rs
+++ b/bdk-ffi-bindgen/src/main.rs
@@ -52,6 +52,7 @@ fn generate_bindings(opt: &Opt) -> anyhow::Result<(), anyhow::Error> {
         None,
         vec![opt.language.to_string().as_str()],
         Some(out_dir),
+        None,
         false,
     )?;
 

--- a/bdk-ffi-bindgen/src/main.rs
+++ b/bdk-ffi-bindgen/src/main.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use structopt::StructOpt;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum Language {
     Kotlin,
     Python,


### PR DESCRIPTION
As per mozilla/uniffi-rs#1322, the new argument introduced in the `generate_bindings()` function should be set to `None` unless we use the new macro-based approach.

This PR unpins the uniffi-bindgen library while also ensuring the CI can build the library properly.