### PR TITLE
Update uniffi dependencies to 0.21.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,8 @@ name = "bdkffi"
 [dependencies]
 bdk = { version = "0.23", features = ["all-keys", "use-esplora-ureq", "sqlite-bundled"] }
 
-uniffi_macros = { version = "0.20.0", features = ["builtin-bindgen"] }
-uniffi = { version = "0.20.0", features = ["builtin-bindgen"] }
+uniffi_macros = { version = "0.21.0", features = ["builtin-bindgen"] }
+uniffi = { version = "0.21.0", features = ["builtin-bindgen"] }
 
 [build-dependencies]
-uniffi_build = { version = "0.20.0", features = ["builtin-bindgen"] }
+uniffi_build = { version = "0.21.0", features = ["builtin-bindgen"] }

--- a/bdk-ffi-bindgen/Cargo.toml
+++ b/bdk-ffi-bindgen/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.45" # remove after upgrading to next version of uniffi
 structopt = "0.3"
-uniffi_bindgen = "0.20.0"
+uniffi_bindgen = "0.21.0"
 camino = "1.0.9"


### PR DESCRIPTION
### Description

Update uniffi dependencies to 0.21.0

### Notes to the reviewers

This is required to pickup my PR to handle swift keywords. https://github.com/mozilla/uniffi-rs/compare/v0.20.0...v0.21.0

### Changelog notice

Update uniffi-rs to latest version 0.20.0 #216

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
