### PR TITLE
Compile libraries before tests

### DIFF
--- a/.github/workflows/test-android.yaml
+++ b/.github/workflows/test-android.yaml
@@ -46,11 +46,6 @@ jobs:
       - name: Install rust android targets
         run: rustup target add x86_64-linux-android aarch64-linux-android armv7-linux-androideabi
 
-      - name: Build bdk-android library
-        run: |
-          cd bdk-android
-          ./gradlew buildAndroidLib
-
       - name: Run Android tests
         run: |
           cd bdk-android

--- a/.github/workflows/test-jvm.yaml
+++ b/.github/workflows/test-jvm.yaml
@@ -31,11 +31,6 @@ jobs:
           distribution: temurin
           java-version: 11
 
-      - name: Build bdk-jvm library
-        run: |
-          cd bdk-jvm
-          ./gradlew buildJvmLib
-
       - name: Run JVM tests
         run: |
           cd bdk-jvm

--- a/bdk-android/lib/build.gradle.kts
+++ b/bdk-android/lib/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 // library version is defined in gradle.properties
 val libraryVersion: String by project
 
@@ -106,4 +108,10 @@ signing {
     val signingPassword: String? by project
     useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword)
     sign(publishing.publications)
+}
+
+// This task dependency ensures that we build the bindings
+// binaries before running the tests
+tasks.withType<KotlinCompile> {
+    dependsOn("buildAndroidLib")
 }

--- a/bdk-jvm/lib/build.gradle.kts
+++ b/bdk-jvm/lib/build.gradle.kts
@@ -1,5 +1,6 @@
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat.*
 import org.gradle.api.tasks.testing.logging.TestLogEvent.*
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 // library version is defined in gradle.properties
 val libraryVersion: String by project
@@ -100,4 +101,10 @@ signing {
     val signingPassword: String? by project
     useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword)
     sign(publishing.publications)
+}
+
+// This task dependency ensures that we build the bindings
+// binaries before running the tests
+tasks.withType<KotlinCompile> {
+    dependsOn("buildJvmLib")
 }


### PR DESCRIPTION
### Description
This PR fixes #236 by making the `KotlinCompile` task depend on the `buildJvmLib` and `buildAndroidLib`. Thanks @kirillzh for the suggestion!

The tests can now be run directly without requiring the building of the libraries first.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)