### PR TITLE
Add build profile 'release-smaller'

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,11 @@ uniffi = { version = "0.21.0", features = ["builtin-bindgen"] }
 
 [build-dependencies]
 uniffi_build = { version = "0.21.0", features = ["builtin-bindgen"] }
+
+[profile.release-smaller]
+inherits = "release"
+opt-level = 'z'     # Optimize for size.
+lto = true          # Enable Link Time Optimization
+codegen-units = 1   # Reduce number of codegen units to increase optimizations.
+panic = 'abort'     # Abort on panic
+strip = true        # Strip symbols from binary*


### PR DESCRIPTION
### Description

New profile turns on all the non-experimental rust build size optimizations.

### Notes to the reviewers

This PR is the first step to fixing bitcoindevkit/bdk-swift#25. 

### Changelog notice

None.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
