### PR TITLE
Streamline CI workflows

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   security_audit:
-    name: Security Audit
+    name: Security audit
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -1,4 +1,4 @@
-name: bdk-ffi CI
+name: Rust layer CI
 on:
   push:
     paths:
@@ -10,7 +10,7 @@ on:
 jobs:
   build-test:
     name: Build and test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         rust:
@@ -18,11 +18,13 @@ jobs:
             clippy: true
           - version: 1.61.0 # MSRV
     steps:
-      - name: checkout
+      - name: Checkout
         uses: actions/checkout@v2
+
       - name: Generate cache key
         run: echo "${{ matrix.rust.version }} ${{ matrix.features }}" | tee .cache_key
-      - name: cache
+
+      - name: Cache
         uses: actions/cache@v2
         with:
           path: |
@@ -30,20 +32,27 @@ jobs:
             ~/.cargo/git
             target
           key: ${{ runner.os }}-cargo-${{ hashFiles('.cache_key') }}-${{ hashFiles('**/Cargo.toml','**/Cargo.lock') }}
+
       - name: Set default toolchain
         run: rustup default ${{ matrix.rust.version }}
+
       - name: Set profile
         run: rustup set profile minimal
+
       - name: Add clippy
         if: ${{ matrix.rust.clippy }}
         run: rustup component add clippy
+
       - name: Update toolchain
         run: rustup update
+
       - name: Build
         run: cargo build --features uniffi/cli
+
       - name: Clippy
         if: ${{ matrix.rust.clippy }}
         run: cargo clippy --all-targets --features "uniffi/bindgen-tests uniffi/cli" -- -D warnings
+
       - name: Test
         run: CLASSPATH=./tests/jna/jna-5.8.0.jar cargo test --features uniffi/bindgen-tests,uniffi/cli
 
@@ -53,13 +62,18 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+
       - name: Set default toolchain
         run: rustup default nightly
+
       - name: Set profile
         run: rustup set profile minimal
+
       - name: Add rustfmt
         run: rustup component add rustfmt
+
       - name: Update toolchain
         run: rustup update
+
       - name: Check fmt
         run: cargo fmt --all -- --config format_code_in_doc_comments=true --check

--- a/.github/workflows/publish-android.yaml
+++ b/.github/workflows/publish-android.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Check out PR branch
         uses: actions/checkout@v2
 
-      - name: cache
+      - name: Cache
         uses: actions/cache@v2
         with:
           path: |
@@ -35,7 +35,7 @@ jobs:
           distribution: temurin
           java-version: 11
 
-      - name: Install rust android targets
+      - name: Install Rust Android targets
         run: rustup target add x86_64-linux-android aarch64-linux-android armv7-linux-androideabi
 
       - name: Build bdk-android library

--- a/.github/workflows/publish-jvm.yaml
+++ b/.github/workflows/publish-jvm.yaml
@@ -3,10 +3,10 @@ on: [workflow_dispatch]
 
 jobs:
   build-jvm-macOS-M1-native-lib:
-    name: Create M1 and x86_64 JVM native binaries
+    name: "Create M1 and x86_64 JVM native binaries"
     runs-on: macos-12
     steps:
-      - name: Checkout publishing branch
+      - name: "Checkout publishing branch"
         uses: actions/checkout@v2
 
       - name: Cache

--- a/.github/workflows/publish-python.yaml
+++ b/.github/workflows/publish-python.yaml
@@ -142,7 +142,7 @@ jobs:
         with:
           path: dist/
 
-      # - name: 'Publish on test PyPI'
+      # - name: "Publish on test PyPI"
       #   uses: pypa/gh-action-pypi-publish@release/v1
       #   with:
       #     user: __token__

--- a/.github/workflows/test-android.yaml
+++ b/.github/workflows/test-android.yaml
@@ -18,17 +18,17 @@ jobs:
   build:
     runs-on: ubuntu-20.04
     steps:
-      - name: Install Android NDK 21.4.7075529
+      - name: "Install Android NDK 21.4.7075529"
         run: |
           ANDROID_ROOT=/usr/local/lib/android
           ANDROID_SDK_ROOT=${ANDROID_ROOT}/sdk
           SDKMANAGER=${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager
           echo "y" | $SDKMANAGER "ndk;21.4.7075529"
 
-      - name: Check out PR branch
+      - name: "Check out PR branch"
         uses: actions/checkout@v2
 
-      - name: cache
+      - name: "Cache"
         uses: actions/cache@v2
         with:
           path: |
@@ -37,16 +37,16 @@ jobs:
             ./target
           key: ${{ runner.os }}-${{ hashFiles('**/Cargo.toml','**/Cargo.lock') }}
 
-      - name: Set up JDK
+      - name: "Set up JDK"
         uses: actions/setup-java@v2
         with:
           distribution: temurin
           java-version: 11
 
-      - name: Install rust android targets
+      - name: "Install Rust Android targets"
         run: rustup target add x86_64-linux-android aarch64-linux-android armv7-linux-androideabi
 
-      - name: Run Android tests
+      - name: "Run Android tests"
         run: |
           cd bdk-android
           ./gradlew test --console=rich

--- a/.github/workflows/test-jvm.yaml
+++ b/.github/workflows/test-jvm.yaml
@@ -1,4 +1,4 @@
-name: Test JVM
+name: Test Kotlin/JVM
 on:
   push:
     paths:
@@ -16,7 +16,7 @@ jobs:
       - name: Check out PR branch
         uses: actions/checkout@v2
 
-      - name: cache
+      - name: Cache
         uses: actions/cache@v2
         with:
           path: |

--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -52,13 +52,13 @@ jobs:
       - name: "Build wheel"
         run: ${PYBIN}/python setup.py bdist_wheel --verbose
 
-      - name: Install wheel
+      - name: "Install wheel"
         run: ${PYBIN}/pip install ./dist/*.whl
 
-      - name: Run tests
+      - name: "Run tests"
         run: ${PYBIN}/python -m unittest tests/test_bdk.py --verbose
 
-      - name: Upload artifact test
+      - name: "Upload artifact test"
         uses: actions/upload-artifact@v2
         with:
           name: bdkpython-manylinux2014-x86_64-${{ matrix.python }}
@@ -98,10 +98,10 @@ jobs:
           ARCHFLAGS: "-arch x86_64 -arch arm64"
         run: python3 setup.py bdist_wheel --verbose
 
-      - name: Install wheel
+      - name: "Install wheel"
         run: pip3 install ./dist/*.whl
 
-      - name: Run tests
+      - name: "Run tests"
         run: python3 -m unittest tests/test_bdk.py --verbose
 
   build-windows-wheel:

--- a/.github/workflows/test-swift.yaml
+++ b/.github/workflows/test-swift.yaml
@@ -13,7 +13,7 @@ jobs:
   build:
     runs-on: macos-12
     steps:
-      - name: Checkout branch
+      - name: Checkout
         uses: actions/checkout@v2
 
       - name: Install Rust targets


### PR DESCRIPTION
## Description
This PR fixes a lot of the small differences between the styles of the different GitHub Actions workflows we have. Examples of the changes proposed:
1. Capitalize the first letter of the name of the CI task
2. Add a newline between tasks for easier readability
3. Pin the version of the image used (`ubuntu-20.04` instead of `ubuntu-latest`, etc.)

In this PR all changes are purely stylistic, so as not to introduce a change in behaviour at the same time as changes in style.

#### All Submissions:
* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)