### PR TITLE
Add descriptor templates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,6 +74,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_matches"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
+
+[[package]]
 name = "async-trait"
 version = "0.1.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -146,6 +152,7 @@ dependencies = [
 name = "bdk-ffi"
 version = "0.25.0"
 dependencies = [
+ "assert_matches",
  "bdk",
  "uniffi",
  "uniffi_build",

--- a/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/AndroidLibTest.kt
+++ b/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/AndroidLibTest.kt
@@ -36,8 +36,7 @@ class AndroidLibTest {
         }
     }
 
-    private val descriptor =
-        "wpkh([c258d2e4/84h/1h/0h]tpubDDYkZojQFQjht8Tm4jsS3iuEmKjTiEGjG6KnuFNKKJb5A6ZUCUZKdvLdSDWofKi4ToRCwb9poe1XdqfUnP4jaJjCB2Zwv11ZLgSbnZSNecE/0/*)"
+    private val descriptor = Descriptor("wpkh([c258d2e4/84h/1h/0h]tpubDDYkZojQFQjht8Tm4jsS3iuEmKjTiEGjG6KnuFNKKJb5A6ZUCUZKdvLdSDWofKi4ToRCwb9poe1XdqfUnP4jaJjCB2Zwv11ZLgSbnZSNecE/0/*)", Network.TESTNET)
 
     private val databaseConfig = DatabaseConfig.Memory
 

--- a/bdk-ffi/Cargo.toml
+++ b/bdk-ffi/Cargo.toml
@@ -11,9 +11,11 @@ name = "bdkffi"
 
 [dependencies]
 bdk = { version = "0.25", features = ["all-keys", "use-esplora-ureq", "sqlite-bundled", "rpc"] }
-
 uniffi_macros = { version = "0.21.0", features = ["builtin-bindgen"] }
 uniffi = { version = "0.21.0", features = ["builtin-bindgen"] }
 
 [build-dependencies]
 uniffi_build = { version = "0.21.0", features = ["builtin-bindgen"] }
+
+[dev-dependencies]
+assert_matches = "1.5.0"

