### PR TITLE
Add FeeRate struct and PSBT fee_amount and fee_rate functions

### DIFF
--- a/src/bdk.udl
+++ b/src/bdk.udl
@@ -202,6 +202,13 @@ interface Wallet {
   sequence<LocalUtxo> list_unspent();
 };
 
+interface FeeRate {
+  [Name=from_sat_per_vb]
+  constructor(float sat_per_vb);
+
+  float as_sat_per_vb();
+};
+
 interface PartiallySignedTransaction {
   [Throws=BdkError]
   constructor(string psbt_base64);
@@ -214,6 +221,10 @@ interface PartiallySignedTransaction {
 
   [Throws=BdkError]
   PartiallySignedTransaction combine(PartiallySignedTransaction other);
+
+  u64? fee_amount();
+
+  FeeRate? fee_rate();
 };
 
 dictionary TxBuilderResult {

--- a/src/bdk.udl
+++ b/src/bdk.udl
@@ -137,7 +137,7 @@ interface Blockchain {
   constructor(BlockchainConfig config);
 
   [Throws=BdkError]
-  void broadcast([ByRef] PartiallySignedBitcoinTransaction psbt);
+  void broadcast([ByRef] PartiallySignedTransaction psbt);
 
   [Throws=BdkError]
   u32 get_height();
@@ -188,7 +188,7 @@ interface Wallet {
   Balance get_balance();
 
   [Throws=BdkError]
-  boolean sign([ByRef] PartiallySignedBitcoinTransaction psbt);
+  boolean sign([ByRef] PartiallySignedTransaction psbt);
 
   [Throws=BdkError]
   sequence<TransactionDetails> list_transactions();
@@ -202,7 +202,7 @@ interface Wallet {
   sequence<LocalUtxo> list_unspent();
 };
 
-interface PartiallySignedBitcoinTransaction {
+interface PartiallySignedTransaction {
   [Throws=BdkError]
   constructor(string psbt_base64);
 
@@ -213,11 +213,11 @@ interface PartiallySignedBitcoinTransaction {
   sequence<u8> extract_tx();
 
   [Throws=BdkError]
-  PartiallySignedBitcoinTransaction combine(PartiallySignedBitcoinTransaction other);
+  PartiallySignedTransaction combine(PartiallySignedTransaction other);
 };
 
 dictionary TxBuilderResult {
-  PartiallySignedBitcoinTransaction psbt;
+  PartiallySignedTransaction psbt;
   TransactionDetails transaction_details;
 };
 
@@ -270,7 +270,7 @@ interface BumpFeeTxBuilder {
   BumpFeeTxBuilder enable_rbf_with_sequence(u32 nsequence);
 
   [Throws=BdkError]
-  PartiallySignedBitcoinTransaction finish([ByRef] Wallet wallet);
+  PartiallySignedTransaction finish([ByRef] Wallet wallet);
 };
 
 interface Mnemonic {


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

Add FeeRate struct and fee_amount() and fee_rate() functions on PartiallySignedTransaction.

### Notes to the reviewers

This PR is dependent on https://github.com/bitcoindevkit/bdk/pull/782.

### Changelog notice

- Breaking Changes
  - Renamed PartiallySignedBitcoinTransaction to PartiallySignedTransaction to be consistent with `rust-bitcoin`
- APIs Added
  - Add FeeRate struct
  - Add fee_amount() and fee_rate() functions on PartiallySignedTransaction

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [x] I've added tests for the new feature
* [x] I've added docs for the new feature
