### PR TITLE
Update uniffi-rs to 0.20.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,8 @@ name = "bdkffi"
 [dependencies]
 bdk = { version = "0.22", features = ["all-keys", "use-esplora-ureq", "sqlite-bundled"] }
 
-uniffi_macros = { version = "0.19.3", features = ["builtin-bindgen"] }
-uniffi = { version = "0.19.3", features = ["builtin-bindgen"] }
+uniffi_macros = { version = "0.20.0", features = ["builtin-bindgen"] }
+uniffi = { version = "0.20.0", features = ["builtin-bindgen"] }
 
 [build-dependencies]
-uniffi_build = { version = "0.19.3", features = ["builtin-bindgen"] }
+uniffi_build = { version = "0.20.0", features = ["builtin-bindgen"] }

--- a/bdk-ffi-bindgen/Cargo.toml
+++ b/bdk-ffi-bindgen/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.2.0"
 edition = "2021"
 
 [dependencies]
-anyhow = "=1.0.45" # remove after upgrading to next version of uniffi
+anyhow = "1.0.45" # remove after upgrading to next version of uniffi
 structopt = "0.3"
-uniffi_bindgen = "0.19.5"
+uniffi_bindgen = "0.20.0"
 camino = "1.0.9"


### PR DESCRIPTION
This PR bumps the uniffi-rs library to `0.20.0`

## Notes to the reviewers
This neatly brings in the PR that fixes the bug with Swift keywords and brings us in line with the latest uniffi-rs version.

## Changelog notice
```txt
- Update uniffi-rs to latest version 0.20.0 [#203]

[#203](https://github.com/bitcoindevkit/bdk-ffi/pull/203)
```

## All Submissions:
* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing