### PR TITLE
Use Address type in address field on AddressInfo

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@
 </p>
 
 The workspace in this repository creates the `libbdkffi` multi-language library for the Rust-based 
-[bdk] library from the [Bitcoin Dev Kit] project. The `bdk-ffi-bindgen` package builds a tool for 
-generating the actual language binding code used to access the `libbdkffi` library.
+[bdk] library from the [Bitcoin Dev Kit] project.
 
 Each supported language and the platform(s) it's packaged for has its own directory. The Rust code in this project is in the bdk-ffi directory and is a wrapper around the [bdk] library to expose its APIs in a uniform way using the [mozilla/uniffi-rs] bindings generator for each supported target language.
 

--- a/bdk-ffi/src/bdk.udl
+++ b/bdk-ffi/src/bdk.udl
@@ -50,7 +50,8 @@ enum BdkError {
 
 dictionary AddressInfo {
   u32 index;
-  string address;
+  Address address;
+  KeychainKind keychain;
 };
 
 [Enum]
@@ -452,6 +453,8 @@ interface Address {
   Script script_pubkey();
 
   string to_qr_uri();
+
+  string as_string();
 };
 
 [Enum]

--- a/bdk-ffi/src/lib.rs
+++ b/bdk-ffi/src/lib.rs
@@ -47,17 +47,20 @@ pub struct ScriptAmount {
 
 /// A derived address and the index it was found at.
 pub struct AddressInfo {
-    /// Child index of this address
+    /// Child index of this address.
     pub index: u32,
-    /// Address
-    pub address: String,
+    /// Address.
+    pub address: Arc<Address>,
+    /// Type of keychain.
+    pub keychain: KeychainKind,
 }
 
 impl From<BdkAddressInfo> for AddressInfo {
-    fn from(x: bdk::wallet::AddressInfo) -> Self {
+    fn from(x: BdkAddressInfo) -> Self {
         AddressInfo {
             index: x.index,
-            address: x.address.to_string(),
+            address: Arc::new(Address::from(x.address)),
+            keychain: x.keychain,
         }
     }
 }
@@ -347,7 +350,8 @@ impl From<bdk::bitcoin::Transaction> for Transaction {
 }
 
 /// A Bitcoin address.
-struct Address {
+#[derive(Debug, PartialEq, Eq)]
+pub struct Address {
     address: BdkAddress,
 }
 
@@ -385,6 +389,16 @@ impl Address {
 
     fn to_qr_uri(&self) -> String {
         self.address.to_qr_uri()
+    }
+
+    fn as_string(&self) -> String {
+        self.address.to_string()
+    }
+}
+
+impl From<BdkAddress> for Address {
+    fn from(address: BdkAddress) -> Self {
+        Address { address }
     }
 }
 

--- a/bdk-ffi/src/wallet.rs
+++ b/bdk-ffi/src/wallet.rs
@@ -655,7 +655,8 @@ mod test {
             wallet
                 .get_address(AddressIndex::Peek { index: 2 })
                 .unwrap()
-                .address,
+                .address
+                .as_string(),
             "bcrt1q5g0mq6dkmwzvxscqwgc932jhgcxuqqkjv09tkj"
         );
 
@@ -663,25 +664,38 @@ mod test {
             wallet
                 .get_address(AddressIndex::Peek { index: 1 })
                 .unwrap()
-                .address,
+                .address
+                .as_string(),
             "bcrt1q0xs7dau8af22rspp4klya4f7lhggcnqfun2y3a"
         );
 
         // new index still 0
         assert_eq!(
-            wallet.get_address(AddressIndex::New).unwrap().address,
+            wallet
+                .get_address(AddressIndex::New)
+                .unwrap()
+                .address
+                .as_string(),
             "bcrt1qqjn9gky9mkrm3c28e5e87t5akd3twg6xezp0tv"
         );
 
         // new index now 1
         assert_eq!(
-            wallet.get_address(AddressIndex::New).unwrap().address,
+            wallet
+                .get_address(AddressIndex::New)
+                .unwrap()
+                .address
+                .as_string(),
             "bcrt1q0xs7dau8af22rspp4klya4f7lhggcnqfun2y3a"
         );
 
         // new index now 2
         assert_eq!(
-            wallet.get_address(AddressIndex::New).unwrap().address,
+            wallet
+                .get_address(AddressIndex::New)
+                .unwrap()
+                .address
+                .as_string(),
             "bcrt1q5g0mq6dkmwzvxscqwgc932jhgcxuqqkjv09tkj"
         );
 
@@ -690,7 +704,8 @@ mod test {
             wallet
                 .get_address(AddressIndex::Peek { index: 1 })
                 .unwrap()
-                .address,
+                .address
+                .as_string(),
             "bcrt1q0xs7dau8af22rspp4klya4f7lhggcnqfun2y3a"
         );
 
@@ -699,13 +714,18 @@ mod test {
             wallet
                 .get_address(AddressIndex::Reset { index: 0 })
                 .unwrap()
-                .address,
+                .address
+                .as_string(),
             "bcrt1qqjn9gky9mkrm3c28e5e87t5akd3twg6xezp0tv"
         );
 
         // new index 1 again
         assert_eq!(
-            wallet.get_address(AddressIndex::New).unwrap().address,
+            wallet
+                .get_address(AddressIndex::New)
+                .unwrap()
+                .address
+                .as_string(),
             "bcrt1q0xs7dau8af22rspp4klya4f7lhggcnqfun2y3a"
         );
     }
@@ -729,12 +749,20 @@ mod test {
         .unwrap();
 
         assert_eq!(
-            wallet.get_address(AddressIndex::New).unwrap().address,
+            wallet
+                .get_address(AddressIndex::New)
+                .unwrap()
+                .address
+                .as_string(),
             "bcrt1qqjn9gky9mkrm3c28e5e87t5akd3twg6xezp0tv"
         );
 
         assert_eq!(
-            wallet.get_address(AddressIndex::New).unwrap().address,
+            wallet
+                .get_address(AddressIndex::New)
+                .unwrap()
+                .address
+                .as_string(),
             "bcrt1q0xs7dau8af22rspp4klya4f7lhggcnqfun2y3a"
         );
 
@@ -742,7 +770,8 @@ mod test {
             wallet
                 .get_address(AddressIndex::LastUnused)
                 .unwrap()
-                .address,
+                .address
+                .as_string(),
             "bcrt1q0xs7dau8af22rspp4klya4f7lhggcnqfun2y3a"
         );
 
@@ -750,7 +779,8 @@ mod test {
             wallet
                 .get_internal_address(AddressIndex::New)
                 .unwrap()
-                .address,
+                .address
+                .as_string(),
             "bcrt1qpmz73cyx00r4a5dea469j40ax6d6kqyd67nnpj"
         );
 
@@ -758,7 +788,8 @@ mod test {
             wallet
                 .get_internal_address(AddressIndex::New)
                 .unwrap()
-                .address,
+                .address
+                .as_string(),
             "bcrt1qaux734vuhykww9632v8cmdnk7z2mw5lsf74v6k"
         );
 
@@ -766,7 +797,8 @@ mod test {
             wallet
                 .get_internal_address(AddressIndex::LastUnused)
                 .unwrap()
-                .address,
+                .address
+                .as_string(),
             "bcrt1qaux734vuhykww9632v8cmdnk7z2mw5lsf74v6k"
         );
     }


### PR DESCRIPTION
This PR leverages the newly exposed methods on the `Address` type and uses that in the AddressInfo type instead of a address string.

## Description
Fixes #332.

## Notes to the reviewers
As with the descriptor type, I'm changing the `to_string()` method to `as_string()` in the FFI. I don't remember why we made this choice way back when. Is that because of the name clash with the toString() methods on Kotlin and Swift? Just looking for validation before locking the API in.

### Changelog notice
```md
API Changes
- address field on `AddressInfo` type is now of type `Address` [#334]

[#334]: https://github.com/bitcoindevkit/bdk-ffi/pull/334
```

### Checklists

#### All Submissions:
* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [x] I've fixed the tests for the new feature
* [x] I've added docs for the new feature
