### PR TITLE
Update rust-bip39 and simplify fn Mnemonic::new

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,14 @@ default-members = [".", "bdk-ffi-bindgen"]
 crate-type = ["staticlib", "cdylib"]
 name = "bdkffi"
 
+[patch.crates-io]
+bip39 = { git = "https://github.com/tcharding/rust-bip39.git", branch = "10-26-bump-version" }
+
 [dependencies]
 bdk = { version = "0.24", features = ["all-keys", "use-esplora-ureq", "sqlite-bundled"] }
-
 uniffi_macros = { version = "0.21.0", features = ["builtin-bindgen"] }
 uniffi = { version = "0.21.0", features = ["builtin-bindgen"] }
+bip39 = { git = "https://github.com/tcharding/rust-bip39.git", branch = "10-26-bump-version", features = ["rand"] }
 
 [build-dependencies]
 uniffi_build = { version = "0.21.0", features = ["builtin-bindgen"] }


### PR DESCRIPTION
### Description

Fixes #226 

### Notes to the reviewers

This is still a WIP. 

### Changelog notice

Fix Mnemonic::new to work with 15 and 21 word counts.

### Checklists

#### All Submissions:

* [ ] I've signed all my commits
* [ ] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [ ] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
