### PR TITLE
Change TxBuilder.finish() to return new TxBuilderResult

### DIFF
--- a/src/bdk.udl
+++ b/src/bdk.udl
@@ -217,6 +217,11 @@ interface PartiallySignedBitcoinTransaction {
   PartiallySignedBitcoinTransaction combine(PartiallySignedBitcoinTransaction other);
 };
 
+dictionary TxBuilderResult {
+  PartiallySignedBitcoinTransaction psbt;
+  TransactionDetails transaction_details;
+};
+
 interface TxBuilder {
   constructor();
 
@@ -253,7 +258,7 @@ interface TxBuilder {
   TxBuilder set_recipients(sequence<ScriptAmount> recipients);
 
   [Throws=Error]
-  PartiallySignedBitcoinTransaction finish([ByRef] Wallet wallet);
+  TxBuilderResult finish([ByRef] Wallet wallet);
 };
 
 interface BumpFeeTxBuilder {


### PR DESCRIPTION
### Description

Change TxBuilder.finish() to return new TxBuilderResult.

### Notes to the reviewers

This fixes #179 in that it return both PartiallySignedBitcoinTransaction and TransactionDetails encapsulated in a new TxBuilderResult structure. It does not calculate the fee rate which requires #208.

### Changelog notice

- Breaking Changes
  - Changed `TxBuilder.finish()` to return new `TxBuilderResult`.
- APIs Added
  - Added `TxBuilderResult` with PSBT and TransactionDetails. 

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [x] I've added tests for the new feature
* [x] I've added docs for the new feature

