### PR TITLE
Add ability to retrieve private keys as bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- APIs Added
+  - Add ability to retrieve any private key inside a descriptor as bytes [#199]
+
+[#199]: https://github.com/bitcoindevkit/bdk-ffi/pull/199
 
 ## [v0.9.0]
 - Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- APIs Added
-  - Add ability to retrieve any private key inside a descriptor as bytes [#199]
-
-[#199]: https://github.com/bitcoindevkit/bdk-ffi/pull/199
 
 ## [v0.9.0]
 - Breaking Changes

--- a/src/bdk.udl
+++ b/src/bdk.udl
@@ -283,7 +283,7 @@ interface DescriptorSecretKey {
 
   DescriptorPublicKey as_public();
 
-  sequence<u8> secret_key_bytes();
+  sequence<u8> secret_bytes();
 
   string as_string();
 };

--- a/src/bdk.udl
+++ b/src/bdk.udl
@@ -283,6 +283,8 @@ interface DescriptorSecretKey {
 
   DescriptorPublicKey as_public();
 
+  sequence<u8> secret_key_bytes();
+
   string as_string();
 };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -914,9 +914,8 @@ impl DescriptorSecretKey {
             BdkDescriptorSecretKey::XPrv(descriptor_x_key) => {
                 descriptor_x_key.xkey.private_key.secret_bytes().to_vec()
             }
-            BdkDescriptorSecretKey::SinglePriv(descriptor_x_key) => {
-                // unreachable!()
-                descriptor_x_key.key.inner.secret_bytes().to_vec()
+            BdkDescriptorSecretKey::SinglePriv(_) => {
+                unreachable!()
             }
         };
 
@@ -1146,5 +1145,15 @@ mod test {
         let master_dpk = get_descriptor_secret_key().as_public();
         let derived_dpk = &derive_dpk(&master_dpk, "m/84h/1h/0h");
         assert!(derived_dpk.is_err());
+    }
+
+    #[test]
+    fn test_retrieve_master_secret_key() {
+        let master_dpk = get_descriptor_secret_key();
+        let master_private_key = master_dpk.secret_key_bytes().to_hex();
+        assert_eq!(
+            master_private_key,
+            "e93315d6ce401eb4db803a56232f0ed3e69b053774e6047df54f1bd00e5ea936"
+        )
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -908,9 +908,9 @@ impl DescriptorSecretKey {
     }
 
     /// Get the private key as bytes.
-    fn secret_key_bytes(&self) -> Vec<u8> {
+    fn secret_bytes(&self) -> Vec<u8> {
         let descriptor_secret_key = self.descriptor_secret_key_mutex.lock().unwrap();
-        let secret_key_bytes: Vec<u8> = match descriptor_secret_key.deref() {
+        let secret_bytes: Vec<u8> = match descriptor_secret_key.deref() {
             BdkDescriptorSecretKey::XPrv(descriptor_x_key) => {
                 descriptor_x_key.xkey.private_key.secret_bytes().to_vec()
             }
@@ -919,7 +919,7 @@ impl DescriptorSecretKey {
             }
         };
 
-        secret_key_bytes
+        secret_bytes
     }
 
     fn as_string(&self) -> String {
@@ -1150,7 +1150,7 @@ mod test {
     #[test]
     fn test_retrieve_master_secret_key() {
         let master_dpk = get_descriptor_secret_key();
-        let master_private_key = master_dpk.secret_key_bytes().to_hex();
+        let master_private_key = master_dpk.secret_bytes().to_hex();
         assert_eq!(
             master_private_key,
             "e93315d6ce401eb4db803a56232f0ed3e69b053774e6047df54f1bd00e5ea936"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -907,6 +907,22 @@ impl DescriptorSecretKey {
         })
     }
 
+    /// Get the private key as bytes.
+    fn secret_key_bytes(&self) -> Vec<u8> {
+        let descriptor_secret_key = self.descriptor_secret_key_mutex.lock().unwrap();
+        let secret_key_bytes: Vec<u8> = match descriptor_secret_key.deref() {
+            BdkDescriptorSecretKey::XPrv(descriptor_x_key) => {
+                descriptor_x_key.xkey.private_key.secret_bytes().to_vec()
+            }
+            BdkDescriptorSecretKey::SinglePriv(descriptor_x_key) => {
+                // unreachable!()
+                descriptor_x_key.key.inner.secret_bytes().to_vec()
+            }
+        };
+
+        secret_key_bytes
+    }
+
     fn as_string(&self) -> String {
         self.descriptor_secret_key_mutex.lock().unwrap().to_string()
     }


### PR DESCRIPTION
This feature is needed for compatibility with LDKLite, where the initial entropy given to LDK is the private key of the root of the BIP32 derivation tree.

Closes #188

### Description

### Changelog notice
```txt
APIs Added:
    - Add `secret_key_bytes()` method on the `DescriptorSecretKey` [#199]

[#199](https://github.com/bitcoindevkit/bdk-ffi/pull/199)
```

### Notes to the reviewers
I just want to make sure I understand why the `BdkDescriptorSecretKey::SinglePriv(_)` is unreachable (will fix the code to add the `unreachable!()` if my understanding is correct. Is it because we currently only build the DescriptorSecretKey from mnemonics, and always make them extendable?

#### All Submissions:
* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:
* [x] I've added tests for the new feature
* [x] I've added docs for the new feature
* [x] I've updated `CHANGELOG.md`