### PR TITLE
Add PartiallySignedTransaction.json_serialize() function

### DIFF
--- a/api-docs/kotlin/src/main/kotlin/org/bitcoindevkit/bdk.kt
+++ b/api-docs/kotlin/src/main/kotlin/org/bitcoindevkit/bdk.kt
@@ -369,6 +369,9 @@ class PartiallySignedTransaction(psbtBase64: String) {
      * In accordance with BIP 174 this function is commutative i.e., `A.combine(B) == B.combine(A)`
      */
     fun combine(other: PartiallySignedTransaction): PartiallySignedTransaction
+
+    /** Serialize the PSBT data structure as a String of JSON. */
+    fun jsonSerialize(): String
 }
 
 /**

--- a/bdk-ffi/src/bdk.udl
+++ b/bdk-ffi/src/bdk.udl
@@ -307,6 +307,8 @@ interface PartiallySignedTransaction {
   u64? fee_amount();
 
   FeeRate? fee_rate();
+
+  string json_serialize();
 };
 
 dictionary TxBuilderResult {

--- a/bdk-ffi/src/psbt.rs
+++ b/bdk-ffi/src/psbt.rs
@@ -1,6 +1,8 @@
 use bdk::bitcoin::hashes::hex::ToHex;
 use bdk::bitcoin::util::psbt::PartiallySignedTransaction as BdkPartiallySignedTransaction;
+use bdk::bitcoincore_rpc::jsonrpc::serde_json;
 use bdk::psbt::PsbtUtils;
+use std::ops::Deref;
 use std::str::FromStr;
 use std::sync::{Arc, Mutex};
 
@@ -65,6 +67,12 @@ impl PartiallySignedTransaction {
     /// If the PSBT is missing a TxOut for an input returns None.
     pub(crate) fn fee_rate(&self) -> Option<Arc<FeeRate>> {
         self.internal.lock().unwrap().fee_rate().map(Arc::new)
+    }
+
+    /// Serialize the PSBT data structure as a String of JSON.
+    pub(crate) fn json_serialize(&self) -> String {
+        let psbt = self.internal.lock().unwrap();
+        serde_json::to_string(psbt.deref()).unwrap()
     }
 }
 


### PR DESCRIPTION
### Description

Fixes #311 

### Notes to the reviewers

Here's an example of what a PSBT would look like serialized as JSON. 

Before signing:
```json
{
  "unsigned_tx": {
    "version": 1,
    "lock_time": 100,
    "input": [
      {
        "previous_output": "7bc1dab547519ebbfa9675f4d523acf09ecc27495dec3453d7995a504fec2b0f:0",
        "script_sig": "",
        "sequence": 4294967294,
        "witness": []
      }
    ],
    "output": [
      {
        "value": 49780,
        "script_pubkey": "0014ff9da567e62f30ea8654fa1d5fbd47bef8e3be13"
      }
    ]
  },
  "version": 0,
  "xpub": {},
  "proprietary": [],
  "unknown": [],
  "inputs": [
    {
      "non_witness_utxo": {
        "version": 1,
        "lock_time": 0,
        "input": [
          {
            "previous_output": "0000000000000000000000000000000000000000000000000000000000000000:0",
            "script_sig": "",
            "sequence": 4294967295,
            "witness": []
          }
        ],
        "output": [
          {
            "value": 50000,
            "script_pubkey": "00148975ac383125aba1f8912b0faf8bf485fede933c"
          }
        ]
      },
      "witness_utxo": {
        "value": 50000,
        "script_pubkey": "00148975ac383125aba1f8912b0faf8bf485fede933c"
      },
      "partial_sigs": {},
      "sighash_type": null,
      "redeem_script": null,
      "witness_script": null,
      "bip32_derivation": [
        [
          "02193f6b64644bf09e1b789b0c231a2888f881041785ce1fda98f858f0b93b7302",
          [
            "4581c495",
            "m/0"
          ]
        ]
      ],
      "final_script_sig": null,
      "final_script_witness": null,
      "ripemd160_preimages": {},
      "sha256_preimages": {},
      "hash160_preimages": {},
      "hash256_preimages": {},
      "tap_key_sig": null,
      "tap_script_sigs": [],
      "tap_scripts": [],
      "tap_key_origins": [],
      "tap_internal_key": null,
      "tap_merkle_root": null,
      "proprietary": [],
      "unknown": []
    }
  ],
  "outputs": [
    {
      "redeem_script": null,
      "witness_script": null,
      "bip32_derivation": [],
      "tap_internal_key": null,
      "tap_tree": null,
      "tap_key_origins": [],
      "proprietary": [],
      "unknown": []
    }
  ]
}
```

After signing:
```json
{
  "unsigned_tx": {
    "version": 1,
    "lock_time": 100,
    "input": [
      {
        "previous_output": "7bc1dab547519ebbfa9675f4d523acf09ecc27495dec3453d7995a504fec2b0f:0",
        "script_sig": "",
        "sequence": 4294967294,
        "witness": []
      }
    ],
    "output": [
      {
        "value": 49780,
        "script_pubkey": "0014ff9da567e62f30ea8654fa1d5fbd47bef8e3be13"
      }
    ]
  },
  "version": 0,
  "xpub": {},
  "proprietary": [],
  "unknown": [],
  "inputs": [
    {
      "non_witness_utxo": {
        "version": 1,
        "lock_time": 0,
        "input": [
          {
            "previous_output": "0000000000000000000000000000000000000000000000000000000000000000:0",
            "script_sig": "",
            "sequence": 4294967295,
            "witness": []
          }
        ],
        "output": [
          {
            "value": 50000,
            "script_pubkey": "00148975ac383125aba1f8912b0faf8bf485fede933c"
          }
        ]
      },
      "witness_utxo": {
        "value": 50000,
        "script_pubkey": "00148975ac383125aba1f8912b0faf8bf485fede933c"
      },
      "partial_sigs": {},
      "sighash_type": null,
      "redeem_script": null,
      "witness_script": null,
      "bip32_derivation": [
        [
          "02193f6b64644bf09e1b789b0c231a2888f881041785ce1fda98f858f0b93b7302",
          [
            "4581c495",
            "m/0"
          ]
        ]
      ],
      "final_script_sig": "",
      "final_script_witness": [
        "3044022049155f5b0f8bf8d9d468691979bcd03ea0af2b43ab0e73a0f88387ec01e62e4d02207d5bc60f1dcf641450197031a636f74633174b9af787ec491fd663b22009339d01",
        "02193f6b64644bf09e1b789b0c231a2888f881041785ce1fda98f858f0b93b7302"
      ],
      "ripemd160_preimages": {},
      "sha256_preimages": {},
      "hash160_preimages": {},
      "hash256_preimages": {},
      "tap_key_sig": null,
      "tap_script_sigs": [],
      "tap_scripts": [],
      "tap_key_origins": [],
      "tap_internal_key": null,
      "tap_merkle_root": null,
      "proprietary": [],
      "unknown": []
    }
  ],
  "outputs": [
    {
      "redeem_script": null,
      "witness_script": null,
      "bip32_derivation": [],
      "tap_internal_key": null,
      "tap_tree": null,
      "tap_key_origins": [],
      "proprietary": [],
      "unknown": []
    }
  ]
}
```

### Changelog notice

Added
- new PartiallySignedTransaction.json_serialize() function to get JSON serialized value of all PSBT fields.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [x] I've added tests for the new feature
* [ ] I've added docs for the new feature
