### PR TITLE
Add external signers

### DIFF
--- a/bdk-ffi/src/bdk.udl
+++ b/bdk-ffi/src/bdk.udl
@@ -3,6 +3,11 @@ namespace bdk {
 };
 
 [Error]
+enum CustomError {
+  "SignerError",
+};
+
+[Error]
 enum BdkError {
   "InvalidU32Bytes",
   "Generic",
@@ -493,4 +498,19 @@ enum WitnessVersion {
 
 interface Script {
   constructor(sequence<u8> raw_output_script);
+};
+
+callback interface InputSigner {
+  [Throws=CustomError]
+  SignerId id();
+
+  [Throws=CustomError]
+  void sign_input(PartiallySignedTransaction psbt, u32 input_index, SignOptions sign_options);
+};
+
+[Enum]
+interface SignerId {
+  PkHash(string hash);
+  Fingerprint(string fingerprint);
+  Dummy(u64 index);
 };

--- a/bdk-ffi/src/bdk.udl
+++ b/bdk-ffi/src/bdk.udl
@@ -210,6 +210,10 @@ enum KeychainKind {
   "Internal",
 };
 
+dictionary SignerOrdering {
+  u64 order;
+};
+
 dictionary LocalUtxo {
   OutPoint outpoint;
   TxOut txout;

--- a/bdk-ffi/src/lib.rs
+++ b/bdk-ffi/src/lib.rs
@@ -16,6 +16,7 @@ use crate::keys::{DescriptorPublicKey, DescriptorSecretKey, Mnemonic};
 use crate::psbt::PartiallySignedTransaction;
 use crate::signer::CustomError;
 use crate::signer::InputSigner;
+use crate::signer::SignerOrdering;
 use crate::signer::SignerId;
 use crate::wallet::SignOptions;
 use crate::wallet::{BumpFeeTxBuilder, TxBuilder, Wallet};

--- a/bdk-ffi/src/lib.rs
+++ b/bdk-ffi/src/lib.rs
@@ -3,6 +3,7 @@ mod database;
 mod descriptor;
 mod keys;
 mod psbt;
+mod signer;
 mod wallet;
 
 use crate::blockchain::{
@@ -13,6 +14,9 @@ use crate::descriptor::Descriptor;
 use crate::keys::DerivationPath;
 use crate::keys::{DescriptorPublicKey, DescriptorSecretKey, Mnemonic};
 use crate::psbt::PartiallySignedTransaction;
+use crate::signer::CustomError;
+use crate::signer::InputSigner;
+use crate::signer::SignerId;
 use crate::wallet::SignOptions;
 use crate::wallet::{BumpFeeTxBuilder, TxBuilder, Wallet};
 use bdk::bitcoin::blockdata::script::Script as BdkScript;

--- a/bdk-ffi/src/psbt.rs
+++ b/bdk-ffi/src/psbt.rs
@@ -9,8 +9,8 @@ use std::sync::{Arc, Mutex};
 use crate::{BdkError, FeeRate, Transaction};
 
 #[derive(Debug)]
-pub(crate) struct PartiallySignedTransaction {
-    pub(crate) internal: Mutex<BdkPartiallySignedTransaction>,
+pub struct PartiallySignedTransaction {
+    pub internal: Mutex<BdkPartiallySignedTransaction>,
 }
 
 impl PartiallySignedTransaction {

--- a/bdk-ffi/src/signer.rs
+++ b/bdk-ffi/src/signer.rs
@@ -1,0 +1,62 @@
+use crate::psbt::PartiallySignedTransaction;
+use bdk::bitcoin::util::bip32::Fingerprint;
+use bdk::bitcoincore_rpc::jsonrpc::serde_json::from_str;
+use bdk::signer::SignerId as BdkSignerId;
+use std::fmt::{Debug, Display};
+use std::str::FromStr;
+use std::sync::Arc;
+use crate::wallet::SignOptions;
+
+pub enum SignerId {
+    /// Bitcoin HASH160 (RIPEMD160 after SHA256) hash of an ECDSA public key
+    PkHash { hash: String },
+    /// The fingerprint of a BIP32 extended key
+    Fingerprint { fingerprint: String },
+    /// Dummy identifier
+    Dummy { index: u64 },
+}
+
+impl From<SignerId> for BdkSignerId {
+    fn from(signer_id: SignerId) -> BdkSignerId {
+        match signer_id {
+            // TODO: is this the way to do this? I'm not sure about the from_str(as_str()) on the PkHash type
+            SignerId::PkHash { hash } => BdkSignerId::PkHash(from_str(hash.as_str()).unwrap()),
+            SignerId::Fingerprint { fingerprint } => {
+                BdkSignerId::Fingerprint(Fingerprint::from_str(fingerprint.as_str()).unwrap())
+            }
+            SignerId::Dummy { index } => BdkSignerId::Dummy(index),
+        }
+    }
+}
+
+pub trait InputSigner: Send + Sync + Debug {
+    fn id(&self) -> Result<SignerId, CustomError>;
+
+    fn sign_input(
+        &self,
+        psbt: Arc<PartiallySignedTransaction>,
+        input_index: u32,
+        sign_options: SignOptions,
+    ) -> Result<(), CustomError>;
+}
+
+#[derive(Debug)]
+pub enum CustomError {
+    SignerError,
+}
+
+impl Display for CustomError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+impl std::error::Error for CustomError {}
+
+// // Need to implement this From<> impl in order to handle unexpected callback errors.  See the
+// // Callback Interfaces section of the handbook for more info.
+impl From<uniffi::UnexpectedUniFFICallbackError> for CustomError {
+    fn from(_: uniffi::UnexpectedUniFFICallbackError) -> Self {
+        Self::SignerError
+    }
+}

--- a/bdk-ffi/src/signer.rs
+++ b/bdk-ffi/src/signer.rs
@@ -1,11 +1,12 @@
 use crate::psbt::PartiallySignedTransaction;
+use crate::wallet::SignOptions;
 use bdk::bitcoin::util::bip32::Fingerprint;
 use bdk::bitcoincore_rpc::jsonrpc::serde_json::from_str;
-use bdk::signer::SignerId as BdkSignerId;
+use bdk::signer::{SignerId as BdkSignerId};
 use std::fmt::{Debug, Display};
 use std::str::FromStr;
 use std::sync::Arc;
-use crate::wallet::SignOptions;
+use bdk::signer::SignerOrdering as BdkSignerOrdering;
 
 pub enum SignerId {
     /// Bitcoin HASH160 (RIPEMD160 after SHA256) hash of an ECDSA public key
@@ -38,6 +39,35 @@ pub trait InputSigner: Send + Sync + Debug {
         input_index: u32,
         sign_options: SignOptions,
     ) -> Result<(), CustomError>;
+}
+
+
+
+// pub trait TransactionSigner
+
+// impl<T: InputSigner> TransactionSigner for T {
+//     fn sign_transaction(
+//         &self,
+//         psbt: &mut psbt::PartiallySignedTransaction,
+//         sign_options: &SignOptions,
+//         secp: &SecpCtx,
+//     ) -> Result<(), SignerError> {
+//         for input_index in 0..psbt.inputs.len() {
+//             self.sign_input(psbt, input_index, sign_options, secp)?;
+//         }
+//
+//         Ok(())
+//     }
+// }
+
+pub struct SignerOrdering {
+    pub order: u64
+}
+
+impl From<SignerOrdering> for BdkSignerOrdering {
+    fn from(signer_ordering: SignerOrdering) -> BdkSignerOrdering {
+        BdkSignerOrdering(signer_ordering.order as usize) // QUESTION 1: is this safe? We seem to use it elsewhere
+    }
 }
 
 #[derive(Debug)]

--- a/bdk-jvm/lib/build.gradle.kts
+++ b/bdk-jvm/lib/build.gradle.kts
@@ -43,6 +43,7 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk7")
     implementation("net.java.dev.jna:jna:5.8.0")
     api("org.slf4j:slf4j-api:1.7.30")
+    testImplementation(kotlin("test"))
     testImplementation("junit:junit:4.13.2")
     testRuntimeOnly("org.junit.vintage:junit-vintage-engine:5.8.2")
     testImplementation("ch.qos.logback:logback-classic:1.2.3")

--- a/bdk-jvm/lib/src/test/kotlin/org/bitcoindevkit/ExternalSignerTest.kt
+++ b/bdk-jvm/lib/src/test/kotlin/org/bitcoindevkit/ExternalSignerTest.kt
@@ -1,0 +1,12 @@
+package org.bitcoindevkit
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ExternalSignerTest {
+    @Test
+    fun testExternalSigner() {
+        val answerToLifeTheUniverseAndEverything = 42
+        assertEquals(42, answerToLifeTheUniverseAndEverything)
+    }
+}


### PR DESCRIPTION
This PR will bring the ability to add external signers to the wallet.

Very much in draft mode. I also think we'll need to really dig into the exact uses for it to make sure we expose all of the APIs required for users (`InputSigner` vs `TransactionSigner` traits, `SignOptions`, etc.)

This PR closes #222.

### Changelog notice
```md
- APIs Added
  - Add external signers to the `Wallet` type [#320]

[#320]: https://github.com/bitcoindevkit/bdk-ffi/pull/320
```

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:
* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature