### PR TITLE
Added Mnemonic Interface

### DIFF
--- a/src/bdk.udl
+++ b/src/bdk.udl
@@ -1,6 +1,5 @@
 namespace bdk {
-  [Throws=BdkError]
-  string generate_mnemonic(WordCount word_count);
+
 };
 
 [Error]
@@ -274,14 +273,25 @@ interface BumpFeeTxBuilder {
   PartiallySignedBitcoinTransaction finish([ByRef] Wallet wallet);
 };
 
+interface Mnemonic {
+  constructor(WordCount word_count);
+
+  [Name=from_str, Throws=BdkError]
+  constructor(string mnemonic);
+
+  [Name=from_entropy, Throws=BdkError]
+  constructor(sequence<u8> entropy);
+
+  string as_string();
+};
+
 interface DerivationPath {
   [Throws=BdkError]
   constructor(string path);
 };
 
 interface DescriptorSecretKey {
-  [Throws=BdkError]
-  constructor(Network network, string mnemonic, string? password);
+  constructor(Network network, Mnemonic mnemonic, string? password);
 
   [Throws=BdkError]
   DescriptorSecretKey derive(DerivationPath path);


### PR DESCRIPTION
### Description
This PR adds `interface Mnemonic` which will make the API to generate new DescriptorSecretKey have type-safe arguments.

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

### Notes to the reviewers

This PR doesn't have any issue linked to it, as it was discusses on a call during the implementation of `DescriptorSecretKey` (PR #154). It was discussed to make `Mnemonic` an interface and use that instead of string `Mnemonic` so that the API to generate `DescriptorSecretKey` doesn't have any potential failure (like in case it's provided with incorrect Mnemonic words).

APIs added
```
// generates and returns Mnemonic with random entropy
Mnemonic::new(word_count: WordCount) -> Self { ... } 
// converts string Mnemonic to Mnemonic type with error (in case of incorrect string Mnemonic)
Mnemonic::from_str(mnemonic: String) -> Result<Self, BdkError> { ... }
// generates and returns Mnemonic with given entropy
Mnemonic::from_entropy(entropy: Vec<u8>) -> Result<Self, BdkError> {...}
// view mnemonic as string
Mnemonic::as_string(&self) -> String { ... }
```
Along with some changes to `DescriptorSecretKey::new()` to fit these new APIs

### Changelog notice
```
- Added Struct Mnemonic with following methods [#219]
  - new(word_count: WordCount) generates and returns Mnemonic with random entropy
  - from_str(mnemonic: String) converts string Mnemonic to Mnemonic type with error
  - from_entropy(entropy: Vec<u8>) generates and returns Mnemonic with given entropy
  - as_string() view Mnemonic as string
- API removed [#219]
  - generate_mnemonic(word_count: WordCount)

[#219](https://github.com/bitcoindevkit/bdk-ffi/pull/219)
```
### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [x] I've added docs for the new feature

#### Bugfixes:

* [x] This pull request breaks the existing API
    * Top level function `generate_mnemonic(...)` was removed