### PR TITLE
Features/getaddress peek + reset

### DIFF
--- a/api-docs/kotlin/src/test/kotlin/org/bitcoindevkit/Samples.kt
+++ b/api-docs/kotlin/src/test/kotlin/org/bitcoindevkit/Samples.kt
@@ -72,10 +72,6 @@ fun addressIndexSample() {
         databaseConfig = DatabaseConfig.Memory
     )
 
-    fun getLastUnusedAddress(): AddressInfo {
-        return wallet.getAddress(AddressIndex.LastUnused)
-    }
-
     fun peekAddress100(): AddressInfo {
         return wallet.getAddress(AddressIndex.Peek(100u))
     }
@@ -89,11 +85,7 @@ fun addressInfoSample() {
         databaseConfig = DatabaseConfig.Memory
     )
 
-    fun getLastUnusedAddress(): AddressInfo {
-        return wallet.getAddress(AddressIndex.New)
-    }
-
-    val newAddress: AddressInfo = getLastUnusedAddress()
+    val newAddress: AddressInfo = wallet.getAddress(AddressIndex.New)
 
     println("New address at index ${newAddress.index} is ${newAddress.address}")
 }

--- a/api-docs/kotlin/src/test/kotlin/org/bitcoindevkit/Samples.kt
+++ b/api-docs/kotlin/src/test/kotlin/org/bitcoindevkit/Samples.kt
@@ -73,7 +73,11 @@ fun addressIndexSample() {
     )
 
     fun getLastUnusedAddress(): AddressInfo {
-        return wallet.getAddress(AddressIndex.LAST_UNUSED)
+        return wallet.getAddress(AddressIndex.LastUnused)
+    }
+
+    fun peekAddress100(): AddressInfo {
+        return wallet.getAddress(AddressIndex.Peek(100u))
     }
 }
 
@@ -86,7 +90,7 @@ fun addressInfoSample() {
     )
 
     fun getLastUnusedAddress(): AddressInfo {
-        return wallet.getAddress(AddressIndex.NEW)
+        return wallet.getAddress(AddressIndex.New)
     }
 
     val newAddress: AddressInfo = getLastUnusedAddress()

--- a/bdk-ffi/src/bdk.udl
+++ b/bdk-ffi/src/bdk.udl
@@ -53,9 +53,11 @@ dictionary AddressInfo {
   string address;
 };
 
