### PR TITLE
Rename KeychainKind variants to ExternalKeys and InternalKeys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.10.0]
+
+- Breaking Changes
+  - Rename `KeychainKind` variants to `ExternalKeys` and `InternalKeys` so as not to conflict with
+    the swift reserved word `internal`.
+
 ## [v0.9.0]
 - Breaking Changes
   - Rename `get_network()` method on `Wallet` interface to `network()` [#185]
@@ -101,7 +107,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [v0.2.0]
 
-[unreleased]: https://github.com/bitcoindevkit/bdk-ffi/compare/v0.9.0...HEAD
+[unreleased]: https://github.com/bitcoindevkit/bdk-ffi/compare/v0.10.0...HEAD
+[v0.10.0]: https://github.com/bitcoindevkit/bdk-ffi/compare/v0.9.0...v0.10.0
 [v0.9.0]: https://github.com/bitcoindevkit/bdk-ffi/compare/v0.8.0...v0.9.0
 [v0.8.0]: https://github.com/bitcoindevkit/bdk-ffi/compare/v0.7.0...v0.8.0
 [v0.7.0]: https://github.com/bitcoindevkit/bdk-ffi/compare/v0.6.0...v0.7.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk-ffi"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["Steve Myers <steve@notmandatory.org>", "Sudarsan Balaji <sudarsan.balaji@artfuldev.com>"]
 edition = "2018"
 

--- a/src/bdk.udl
+++ b/src/bdk.udl
@@ -162,8 +162,8 @@ dictionary TxOut {
 };
 
 enum KeychainKind {
-  "External",
-  "Internal",
+  "ExternalKeys",
+  "InternalKeys",
 };
 
 dictionary LocalUtxo {


### PR DESCRIPTION
### Description

I ran into an issue with updating `bdk-swift` to the latest `bdk-ffi` version (0.9.0). There's a conflict with the `KeychainKind.Internal` variant, in Swift `uniffi-rs` maps the variant name to `internal` which isn't allowed because it's a Swift keyword.

For now I think the best approach is to created a `bdk-ffi` version of  `KeychainKind` with variants `ExternalKeys` and `InternalKeys` so there won't be any conflict in Swift. 

I also bumped the `bdk-ffi` version to `0.10.0` so we can tag this change as a new API breaking version and make a new `bdk-swift` release. I don't think we need to do new Kotlin and Python releases, but we should warn those users of the breaking change when we do their next releases.

### Notes to the reviewers

This is a breaking change for any apps that use the `LocalUtxo.keychain` field value for filtering or anything else where the original enum variant type is used.  

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature
* [x] I've updated `CHANGELOG.md`

#### Bugfixes:

* [x] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
