### PR TITLE
Expose/get internal address

### DIFF
--- a/api-docs/kotlin/src/main/kotlin/org/bitcoindevkit/bdk.kt
+++ b/api-docs/kotlin/src/main/kotlin/org/bitcoindevkit/bdk.kt
@@ -384,6 +384,15 @@ class Wallet(
      */
     fun getAddress(addressIndex: AddressIndex): AddressInfo {}
 
+    /**
+     * Return a derived address using the internal (change) descriptor.
+     * If the wallet doesn't have an internal descriptor it will use the external descriptor.
+     * See [AddressIndex] for available address index selection strategies. If none of the keys
+     * in the descriptor are derivable (i.e. does not end with /\*) then the same address will always
+     * be returned for any [AddressIndex].
+     */
+    fun getInternalAddress(addressIndex: AddressIndex): AddressInfo {}
+
     /** Return the wallet's balance, across different categories. See [Balance] for the categories. Note that this method only operates on the internal database, which first needs to be [Wallet.sync] manually. */
     fun getBalance(): Balance {}
 

--- a/bdk-ffi/src/bdk.udl
+++ b/bdk-ffi/src/bdk.udl
@@ -213,6 +213,9 @@ interface Wallet {
   AddressInfo get_address(AddressIndex address_index);
 
   [Throws=BdkError]
+  AddressInfo get_internal_address(AddressIndex address_index);
+
+  [Throws=BdkError]
   Balance get_balance();
 
   [Throws=BdkError]

--- a/bdk-ffi/src/wallet.rs
+++ b/bdk-ffi/src/wallet.rs
@@ -577,6 +577,14 @@ mod test {
 
         assert_eq!(
             wallet
+                .get_address(crate::AddressIndex::LastUnused)
+                .unwrap()
+                .address,
+            "bcrt1q0xs7dau8af22rspp4klya4f7lhggcnqfun2y3a"
+        );
+
+        assert_eq!(
+            wallet
                 .get_internal_address(crate::AddressIndex::New)
                 .unwrap()
                 .address,
@@ -589,6 +597,14 @@ mod test {
                 .unwrap()
                 .address,
             "bcrt1qaux734vuhykww9632v8cmdnk7z2mw5lsf74v6k"
+        );
+
+        assert_eq!(
+            wallet
+                .get_internal_address(crate::AddressIndex::LastUnused)
+                .unwrap()
+                .address,
+            "bcrt1qpmz73cyx00r4a5dea469j40ax6d6kqyd67nnpj"
         );
     }
 }

--- a/bdk-ffi/src/wallet.rs
+++ b/bdk-ffi/src/wallet.rs
@@ -604,7 +604,7 @@ mod test {
                 .get_internal_address(crate::AddressIndex::LastUnused)
                 .unwrap()
                 .address,
-            "bcrt1qpmz73cyx00r4a5dea469j40ax6d6kqyd67nnpj"
+            "bcrt1qaux734vuhykww9632v8cmdnk7z2mw5lsf74v6k"
         );
     }
 }

--- a/bdk-ffi/src/wallet.rs
+++ b/bdk-ffi/src/wallet.rs
@@ -88,6 +88,22 @@ impl Wallet {
             .map(AddressInfo::from)
     }
 
+    /// Return a derived address using the internal (change) descriptor.
+    ///
+    /// If the wallet doesn't have an internal descriptor it will use the external descriptor.
+    ///
+    /// see [`AddressIndex`] for available address index selection strategies. If none of the keys
+    /// in the descriptor are derivable (i.e. does not end with /*) then the same address will always
+    /// be returned for any [`AddressIndex`].
+    pub(crate) fn get_internal_address(
+        &self,
+        address_index: AddressIndex,
+    ) -> Result<AddressInfo, BdkError> {
+        self.get_wallet()
+            .get_internal_address(address_index.into())
+            .map(AddressInfo::from)
+    }
+
     /// Return the balance, meaning the sum of this wallet’s unspent outputs’ values. Note that this method only operates
     /// on the internal database, which first needs to be Wallet.sync manually.
     pub(crate) fn get_balance(&self) -> Result<Balance, BdkError> {

--- a/bdk-ffi/src/wallet.rs
+++ b/bdk-ffi/src/wallet.rs
@@ -563,8 +563,7 @@ mod test {
             wallet
                 .get_address(crate::AddressIndex::New)
                 .unwrap()
-                .address
-                .to_string(),
+                .address,
             "bcrt1qqjn9gky9mkrm3c28e5e87t5akd3twg6xezp0tv"
         );
 
@@ -572,8 +571,7 @@ mod test {
             wallet
                 .get_address(crate::AddressIndex::New)
                 .unwrap()
-                .address
-                .to_string(),
+                .address,
             "bcrt1q0xs7dau8af22rspp4klya4f7lhggcnqfun2y3a"
         );
 
@@ -581,8 +579,7 @@ mod test {
             wallet
                 .get_internal_address(crate::AddressIndex::New)
                 .unwrap()
-                .address
-                .to_string(),
+                .address,
             "bcrt1qpmz73cyx00r4a5dea469j40ax6d6kqyd67nnpj"
         );
 
@@ -590,8 +587,7 @@ mod test {
             wallet
                 .get_internal_address(crate::AddressIndex::New)
                 .unwrap()
-                .address
-                .to_string(),
+                .address,
             "bcrt1qaux734vuhykww9632v8cmdnk7z2mw5lsf74v6k"
         );
     }


### PR DESCRIPTION
<!-- Erase any parts of this template not applicable to your Pull Request. -->

### Description

Until this PR,  bdk-ffi get_address did not support internal/change addresses. Any sufficiently advanced wallet will need this functionality, or be indistinguishable from an insufficiently-advanced wallet.

### Notes to the reviewers

I created a separate mapping for get_internal_address instead of adding another field to get_address, which matches the existing bdk naming pattern and keeps the exposed get_{x_}address methods from being cluttered.

### Changelog notice

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->
Add `wallet::get_internal_addresses` API

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [x] I've added tests for the new feature
* [x] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
