### PR TITLE
Fix jvm and android library version defined in two places

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ dependencies {
 }
 ```
 
+_Note:_ We also publish snapshot versions of bdk-jvm and bdk-android. See the specific readmes for instructions on how to use those.
+
 ### bdk-python
 ```shell
 pip3 install bdkpython

--- a/bdk-android/README.md
+++ b/bdk-android/README.md
@@ -1,9 +1,9 @@
 # bdk-android
-This project builds an .aar package for the `android` platform that provide [Kotlin] language bindings for the [`bdk`] library. The Kotlin language bindings are created by the [`bdk-ffi`] project which is included in the root of this repository.
+This project builds an .aar package for the Android platform that provide Kotlin language bindings for the [`bdk`] library. The Kotlin language bindings are created by the [`bdk-ffi`] project which is included in the root of this repository.
 
 ## How to Use
-To use the Kotlin language bindings for [`bdk`] in your `android` project add the following to your gradle dependencies:
-```groovy
+To use the Kotlin language bindings for [`bdk`] in your Android project add the following to your gradle dependencies:
+```kotlin
 repositories {
     mavenCentral()
 }
@@ -30,6 +30,18 @@ val blockchainConfig =
   )
 val wallet = Wallet(externalDescriptor, internalDescriptor, Network.TESTNET, databaseConfig, blockchainConfig)
 val newAddress = wallet.getNewAddress()
+```
+
+### Snapshot releases
+To use a snapshot release, specify the snapshot repository url in the `repositories` block and use the snapshot version in the `dependencies` block:
+```kotlin
+repositories {
+    maven("https://s01.oss.sonatype.org/content/repositories/snapshots/")
+}
+
+dependencies {
+  implementation("org.bitcoindevkit:bdk-android:<version-SNAPSHOT>")
+}
 ```
 
 ### Example Projects
@@ -67,10 +79,8 @@ git clone https://github.com/bitcoindevkit/bdk-ffi
 ./gradlew connectedAndroidTest 
 ```
 
-## How to publish
-### Publish to your local maven repo
+## How to publish to your local Maven repo
 ```shell
-# bdk-android
 cd bdk-android
 ./gradlew publishToMavenLocal --exclude-task signMavenPublication
 ```
@@ -85,3 +95,6 @@ and use the `publishToMavenLocal` task without excluding the signing task:
 ```shell
 ./gradlew publishToMavenLocal
 ```
+
+[`bdk`]: https://github.com/bitcoindevkit/bdk
+[`bdk-ffi`]: https://github.com/bitcoindevkit/bdk-ffi

--- a/bdk-android/build.gradle.kts
+++ b/bdk-android/build.gradle.kts
@@ -11,12 +11,15 @@ plugins {
     id("io.github.gradle-nexus.publish-plugin") version "1.1.0"
 }
 
+// library version is defined in gradle.properties
+val libraryVersion: String by project
+
 // These properties are required here so that the nexus publish-plugin
 // finds a staging profile with the correct group (group is otherwise set as "")
 // and knows whether to publish to a SNAPSHOT repository or not
 // https://github.com/gradle-nexus/publish-plugin#applying-the-plugin
 group = "org.bitcoindevkit"
-version = "0.12.0-SNAPSHOT"
+version = libraryVersion
 
 nexusPublishing {
     repositories {

--- a/bdk-android/gradle.properties
+++ b/bdk-android/gradle.properties
@@ -2,3 +2,4 @@ org.gradle.jvmargs=-Xmx1536m
 android.useAndroidX=true
 android.enableJetifier=true
 kotlin.code.style=official
+libraryVersion=0.12.0-SNAPSHOT

--- a/bdk-android/lib/build.gradle.kts
+++ b/bdk-android/lib/build.gradle.kts
@@ -1,3 +1,6 @@
+// library version is defined in gradle.properties
+val libraryVersion: String by project
+
 plugins {
     id("com.android.library")
     id("org.jetbrains.kotlin.android") version "1.6.10"
@@ -57,7 +60,7 @@ afterEvaluate {
             create<MavenPublication>("maven") {
                 groupId = "org.bitcoindevkit"
                 artifactId = "bdk-android"
-                version = "0.12.0-SNAPSHOT"
+                version = libraryVersion
 
                 from(components["release"])
                 pom {

--- a/bdk-jvm/README.md
+++ b/bdk-jvm/README.md
@@ -1,8 +1,8 @@
 # bdk-android
-This project builds a .jar package for the `jvm` platform that provide [Kotlin] language bindings for the [`bdk`] library. The Kotlin language bindings are created by the [`bdk-ffi`] project which is included in the root of this repository.
+This project builds a .jar package for the JVM platform that provide Kotlin language bindings for the [`bdk`] library. The Kotlin language bindings are created by the `bdk-ffi` project which is included in the root of this repository.
 
 ## How to Use
-To use the Kotlin language bindings for [`bdk`] in your `jvm` project add the following to your gradle dependencies:
+To use the Kotlin language bindings for [`bdk`] in your JVM project add the following to your gradle dependencies:
 ```kotlin
 repositories {
     mavenCentral()
@@ -32,10 +32,23 @@ val wallet = Wallet(externalDescriptor, internalDescriptor, Network.TESTNET, dat
 val newAddress = wallet.getNewAddress()
 ```
 
-### Example Projects
+### Snapshot releases
+To use a snapshot release, specify the snapshot repository url in the `repositories` block and use the snapshot version in the `dependencies` block:
+```kotlin
+repositories {
+    maven("https://s01.oss.sonatype.org/content/repositories/snapshots/")
+}
+
+dependencies {
+  implementation("org.bitcoindevkit:bdk-jvm:<version-SNAPSHOT>")
+}
+```
+
+
+## Example Projects
 * [Tatooine Faucet](https://github.com/thunderbiscuit/tatooine)
 
-### How to build
+## How to build
 _Note that Kotlin version `1.6.10` or later is required to build the library._
 
 1. Clone this repository.
@@ -53,10 +66,8 @@ rustup target add x86_64-apple-darwin aarch64-apple-darwin
  ./gradlew buildJvmLib
  ```
 
-## How to publish
-### Publish to your local maven repo
+## How to publish to your local Maven repo
 ```shell
-# bdk-jvm
 cd bdk-jvm
 ./gradlew publishToMavenLocal --exclude-task signMavenPublication
 ```
@@ -71,3 +82,6 @@ and use the `publishToMavenLocal` task without excluding the signing task:
 ```shell
 ./gradlew publishToMavenLocal
 ```
+
+[`bdk`]: https://github.com/bitcoindevkit/bdk
+[`bdk-ffi`]: https://github.com/bitcoindevkit/bdk-ffi

--- a/bdk-jvm/build.gradle.kts
+++ b/bdk-jvm/build.gradle.kts
@@ -2,12 +2,15 @@ plugins {
     id("io.github.gradle-nexus.publish-plugin") version "1.1.0"
 }
 
+// library version is defined in gradle.properties
+val libraryVersion: String by project
+
 // These properties are required here so that the nexus publish-plugin
 // finds a staging profile with the correct group (group is otherwise set as "")
 // and knows whether to publish to a SNAPSHOT repository or not
 // https://github.com/gradle-nexus/publish-plugin#applying-the-plugin
 group = "org.bitcoindevkit"
-version = "0.12.0-SNAPSHOT"
+version = libraryVersion
 
 nexusPublishing {
     repositories {

--- a/bdk-jvm/gradle.properties
+++ b/bdk-jvm/gradle.properties
@@ -1,3 +1,4 @@
 org.gradle.jvmargs=-Xmx1536m
 android.enableJetifier=true
 kotlin.code.style=official
+libraryVersion=0.12.0-SNAPSHOT

--- a/bdk-jvm/lib/build.gradle.kts
+++ b/bdk-jvm/lib/build.gradle.kts
@@ -1,6 +1,9 @@
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat.*
 import org.gradle.api.tasks.testing.logging.TestLogEvent.*
 
+// library version is defined in gradle.properties
+val libraryVersion: String by project
+
 plugins {
     id("org.jetbrains.kotlin.jvm") version "1.6.10"
     id("java-library")
@@ -51,7 +54,7 @@ afterEvaluate {
             create<MavenPublication>("maven") {
                 groupId = "org.bitcoindevkit"
                 artifactId = "bdk-jvm"
-                version = "0.12.0-SNAPSHOT"
+                version = libraryVersion
 
                 from(components["java"])
                 pom {


### PR DESCRIPTION
This PR fixes #234.

The library version for bdk-android and bdk-jvm is now defined in the `gradle.properties` file, and picked up in the gradle build scripts using property delegates.

This PR also adds documentation on how to use the snapshot versions of bdk-jvm and bdk-android.