--- a/bdk-ffi/src/bdk.udl
+++ b/bdk-ffi/src/bdk.udl
@@ -203,7 +203,7 @@ dictionary ScriptAmount {
 
 interface Wallet {
   [Throws=BdkError]
-  constructor(string descriptor, string? change_descriptor, Network network, DatabaseConfig database_config);
+  constructor(Descriptor descriptor, Descriptor? change_descriptor, Network network, DatabaseConfig database_config);
 
   [Throws=BdkError]
   AddressInfo get_address(AddressIndex address_index);

--- a/bdk-ffi/src/bdk.udl
+++ b/bdk-ffi/src/bdk.udl
@@ -357,6 +357,33 @@ interface DescriptorPublicKey {
   string as_string();
 };
 
+interface Descriptor {
+  // [Throws=Error]
+  // constructor(string descriptor);
+
+  [Name=new_bip44]
+  constructor(DescriptorSecretKey secret_key, KeychainKind keychain, Network network);
+
+  [Name=new_bip44_public]
+  constructor(DescriptorPublicKey public_key, string fingerprint, KeychainKind keychain, Network network);
+
+  // [Name=new_bip49]
+  // constructor(DescriptorSecretKey secret_key, KeychainKind keychain);
+
+  // [Name=new_bip49_public]
+  // constructor(DescriptorPublicKey public_key, string fingerprint, KeychainKind keychain);
+
+  // [Name=new_bip84]
+  // constructor(DescriptorSecretKey secret_key, KeychainKind keychain);
+
+  // [Name=new_bip84_public]
+  // constructor(DescriptorPublicKey public_key, string fingerprint, KeychainKind keychain);
+
+  string as_string();
+
+  string as_string_private();
+};
+
 interface Address {
   [Throws=BdkError]
   constructor(string address);

--- a/bdk-ffi/src/bdk.udl
+++ b/bdk-ffi/src/bdk.udl
@@ -367,17 +367,17 @@ interface Descriptor {
   [Name=new_bip44_public]
   constructor(DescriptorPublicKey public_key, string fingerprint, KeychainKind keychain, Network network);
 
-  // [Name=new_bip49]
-  // constructor(DescriptorSecretKey secret_key, KeychainKind keychain);
+  [Name=new_bip49]
+  constructor(DescriptorSecretKey secret_key, KeychainKind keychain, Network network);
 
-  // [Name=new_bip49_public]
-  // constructor(DescriptorPublicKey public_key, string fingerprint, KeychainKind keychain);
+  [Name=new_bip49_public]
+  constructor(DescriptorPublicKey public_key, string fingerprint, KeychainKind keychain, Network network);
 
-  // [Name=new_bip84]
-  // constructor(DescriptorSecretKey secret_key, KeychainKind keychain);
+  [Name=new_bip84]
+  constructor(DescriptorSecretKey secret_key, KeychainKind keychain, Network network);
 
-  // [Name=new_bip84_public]
-  // constructor(DescriptorPublicKey public_key, string fingerprint, KeychainKind keychain);
+  [Name=new_bip84_public]
+  constructor(DescriptorPublicKey public_key, string fingerprint, KeychainKind keychain, Network network);
 
   string as_string();
 

--- a/bdk-ffi/src/bdk.udl
+++ b/bdk-ffi/src/bdk.udl
@@ -358,8 +358,8 @@ interface DescriptorPublicKey {
 };
 
 interface Descriptor {
-  // [Throws=Error]
-  // constructor(string descriptor);
+  [Throws=BdkError]
+  constructor(string descriptor, Network network);
 
   [Name=new_bip44]
   constructor(DescriptorSecretKey secret_key, KeychainKind keychain, Network network);

--- a/bdk-ffi/src/lib.rs
+++ b/bdk-ffi/src/lib.rs
@@ -1375,7 +1375,10 @@ uniffi::deps::static_assertions::assert_impl_all!(Wallet: Sync, Send);
 #[cfg(test)]
 mod test {
     use crate::*;
+    use assert_matches::assert_matches;
     use bdk::bitcoin::Address;
+    use bdk::descriptor::DescriptorError::Key;
+    use bdk::keys::KeyError::InvalidNetwork;
     use bdk::wallet::get_funded_wallet;
     use std::str::FromStr;
     use std::sync::Mutex;
@@ -1713,9 +1716,9 @@ mod test {
 
         // Creating a Descriptor using an extended key that doesn't match the network provided will throw and InvalidNetwork Error
         assert!(descriptor1.is_ok());
-        assert_eq!(
-            descriptor2.unwrap_err().to_string(),
-            "Descriptor(Key(InvalidNetwork))"
+        assert_matches!(
+            descriptor2.unwrap_err(),
+            bdk::Error::Descriptor(Key(InvalidNetwork))
         )
     }
 
@@ -1739,9 +1742,9 @@ mod test {
 
         // Creating a wallet using a Descriptor with an extended key that doesn't match the network provided in the wallet constructor will throw and InvalidNetwork Error
         assert!(wallet1.is_ok());
-        assert_eq!(
-            wallet2.unwrap_err().to_string(),
-            "Descriptor(Key(InvalidNetwork))"
-        );
+        assert_matches!(
+            wallet2.unwrap_err(),
+            bdk::Error::Descriptor(Key(InvalidNetwork))
+        )
     }
 }

--- a/bdk-jvm/lib/src/test/kotlin/org/bitcoindevkit/JvmLibTest.kt
+++ b/bdk-jvm/lib/src/test/kotlin/org/bitcoindevkit/JvmLibTest.kt
@@ -28,8 +28,7 @@ class JvmLibTest {
         }
     }
 
-    private val descriptor =
-        "wpkh([c258d2e4/84h/1h/0h]tpubDDYkZojQFQjht8Tm4jsS3iuEmKjTiEGjG6KnuFNKKJb5A6ZUCUZKdvLdSDWofKi4ToRCwb9poe1XdqfUnP4jaJjCB2Zwv11ZLgSbnZSNecE/0/*)"
+    private val descriptor = Descriptor("wpkh([c258d2e4/84h/1h/0h]tpubDDYkZojQFQjht8Tm4jsS3iuEmKjTiEGjG6KnuFNKKJb5A6ZUCUZKdvLdSDWofKi4ToRCwb9poe1XdqfUnP4jaJjCB2Zwv11ZLgSbnZSNecE/0/*)", Network.TESTNET)
 
     private val databaseConfig = DatabaseConfig.Memory
 

--- a/bdk-swift/Tests/BitcoinDevKitTests/BitcoinDevKitTests.swift
+++ b/bdk-swift/Tests/BitcoinDevKitTests/BitcoinDevKitTests.swift
@@ -3,7 +3,10 @@ import XCTest
 
 final class BitcoinDevKitTests: XCTestCase {
     func testMemoryWalletNewAddress() throws {
-        let desc = "wpkh([c258d2e4/84h/1h/0h]tpubDDYkZojQFQjht8Tm4jsS3iuEmKjTiEGjG6KnuFNKKJb5A6ZUCUZKdvLdSDWofKi4ToRCwb9poe1XdqfUnP4jaJjCB2Zwv11ZLgSbnZSNecE/0/*)"
+        let desc = try Descriptor(
+            descriptor: "wpkh([c258d2e4/84h/1h/0h]tpubDDYkZojQFQjht8Tm4jsS3iuEmKjTiEGjG6KnuFNKKJb5A6ZUCUZKdvLdSDWofKi4ToRCwb9poe1XdqfUnP4jaJjCB2Zwv11ZLgSbnZSNecE/0/*)",
+            network: Network.regtest
+        )
         let databaseConfig = DatabaseConfig.memory
         let wallet = try Wallet.init(descriptor: desc, changeDescriptor: nil, network: Network.regtest, databaseConfig: databaseConfig)
         let addressInfo = try wallet.getAddress(addressIndex: AddressIndex.new)


### PR DESCRIPTION
Fixes #165.

Also relevant is bitcoindevkit/bdk#817

### Description
This PR adds the descriptor templates as described in #165.

### Links
[Docs for BIP84 template](https://docs.rs/bdk/latest/bdk/descriptor/template/struct.Bip84.html)

### Changelog notice

### Checklists

#### All Submissions:
* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:
* [x] I've added tests for the new feature
* [ ] I've added docs for the new feature