### PR TITLE
Fix Python release workflow

### DIFF
--- a/.github/workflows/build-python-wheels.yaml
+++ b/.github/workflows/build-python-wheels.yaml
@@ -90,7 +90,7 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           name: bdkpython-macos-${{ matrix.python }}
-          path: dist/*.whl
+          path: /Users/runner/work/bdk-ffi/bdk-ffi/bdk-python/dist/*.whl
 
   build-windows-wheel:
     name: 'Build windows wheel'
@@ -123,4 +123,4 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           name: bdkpython-win-${{ matrix.python }}
-          path: dist/*.whl
+          path: D:\a\bdk-ffi\bdk-ffi\bdk-python\dist\*.whl

--- a/.github/workflows/publish-python.yaml
+++ b/.github/workflows/publish-python.yaml
@@ -82,7 +82,7 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           name: bdkpython-macos-${{ matrix.python }}
-          path: dist/*.whl
+          path: /Users/runner/work/bdk-ffi/bdk-ffi/bdk-python/dist/*.whl
 
   build-windows-wheel:
     name: 'Build windows wheel'
@@ -115,7 +115,7 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           name: bdkpython-win-${{ matrix.python }}
-          path: dist/*.whl
+          path: D:\a\bdk-ffi\bdk-ffi\bdk-python\dist\*.whl
 
   publish-pypi:
     name: 'Publish on PyPI'


### PR DESCRIPTION
This PR fixes the Python release workflows for macOS and Windows.

## Notes for reviewers
I simply added the absolute path to the correct directories so that the upload task would find the tarballs, but I wonder if I should instead work with relative paths and the `with:` key. Happy to revise if you think there is significant advantages to this approach.