### PR TITLE
Add from_miniscript_policy() method on Descriptor type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,6 +160,7 @@ version = "0.26.0"
 dependencies = [
  "assert_matches",
  "bdk",
+ "miniscript",
  "uniffi",
  "uniffi_build",
  "uniffi_macros",

--- a/bdk-ffi/Cargo.toml
+++ b/bdk-ffi/Cargo.toml
@@ -11,6 +11,7 @@ name = "bdkffi"
 
 [dependencies]
 bdk = { version = "0.26", features = ["all-keys", "use-esplora-ureq", "sqlite-bundled", "rpc"] }
+miniscript = { version = "8.0", features = ["serde", "compiler"] }
 uniffi_macros = { version = "0.21.0", features = ["builtin-bindgen"] }
 uniffi = { version = "0.21.0", features = ["builtin-bindgen"] }
 

--- a/bdk-ffi/src/bdk.udl
+++ b/bdk-ffi/src/bdk.udl
@@ -390,6 +390,9 @@ interface Descriptor {
   [Name=new_bip84_public]
   constructor(DescriptorPublicKey public_key, string fingerprint, KeychainKind keychain, Network network);
 
+  [Name=from_miniscript_policy]
+  constructor(string policy, Network network);
+
   string as_string();
 
   string as_string_private();


### PR DESCRIPTION
### Description
This PR is meant to allow us to continue the discussion opened in #294.

It currently doesn't compile. I'm basically trying to implement something like [what we have in the bdk example](https://github.com/bitcoindevkit/bdk/blob/master/examples/compiler.rs). One of the issue is that we don't have the `Descriptor` type directly, and so we can't call the methods we have in Rust like `new_wpkh()` and `new_wsh()`. We either need to expose that type somehow, or change the API slightly and add the choice of what type of script to use for the descriptor by passing it as an enum to the method I created here. Overall not a straightforward "port" of BDK directly, so we should look to get feedback on how people might use it before moving into a specific direction.

### Changelog notice
No changelog notice yet.

### Checklists
* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [ ] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:
* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature