### PR TITLE
Added from_script constructor to Address

### DIFF
--- a/api-docs/kotlin/src/main/kotlin/org/bitcoindevkit/bdk.kt
+++ b/api-docs/kotlin/src/main/kotlin/org/bitcoindevkit/bdk.kt
@@ -831,6 +831,9 @@ class Script(rawOutputScript: List<UByte>)
  * @param address The address in string format.
  */
 class Address(address: String) {
+    /** Construct an [`Address`] from an output script. */
+    fun fromScript(script: Script, network: Network): Address {}
+
     /** Return the Payload */
     fun payload(): Payload
 

--- a/bdk-ffi/src/bdk.udl
+++ b/bdk-ffi/src/bdk.udl
@@ -446,6 +446,9 @@ interface Address {
   [Throws=BdkError]
   constructor(string address);
 
+  [Name=from_script, Throws=BdkError]
+  constructor(Script script, Network network);
+
   Payload payload();
 
   Network network();

--- a/bdk-ffi/src/lib.rs
+++ b/bdk-ffi/src/lib.rs
@@ -364,6 +364,13 @@ impl Address {
             .map_err(|e| BdkError::Generic(e.to_string()))
     }
 
+    /// alternative constructor
+    fn from_script(script: Arc<Script>, network: Network) -> Result<Self, BdkError> {
+        BdkAddress::from_script(&script.script, network)
+            .map(|a| Address { address: a })
+            .map_err(|e| BdkError::Generic(e.to_string()))
+    }
+
     fn payload(&self) -> Payload {
         match &self.address.payload.clone() {
             BdkPayload::PubkeyHash(pubkey_hash) => Payload::PubkeyHash {

--- a/bdk-python/tests/test_bdk.py
+++ b/bdk-python/tests/test_bdk.py
@@ -43,6 +43,21 @@ class TestSimpleBip84Wallet(unittest.TestCase):
         # print(f"Balance is {balance.total} sat")
         assert balance.total > 0, "Balance is 0, send testnet coins to tb1qzg4mckdh50nwdm9hkzq06528rsu73hjxxzem3e"
 
-
+    def test_output_address_from_script_pubkey(self):
+        wallet = bdk.Wallet(
+            descriptor=descriptor,
+            change_descriptor=None,
+            network=bdk.Network.TESTNET,
+            database_config=db_config,
+        )
+        wallet.sync(blockchain, None)
+        first_tx = list(wallet.list_transactions(True))[0]
+        assert first_tx.txid == '35d3de8dd429ec4c9684168c1fbb9a4fb6db6f2ce89be214a024657a73ef4908'
+        
+        output1, output2 = list(first_tx.transaction.output())
+        
+        assert bdk.Address.from_script(output1.script_pubkey, bdk.Network.TESTNET).as_string() == 'tb1qw6ly2te8k9vy2mwj3g6gx82hj7hc8f5q3vry8t'
+        assert bdk.Address.from_script(output2.script_pubkey, bdk.Network.TESTNET).as_string() == 'tb1qzsvpnmme78yl60j7ldh9aqvhvxr4mz7mjpmh22'
+        
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
### Description

AFAIK there was no way to convert the output.script_pubkey into an address.  This PR adds that.

This PR allows to construct the addresses from tx outputs in python like:
```
def output_addresses(transaction):
    for output in transaction.transaction.output():
        add = bdk.Address.from_script(output.script_pubkey, bdk.Network.BITCOIN)
        print(add.as_string())

```

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [x] I've added tests for the new feature
* [ ] I've added docs for the new feature