-enum AddressIndex {
-  "New",
-  "LastUnused",
+[Enum]
+interface AddressIndex {
+  New();
+  LastUnused();
+  Peek(u32 index);
 };
 
 enum Network {

--- a/bdk-ffi/src/bdk.udl
+++ b/bdk-ffi/src/bdk.udl
@@ -58,6 +58,7 @@ interface AddressIndex {
   New();
   LastUnused();
   Peek(u32 index);
+  Reset(u32 index);
 };
 
 enum Network {

--- a/bdk-ffi/src/lib.rs
+++ b/bdk-ffi/src/lib.rs
@@ -69,9 +69,11 @@ pub enum AddressIndex {
     /// caller is untrusted; for example when deriving donation addresses on-demand for a public
     /// web page.
     LastUnused,
-    Peek {
-        index: u32,
-    },
+    /// Return the address for a specific descriptor index. Does not change the current descriptor
+    /// index used by `AddressIndex::New` and `AddressIndex::LastUsed`.
+    /// Use with caution, if an index is given that is less than the current descriptor index
+    /// then the returned address may have already been used.
+    Peek { index: u32 },
 }
 
 impl From<AddressIndex> for BdkAddressIndex {

--- a/bdk-ffi/src/lib.rs
+++ b/bdk-ffi/src/lib.rs
@@ -74,6 +74,14 @@ pub enum AddressIndex {
     /// Use with caution, if an index is given that is less than the current descriptor index
     /// then the returned address may have already been used.
     Peek { index: u32 },
+    /// Return the address for a specific descriptor index and reset the current descriptor index
+    /// used by `AddressIndex::New` and `AddressIndex::LastUsed` to this value.
+    /// Use with caution, if an index is given that is less than the current descriptor index
+    /// then the returned address and subsequent addresses returned by calls to `AddressIndex::New`
+    /// and `AddressIndex::LastUsed` may have already been used. Also if the index is reset to a
+    /// value earlier than the [`crate::blockchain::Blockchain`] stop_gap (default is 20) then a
+    /// larger stop_gap should be used to monitor for all possibly used addresses.
+    Reset { index: u32 },
 }
 
 impl From<AddressIndex> for BdkAddressIndex {
@@ -82,6 +90,7 @@ impl From<AddressIndex> for BdkAddressIndex {
             AddressIndex::New => BdkAddressIndex::New,
             AddressIndex::LastUnused => BdkAddressIndex::LastUnused,
             AddressIndex::Peek { index } => BdkAddressIndex::Peek(index),
+            AddressIndex::Reset { index } => BdkAddressIndex::Reset(index),
         }
     }
 }

--- a/bdk-ffi/src/lib.rs
+++ b/bdk-ffi/src/lib.rs
@@ -69,6 +69,9 @@ pub enum AddressIndex {
     /// caller is untrusted; for example when deriving donation addresses on-demand for a public
     /// web page.
     LastUnused,
+    Peek {
+        index: u32,
+    },
 }
 
 impl From<AddressIndex> for BdkAddressIndex {
@@ -76,6 +79,7 @@ impl From<AddressIndex> for BdkAddressIndex {
         match x {
             AddressIndex::New => BdkAddressIndex::New,
             AddressIndex::LastUnused => BdkAddressIndex::LastUnused,
+            AddressIndex::Peek { index } => BdkAddressIndex::Peek(index),
         }
     }
 }

--- a/bdk-ffi/src/wallet.rs
+++ b/bdk-ffi/src/wallet.rs
@@ -575,6 +575,7 @@ mod test {
             "bcrt1q0xs7dau8af22rspp4klya4f7lhggcnqfun2y3a"
         );
 
+        // new index still 0
         assert_eq!(
             wallet
                 .get_address(crate::AddressIndex::New)
@@ -583,6 +584,7 @@ mod test {
             "bcrt1qqjn9gky9mkrm3c28e5e87t5akd3twg6xezp0tv"
         );
 
+        // new index now 1
         assert_eq!(
             wallet
                 .get_address(crate::AddressIndex::New)
@@ -591,12 +593,22 @@ mod test {
             "bcrt1q0xs7dau8af22rspp4klya4f7lhggcnqfun2y3a"
         );
 
+        // new index now 2
+        assert_eq!(
+            wallet
+                .get_address(crate::AddressIndex::New)
+                .unwrap()
+                .address,
+            "bcrt1q5g0mq6dkmwzvxscqwgc932jhgcxuqqkjv09tkj"
+        );
+
+        // peek index 1
         assert_eq!(
             wallet
                 .get_address(AddressIndex::Peek { index: 0 })
                 .unwrap()
                 .address,
-            "bcrt1qqjn9gky9mkrm3c28e5e87t5akd3twg6xezp0tv"
+            "bcrt1q0xs7dau8af22rspp4klya4f7lhggcnqfun2y3a"
         );
     }
 

--- a/bdk-ffi/src/wallet.rs
+++ b/bdk-ffi/src/wallet.rs
@@ -542,7 +542,7 @@ mod test {
     }
 
     #[test]
-    fn test_peek_address() {
+    fn test_peek_reset_address() {
         let test_wpkh = "wpkh(tprv8hwWMmPE4BVNxGdVt3HhEERZhondQvodUY7Ajyseyhudr4WabJqWKWLr4Wi2r26CDaNCQhhxEftEaNzz7dPGhWuKFU4VULesmhEfZYyBXdE/0/*)";
         let descriptor = Descriptor::new(test_wpkh.to_string(), Network::Regtest).unwrap();
         let change_descriptor = Descriptor::new(
@@ -608,6 +608,21 @@ mod test {
                 .get_address(AddressIndex::Peek { index: 0 })
                 .unwrap()
                 .address,
+            "bcrt1q0xs7dau8af22rspp4klya4f7lhggcnqfun2y3a"
+        );
+
+        // reset to index 0
+        assert_eq!(
+            wallet
+                .get_address(AddressIndex::Reset { index: 0 })
+                .unwrap()
+                .address,
+            "bcrt1qqjn9gky9mkrm3c28e5e87t5akd3twg6xezp0tv"
+        );
+
+        // new index 1 again
+        assert_eq!(
+            wallet.get_address(AddressIndex::New).unwrap().address,
             "bcrt1q0xs7dau8af22rspp4klya4f7lhggcnqfun2y3a"
         );
     }

--- a/bdk-ffi/src/wallet.rs
+++ b/bdk-ffi/src/wallet.rs
@@ -605,7 +605,7 @@ mod test {
         // peek index 1
         assert_eq!(
             wallet
-                .get_address(AddressIndex::Peek { index: 0 })
+                .get_address(AddressIndex::Peek { index: 1 })
                 .unwrap()
                 .address,
             "bcrt1q0xs7dau8af22rspp4klya4f7lhggcnqfun2y3a"

--- a/bdk-ffi/src/wallet.rs
+++ b/bdk-ffi/src/wallet.rs
@@ -563,8 +563,7 @@ mod test {
             wallet
                 .get_address(AddressIndex::Peek { index: 2 })
                 .unwrap()
-                .address
-                .to_string(),
+                .address,
             "bcrt1q5g0mq6dkmwzvxscqwgc932jhgcxuqqkjv09tkj"
         );
 
@@ -572,8 +571,7 @@ mod test {
             wallet
                 .get_address(AddressIndex::Peek { index: 1 })
                 .unwrap()
-                .address
-                .to_string(),
+                .address,
             "bcrt1q0xs7dau8af22rspp4klya4f7lhggcnqfun2y3a"
         );
 
@@ -581,8 +579,7 @@ mod test {
             wallet
                 .get_address(crate::AddressIndex::New)
                 .unwrap()
-                .address
-                .to_string(),
+                .address,
             "bcrt1qqjn9gky9mkrm3c28e5e87t5akd3twg6xezp0tv"
         );
 
@@ -590,8 +587,7 @@ mod test {
             wallet
                 .get_address(crate::AddressIndex::New)
                 .unwrap()
-                .address
-                .to_string(),
+                .address,
             "bcrt1q0xs7dau8af22rspp4klya4f7lhggcnqfun2y3a"
         );
 
@@ -599,8 +595,7 @@ mod test {
             wallet
                 .get_address(AddressIndex::Peek { index: 0 })
                 .unwrap()
-                .address
-                .to_string(),
+                .address,
             "bcrt1qqjn9gky9mkrm3c28e5e87t5akd3twg6xezp0tv"
         );
     }

--- a/bdk-ffi/src/wallet.rs
+++ b/bdk-ffi/src/wallet.rs
@@ -468,7 +468,7 @@ impl BumpFeeTxBuilder {
 mod test {
     use crate::database::DatabaseConfig;
     use crate::descriptor::Descriptor;
-    use crate::wallet::{TxBuilder, Wallet};
+    use crate::wallet::{AddressIndex, TxBuilder, Wallet};
     use bdk::bitcoin::{Address, Network};
     use bdk::wallet::get_funded_wallet;
     use std::str::FromStr;
@@ -539,6 +539,70 @@ mod test {
         assert!(tx_details.fee.is_some());
         assert_eq!(tx_details.fee.unwrap(), 110);
         assert!(tx_details.confirmation_time.is_none());
+    }
+
+    #[test]
+    fn test_peek_address() {
+        let test_wpkh = "wpkh(tprv8hwWMmPE4BVNxGdVt3HhEERZhondQvodUY7Ajyseyhudr4WabJqWKWLr4Wi2r26CDaNCQhhxEftEaNzz7dPGhWuKFU4VULesmhEfZYyBXdE/0/*)";
+        let descriptor = Descriptor::new(test_wpkh.to_string(), Network::Regtest).unwrap();
+        let change_descriptor = Descriptor::new(
+            test_wpkh.to_string().replace("/0/*", "/1/*"),
+            Network::Regtest,
+        )
+        .unwrap();
+
+        let wallet = Wallet::new(
+            Arc::new(descriptor),
+            Some(Arc::new(change_descriptor)),
+            Network::Regtest,
+            DatabaseConfig::Memory,
+        )
+        .unwrap();
+
+        assert_eq!(
+            wallet
+                .get_address(AddressIndex::Peek { index: 2 })
+                .unwrap()
+                .address
+                .to_string(),
+            "bcrt1q5g0mq6dkmwzvxscqwgc932jhgcxuqqkjv09tkj"
+        );
+
+        assert_eq!(
+            wallet
+                .get_address(AddressIndex::Peek { index: 1 })
+                .unwrap()
+                .address
+                .to_string(),
+            "bcrt1q0xs7dau8af22rspp4klya4f7lhggcnqfun2y3a"
+        );
+
+        assert_eq!(
+            wallet
+                .get_address(crate::AddressIndex::New)
+                .unwrap()
+                .address
+                .to_string(),
+            "bcrt1qqjn9gky9mkrm3c28e5e87t5akd3twg6xezp0tv"
+        );
+
+        assert_eq!(
+            wallet
+                .get_address(crate::AddressIndex::New)
+                .unwrap()
+                .address
+                .to_string(),
+            "bcrt1q0xs7dau8af22rspp4klya4f7lhggcnqfun2y3a"
+        );
+
+        assert_eq!(
+            wallet
+                .get_address(AddressIndex::Peek { index: 0 })
+                .unwrap()
+                .address
+                .to_string(),
+            "bcrt1qqjn9gky9mkrm3c28e5e87t5akd3twg6xezp0tv"
+        );
     }
 
     #[test]

--- a/bdk-jvm/lib/src/test/kotlin/org/bitcoindevkit/JvmLibTest.kt
+++ b/bdk-jvm/lib/src/test/kotlin/org/bitcoindevkit/JvmLibTest.kt
@@ -46,7 +46,7 @@ class JvmLibTest {
     @Test
     fun memoryWalletNewAddress() {
         val wallet = Wallet(descriptor, null, Network.TESTNET, databaseConfig)
-        val address = wallet.getAddress(AddressIndex.NEW).address
+        val address = wallet.getAddress(AddressIndex.New).address
         assertEquals("tb1qzg4mckdh50nwdm9hkzq06528rsu73hjxxzem3e", address)
     }
 


### PR DESCRIPTION
<!-- Erase any parts of this template not applicable to your Pull Request. -->

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->
The `get_address` 'Peek' `AddressIndex` option is useful to obtain specific addresses by their indices, without affecting the internal wallet database.

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->
Matched bdk patterns.

### Changelog notice

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->
Add `AddressIndex::Peek(index)` and `get_address(Peek(index))` API

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [x] I've added tests for the new feature
* [x] I've added docs for the new feature