### PR TITLE
Change TxBuilder.drain_to argument to Script instead of address String

### DIFF
--- a/api-docs/kotlin/src/main/kotlin/org/bitcoindevkit/bdk.kt
+++ b/api-docs/kotlin/src/main/kotlin/org/bitcoindevkit/bdk.kt
@@ -410,7 +410,7 @@ class TxBuilder() {
      * [drainWallet] to spend all of them. When bumping the fees of a transaction made with this option,
      * you probably want to use [BumpFeeTxBuilder.allowShrinking] to allow this output to be reduced to pay for the extra fees.
      */
-    fun drainTo(address: String): TxBuilder {}
+    fun drainTo(script: Script): TxBuilder {}
 
     /** Enable signaling RBF. This will use the default `nsequence` value of `0xFFFFFFFD`. */
     fun enableRbf(): TxBuilder {}

--- a/bdk-ffi/src/bdk.udl
+++ b/bdk-ffi/src/bdk.udl
@@ -257,7 +257,7 @@ interface TxBuilder {
 
   TxBuilder drain_wallet();
 
-  TxBuilder drain_to(string address);
+  TxBuilder drain_to(Script script);
 
   TxBuilder enable_rbf();
 


### PR DESCRIPTION
### Description

Change `TxBuilder.drain_to()` argument to Script instead of address String. Also remove unneeded `fn to_script_pubkey()` fixes #261.

### Notes to the reviewers

This change aligns bdk-ffi with bdk API which also takes a script instead of an address string for the `TxBuilder.drain_to()`. 

### Changelog notice

* APIs Changed
  * `TxBuilder.drain_to()` argument is now `Script` instead of address `String`.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
