### PR TITLE
Add `combine()` method on PSBT

### DIFF
--- a/src/bdk.udl
+++ b/src/bdk.udl
@@ -210,6 +210,9 @@ interface PartiallySignedBitcoinTransaction {
   string serialize();
 
   string txid();
+
+  [Throws=BdkError]
+  PartiallySignedBitcoinTransaction combine(PartiallySignedBitcoinTransaction other);
 };
 
 interface TxBuilder {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -304,12 +304,9 @@ impl NetworkLocalUtxo for LocalUtxo {
             },
             txout: TxOut {
                 value: x.txout.value,
-                address: bdk::bitcoin::util::address::Address::from_script(
-                    &x.txout.script_pubkey,
-                    network,
-                )
-                .unwrap()
-                .to_string(),
+                address: Address::from_script(&x.txout.script_pubkey, network)
+                    .unwrap()
+                    .to_string(),
             },
             keychain: x.keychain,
             is_spent: x.is_spent,
@@ -1046,7 +1043,7 @@ mod test {
     fn get_descriptor_secret_key() -> DescriptorSecretKey {
         let mnemonic =
         "chaos fabric time speed sponsor all flat solution wisdom trophy crack object robot pave observe combine where aware bench orient secret primary cable detect".to_string();
-        DescriptorSecretKey::new(Network::Testnet, mnemonic, None).unwrap()
+        DescriptorSecretKey::new(Testnet, mnemonic, None).unwrap()
     }
 
     fn derive_dsk(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -364,6 +364,22 @@ impl PartiallySignedBitcoinTransaction {
         let txid = tx.txid();
         txid.to_hex()
     }
+
+    /// Combines this PartiallySignedTransaction with other PSBT as described by BIP 174.
+    ///
+    /// In accordance with BIP 174 this function is commutative i.e., `A.combine(B) == B.combine(A)`
+    fn combine(
+        &self,
+        other: Arc<PartiallySignedBitcoinTransaction>,
+    ) -> Result<Arc<PartiallySignedBitcoinTransaction>, Error> {
+        let other_psbt = other.internal.lock().unwrap().clone();
+        let mut original_psbt = self.internal.lock().unwrap().clone();
+
+        original_psbt.combine(other_psbt)?;
+        Ok(Arc::new(PartiallySignedBitcoinTransaction {
+            internal: Mutex::new(original_psbt),
+        }))
+    }
 }
 
 /// A Bitcoin wallet.


### PR DESCRIPTION
This method adds the ability to combine two PSBTs.

Closes #198

### Changelog notice
```txt
APIs Added:
    - Add `PartiallySignedBitcoinTransaction.combine()` method [#200]

[#200](https://github.com/bitcoindevkit/bdk-ffi/pull/200)
```

### Notes to the reviewers
Please merge #199 before this one. I will update the changelog and add the commit once that's in.

### Checklists

#### All Submissions:
* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:
* [ ] I've added tests for the new feature
* [x] I've added docs for the new feature