### PR TITLE
Use version 21 of the Android NDK in the CI test, build, and publish workflows

### DIFF
--- a/.github/workflows/publish-android.yaml
+++ b/.github/workflows/publish-android.yaml
@@ -1,10 +1,24 @@
 name: Publish bdk-android to Maven Central
 on: [workflow_dispatch]
 
+# The default Android NDK on the ubuntu-22.04 image is 25.2.9519653
+# We replace the default environment variable ANDROID_NDK_ROOT: /usr/local/lib/android/sdk/ndk/25.2.9519653
+# with an older version of the NDK (21.4.7075529) using the fix proposed here: https://github.com/actions/runner-images/issues/5930
+# For information on why this is needed at the moment see issues #242 and #243, and PR #282
+env:
+  ANDROID_NDK_ROOT: /usr/local/lib/android/sdk/ndk/21.4.7075529
+
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
+      - name: "Install Android NDK 21.4.7075529"
+        run: |
+          ANDROID_ROOT=/usr/local/lib/android
+          ANDROID_SDK_ROOT=${ANDROID_ROOT}/sdk
+          SDKMANAGER=${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager
+          echo "y" | $SDKMANAGER "ndk;21.4.7075529"
+
       - name: "Check out PR branch"
         uses: actions/checkout@v2
 

--- a/.github/workflows/test-android.yaml
+++ b/.github/workflows/test-android.yaml
@@ -9,10 +9,24 @@ on:
       - "bdk-ffi/**"
       - "bdk-android/**"
 
+# The default Android NDK on the ubuntu-22.04 image is 25.2.9519653
+# We replace the default environment variable ANDROID_NDK_ROOT: /usr/local/lib/android/sdk/ndk/25.2.9519653
+# with an older version of the NDK (21.4.7075529) using the fix proposed here: https://github.com/actions/runner-images/issues/5930
+# For information on why this is needed at the moment see issues #242 and #243, and PR #282
+env:
+  ANDROID_NDK_ROOT: /usr/local/lib/android/sdk/ndk/21.4.7075529
+
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
+      - name: "Install Android NDK 21.4.7075529"
+        run: |
+          ANDROID_ROOT=/usr/local/lib/android
+          ANDROID_SDK_ROOT=${ANDROID_ROOT}/sdk
+          SDKMANAGER=${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager
+          echo "y" | $SDKMANAGER "ndk;21.4.7075529"
+
       - name: "Check out PR branch"
         uses: actions/checkout@v2
 
@@ -34,7 +48,9 @@ jobs:
       - name: "Install Rust Android targets"
         run: rustup target add x86_64-linux-android aarch64-linux-android armv7-linux-androideabi
 
-      - name: "Run Android tests"
-        run: |
-          cd bdk-android
-          ./gradlew test --console=rich
+# There are currently no unit tests for bdk-android and the integration tests require the macOS image
+# which is not working with the older NDK version we are using, so for now we just make sure that the library builds.
+#      - name: "Run Android unit tests"
+#        run: |
+#          cd bdk-android
+#          ./gradlew test --console=rich


### PR DESCRIPTION
This PR reverts an update to our Android CI workflows.

For info on why this is needed, see issues #242 and #243.