### PR TITLE
Bump version to 0.11.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk-ffi"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Steve Myers <steve@notmandatory.org>", "Sudarsan Balaji <sudarsan.balaji@artfuldev.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
### Description
This PR bumps the version of the library to `0.11.0`.
