### PR TITLE
Add API for generating master keys directly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ name = "bdkffi"
 
 [dependencies]
 bdk = { version = "0.23", features = ["all-keys", "use-esplora-ureq", "sqlite-bundled"] }
+rand = "^0.8"
 
 uniffi_macros = { version = "0.21.0", features = ["builtin-bindgen"] }
 uniffi = { version = "0.21.0", features = ["builtin-bindgen"] }

--- a/src/bdk.udl
+++ b/src/bdk.udl
@@ -283,6 +283,12 @@ interface DescriptorSecretKey {
   [Throws=BdkError]
   constructor(Network network, string mnemonic, string? password);
 
+  [Name=generate, Throws=BdkError]
+  constructor(Network network);
+
+  [Name=generate_from_entropy, Throws=BdkError]
+  constructor(Network network, sequence<u8> entropy);
+
   [Throws=BdkError]
   DescriptorSecretKey derive(DerivationPath path);
 

--- a/src/bdk.udl
+++ b/src/bdk.udl
@@ -283,10 +283,10 @@ interface DescriptorSecretKey {
   [Throws=BdkError]
   constructor(Network network, string mnemonic, string? password);
 
-  [Name=generate, Throws=BdkError]
+  [Name=generate]
   constructor(Network network);
 
-  [Name=generate_from_entropy, Throws=BdkError]
+  [Name=generate_from_entropy]
   constructor(Network network, sequence<u8> entropy);
 
   [Throws=BdkError]


### PR DESCRIPTION
Rough draft of the new API for generating `DescriptorSecretKey` without going through the mnemonics step.

A few questions still left to figure out:
1. Do we want the `generate_from_entropy()` method? I added it as a bonus but we should still discuss if there is a need for it.
2. I'd like to make sure the random number generation is handled properly; this is the very core of the security of the keys. I tried to reproduce what is done for the mnemonic, [see the code here](https://docs.rs/bdk/latest/src/bdk/keys/mod.rs.html#631-637).
3. I'm not sure if I really need to have the `rand` crate imported here (we don't need it on the mnemonic step for example). There might be a way to get this done internally in bdk without generating the entropy at the ffi layer.