### PR TITLE
Refactor from_str() method on the Mnemonic struct to from_string()

### DIFF
--- a/src/bdk.udl
+++ b/src/bdk.udl
@@ -287,7 +287,7 @@ interface BumpFeeTxBuilder {
 interface Mnemonic {
   constructor(WordCount word_count);
 
-  [Name=from_str, Throws=BdkError]
+  [Name=from_string, Throws=BdkError]
   constructor(string mnemonic);
 
   [Name=from_entropy, Throws=BdkError]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -890,7 +890,7 @@ impl Mnemonic {
     }
 
     /// Parse a Mnemonic with given string
-    fn from_str(mnemonic: String) -> Result<Self, BdkError> {
+    fn from_string(mnemonic: String) -> Result<Self, BdkError> {
         BdkMnemonic::from_str(&mnemonic)
             .map(|m| Mnemonic { internal: m })
             .map_err(|e| BdkError::Generic(e.to_string()))
@@ -1164,7 +1164,7 @@ mod test {
     }
 
     fn get_descriptor_secret_key() -> DescriptorSecretKey {
-        let mnemonic = Mnemonic::from_str("chaos fabric time speed sponsor all flat solution wisdom trophy crack object robot pave observe combine where aware bench orient secret primary cable detect".to_string()).unwrap();
+        let mnemonic = Mnemonic::from_string("chaos fabric time speed sponsor all flat solution wisdom trophy crack object robot pave observe combine where aware bench orient secret primary cable detect".to_string()).unwrap();
         DescriptorSecretKey::new(Testnet, Arc::new(mnemonic), None)
     }
 


### PR DESCRIPTION
### Description
This PR refactors the `Mnemonic.to_str()` method to `Mnemonic.to_string()`.
