### PR TITLE
Add Mnemonic type and key constructors from string

### DIFF
--- a/src/bdk.udl
+++ b/src/bdk.udl
@@ -1,6 +1,5 @@
 namespace bdk {
-  [Throws=Error]
-  string generate_mnemonic(WordCount word_count);
+
 };
 
 [Error]
@@ -46,6 +45,12 @@ enum Error {
   "Esplora",
   "Sled",
   "Rusqlite",
+};
+
+interface Mnemonic {
+  constructor(WordCount word_count)
+
+  string as_string();
 };
 
 dictionary AddressInfo {
@@ -280,8 +285,12 @@ interface DerivationPath {
 };
 
 interface DescriptorSecretKey {
+
   [Throws=Error]
-  constructor(Network network, string mnemonic, string? password);
+  constructor(Network network, string key);
+
+  [Name=from_mnemonic]
+  constructor(Network network, Mnemonic mnemonic, string? password);
 
   [Throws=Error]
   DescriptorSecretKey derive(DerivationPath path);
@@ -296,6 +305,9 @@ interface DescriptorSecretKey {
 };
 
 interface DescriptorPublicKey {
+  [Throws=Error]
+  constructor(Network network, string key);
+
   [Throws=Error]
   DescriptorPublicKey derive(DerivationPath path);
 


### PR DESCRIPTION
### Description

Add the ability to create PublicDescriptorKey or SecretDescriptorKey from a string, including non-extended key types like WIF. An error is thrown if the string isn't a valid key. 

### Notes to the reviewers

The Mnemonic type also needs to be added back since only one constructor type can throw an error per the UDL limitations, and that means we need to type check the mnemonic words in the Mnemonic constructor.   

### Changelog notice

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

### Checklists

#### All Submissions:

* [ ] I've signed all my commits
* [ ] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [ ] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
