### PR TITLE
Add MVP Python API docs

### DIFF
--- a/api-docs/python/README.md
+++ b/api-docs/python/README.md
@@ -1,0 +1,9 @@
+# Readme
+
+The API docs for Python.
+
+Build the API documentation website locally:
+```shell
+cd docs
+make html
+```

--- a/api-docs/python/docs/Makefile
+++ b/api-docs/python/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/api-docs/python/docs/bdk.py
+++ b/api-docs/python/docs/bdk.py
@@ -1,0 +1,20 @@
+class Address(object):
+    """
+    A bitcoin address.
+
+    Args:
+        address: A bitcoin address
+    """
+    def __init__(self, address):
+        address = address[str]
+
+    """
+    Return the ScriptPubKey.
+    """
+    def script_pubkey(self):
+        return script[Script]
+
+
+class Script(object):
+    def __init__(self, raw_output_script):
+        raw_output_script = list(int(x) for x in raw_output_script)

--- a/api-docs/python/docs/make.bat
+++ b/api-docs/python/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=source
+set BUILDDIR=build
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/api-docs/python/docs/source/conf.py
+++ b/api-docs/python/docs/source/conf.py
@@ -1,0 +1,18 @@
+import sys, os
+sys.path.append(os.path.join(os.path.dirname(__name__), '.'))
+
+project = 'bdkpython'
+copyright = '2022, The Bitcoin Dev Kit developers'
+author = 'The Bitcoin Dev Kit developers'
+release = '0.25.0'
+
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.napoleon'
+]
+
+templates_path = ['_templates']
+exclude_patterns = []
+
+html_theme = 'alabaster'
+html_static_path = ['_static']

--- a/api-docs/python/docs/source/index.rst
+++ b/api-docs/python/docs/source/index.rst
@@ -1,0 +1,17 @@
+Welcome to bdkpython's documentation!
+======================================
+
+The [bitcoindevkit](https://bitcoindevkit.org/) language bindings library for Python.
+
+.. toctree::
+   usage
+   :maxdepth: 2
+   :caption: Contents:
+
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`search`

--- a/api-docs/python/docs/source/usage.rst
+++ b/api-docs/python/docs/source/usage.rst
@@ -1,0 +1,17 @@
+Usage
+=====
+
+Installation
+------------
+
+To use bdkpython, first install it using pip:
+
+.. code-block:: console
+
+   $ pip install bdkpython
+
+
+Creating an address
+----------------
+
+.. autofunction:: bdk.Address


### PR DESCRIPTION
Not ready, but the core machinery is there. I just don't really know how to make them look really "Pythonesque" yet.

<img width="800" alt="bdkpython docs" src="https://user-images.githubusercontent.com/39974688/207954262-ed2681b2-13f1-4317-8915-7b0db1026ea4.png">
