### PR TITLE
Bump snapshot versions

### DIFF
--- a/.github/ISSUE_TEMPLATE/minor_release.md
+++ b/.github/ISSUE_TEMPLATE/minor_release.md
@@ -7,77 +7,79 @@ assignees: ''
 ---
 
 ## Create a new minor release
-### _Main Workflow_
+## Bumping BDK Rust Version
 1. - [ ] Open a PR with an update to `Cargo.toml` to the new bdk release candidate and ensure all CI workflows run correctly. Fix errors if necessary.
 2. - [ ] Once the new bdk release is out, update the PR to replace the release candidate with the full release and merge.
-3. - [ ] Update the Android, JVM, Python, and Swift libraries as per the ["**_Sub-Workflows_**" section below](#Sub-Workflows). Open a single PR on master for all of these changes called `Prepare language bindings libraries for 0.X release`
-18. - [ ] Create a new branch off of `master` called `release/version`
-19. - [ ] Checkout that branch and open a PR to update the Android, JVM, and Python libraries' versions
-  - [ ] Update bdk-android version from `SNAPSHOT` version to release version
-  - [ ] Update bdk-jvm version from `SNAPSHOT` version to release version
-  - [ ] Update bdk-python version from `.dev` version to release version
-20. - [ ] Merge the PR updating all of the languages to their release versions
-21. - [ ] Create the tag and make sure to add the changelog info to the tag (works better if you prepare the tag message on the side in a text editor) and push it to GitHub.
+
+### Specific Libraries' Workflows
+#### _Android_
+3. - [ ] Update the API docs to reflect the changes in the API
+4. - [ ] Delete the `target` directory in bdk-ffi and all previous artifacts to make sure you're building the library from scratch.
+5. - [ ] Build the library and run the tests, and adjust if necessary.
+```sh
+# start an emulator prior to running the tests
+cd ./bdk-android/
+./gradlew buildAndroidLib
+./gradlew connectedAndroidTest
+```
+6. - [ ] Update the readme if necessary
+#### _JVM_
+7. - [ ] Update the API docs to reflect the changes in the API
+8. - [ ] Delete the `target` directory in bdk-ffi and all previous artifacts to make sure you're building the library from scratch
+9. - [ ] Build the library and run the tests, and adjust if necessary
+```sh
+cd ./bdk-jvm/
+./gradlew buildJvmLib
+./gradlew test
+```
+10. - [ ] Update the readme if necessary
+#### _Swift_
+11. - [ ] Run the tests and adjust if necessary
+```sh
+./bdk-swift/build-local-swift.sh
+cd ./bdk-swift/
+swift test
+```
+12. - [ ] Update the readme if necessary
+#### _Python_
+13. - [ ] Delete the `.tox`, `dist`, `build`, and `bdkpython.egg-info` and rust `target` directories to make sure you are building the library from scratch without any caches
+14. - [ ] Build the library
+```shell
+cd ./bdk-python/
+pip3 install --requirement requirements.txt
+bash ./generate.sh
+python3 setup.py --verbose bdist_wheel
+```
+15. - [ ] Run the tests and adjust if necessary
+```shell
+pip3 install ./dist/bdkpython-<yourversion>-py3-none-any.whl --force-reinstall
+python -m unittest --verbose tests/test_bdk.py
+```
+16. - [ ] Update the readme and `setup.py` if necessary
+
+### Release Workflow
+17. - [ ] Update the Android, JVM, Python, and Swift libraries as per the _Specific Libraries' Workflows_ section above. Open a single PR on master for all of these changes called `Prepare language bindings libraries for 0.X release`. See [example PR here](https://github.com/bitcoindevkit/bdk-ffi/pull/315).
+- [ ] Create a new branch off of `master` called `release/version`
+18. - [ ] Open a PR to that branch to update the Android, JVM, and Python libraries' versions. See [example PR here](https://github.com/bitcoindevkit/bdk-ffi/pull/316).
+    - [ ] Update bdk-android version from `SNAPSHOT` version to release version
+    - [ ] Update bdk-jvm version from `SNAPSHOT` version to release version
+    - [ ] Update bdk-python version from `.dev` version to release version
+19. - [ ] Merge the PR updating all the languages to their release versions
+20. - [ ] Create the tag and make sure to add the changelog info to the tag (works better if you prepare the tag message on the side in a text editor) and push it to GitHub.
 ```sh
 git tag v0.6.0 --sign --edit
 git push upstream v0.6.0
 ```
-22. - [ ] Make release on GitHub (set as pre-release and generate auto release notes between the previous tag and the new one)
-23. - [ ] Trigger manual releases for all 4 libraries (for Swift, simply add the version number in the text field when running the workflow manually. Note that the version number must not contain the `v`, i.e. `0.26.0`)
-24. - [ ] Bump the versions on master from `0.9.0-SNAPSHOT` to `0.10.0-SNAPSHOT`, `0.6.0.dev0` to `0.7.0.dev0`
-25. - [ ] Build and publish API docs for JVM, Android, and Java on the website
+21. - [ ] Aggregate all the changelog notices from the PRs and add them to the changelog file
+22. - [ ] Open a PR on master with the changes to the changelog file and the development versions bump. See [example PR here](https://github.com/bitcoindevkit/bdk-ffi/pull/317).
+23. - [ ] Make release on GitHub (set as pre-release and generate auto release notes between the previous tag and the new one)
+24. - [ ] Trigger manual releases for all 4 libraries (for Swift, simply add the version number in the text field when running the workflow manually. Note that the version number must not contain the `v`, i.e. `0.26.0`)
+25. - [ ] Bump the versions on master from `0.9.0-SNAPSHOT` to `0.10.0-SNAPSHOT`, `0.6.0.dev0` to `0.7.0.dev0`
+26. - [ ] Build and publish API docs for JVM, Android, and Java on the website
 ```bash!
 ./gradlew dokkaHtml    # bdk-jvm (Dokka)
 ./gradlew dokkaJavadoc # bdk-jvm (java-style documentation)
 ./gradlew dokkaHtml    # bdk-android (Dokka)
 ```
-26. - [ ] Tweet about the library
-27. - [ ] Post in the announcement channel
-
-### _Sub Workflows_
-#### _Android_
-4. - [ ] Update the API docs to reflect the changes in the API
-5. - [ ] Delete the `target` directory in bdk-ffi and all previous artifacts to make sure you're building the library from scratch
-6. - [ ] Build the library and run the tests, and adjust if necessary.
-```sh
-# start an emulator prior to running the tests
-cd bdk-android
-./gradlew buildAndroidLib
-./gradlew connectedAndroidTest
-```
-7. - [ ] Update the readme if necessary
-
-#### _JVM_
-8. - [ ] Update the API docs to reflect the changes in the API
-9. - [ ] Delete the `target` directory in bdk-ffi and all previous artifacts to make sure you're building the library from scratch
-10. - [ ] Build the library and run the tests, and adjust if necessary
-```sh
-cd bdk-jvm
-./gradlew buildJvmLib
-./gradlew test
-```
-11. - [ ] Update the readme if necessary
-
-#### _Swift_
-12. - [ ] Run the tests and adjust if necessary
-```sh
-./bdk-swift/build-local-swift.sh
-cd bdk-swift
-swift test
-```
-13. - [ ] Update the readme if necessary
-
-#### _Python_
-14. - [ ] Delete the `.tox`, `dist`, `build`, and `bdkpython.egg-info` and rust `target` directories to make sure you are building the library from scratch without any caches
-15. - [ ] Build the library
-```shell
-pip3 install --requirement requirements.txt
-bash ./generate.sh
-python3 setup.py --verbose bdist_wheel
-```
-16. - [ ] Run the tests and adjust if necessary
-```shell
-pip3 install ./dist/bdkpython-<yourversion>-py3-none-any.whl
-python -m unittest --verbose tests/test_bdk.py
-```
-17. - [ ] Update the readme and `setup.py` if necessary
+27. - [ ] Tweet about the library
+28. - [ ] Post in the announcement channel

--- a/.github/ISSUE_TEMPLATE/patch_release.md
+++ b/.github/ISSUE_TEMPLATE/patch_release.md
@@ -7,7 +7,6 @@ assignees: ''
 ---
 
 # Creating a new patch release
-
 ## Bumping BDK Rust Version
 1. - [ ] Open a PR with an update to `Cargo.toml` to the new bdk release candidate and ensure all CI workflows run correctly. Fix errors if necessary.
 2. - [ ] Once the new bdk release is out, update the PR to replace the release candidate with the full release and merge.
@@ -59,26 +58,28 @@ python -m unittest --verbose tests/test_bdk.py
 16. - [ ] Update the readme and `setup.py` if necessary
 
 ### Release Workflow
-17. - [ ] Update the Android, JVM, Python, and Swift libraries as per the _Specific Libraries' Workflows_ section above. Open a single PR on master for all of these changes called `Prepare language bindings libraries for 0.X release`
+17. - [ ] Update the Android, JVM, Python, and Swift libraries as per the _Specific Libraries' Workflows_ section above. Open a single PR on master for all of these changes called `Prepare language bindings libraries for 0.X release`. See [example PR here](https://github.com/bitcoindevkit/bdk-ffi/pull/315).
 - [ ] Create a new branch off of `master` called `release/version`
-18. - [ ] Checkout that branch and open a PR to update the Android, JVM, and Python libraries' versions
-    - [ ] Update bdk-android version from `SNAPSHOT` version to release version
-    - [ ] Update bdk-jvm version from `SNAPSHOT` version to release version
-    - [ ] Update bdk-python version from `.dev` version to release version
-19. - [ ] Merge the PR updating all of the languages to their release versions
+18. - [ ] Open a PR to that branch to update the Android, JVM, and Python libraries' versions. See [example PR here](https://github.com/bitcoindevkit/bdk-ffi/pull/316).
+- [ ] Update bdk-android version from `SNAPSHOT` version to release version
+- [ ] Update bdk-jvm version from `SNAPSHOT` version to release version
+- [ ] Update bdk-python version from `.dev` version to release version
+19. - [ ] Merge the PR updating all the languages to their release versions
 20. - [ ] Create the tag and make sure to add the changelog info to the tag (works better if you prepare the tag message on the side in a text editor) and push it to GitHub.
 ```sh
 git tag v0.6.0 --sign --edit
 git push upstream v0.6.0
 ```
-21. - [ ] Make release on GitHub (set as pre-release and generate auto release notes between the previous tag and the new one)
-22. - [ ] Trigger manual releases for all 4 libraries (for Swift, simply add the version number in the text field when running the workflow manually. Note that the version number must not contain the `v`, i.e. `0.26.0`)
-23. - [ ] Bump the versions on master from `0.9.0-SNAPSHOT` to `0.10.0-SNAPSHOT`, `0.6.0.dev0` to `0.7.0.dev0`
-24. - [ ] Build and publish API docs for JVM, Android, and Java on the website
+21. - [ ] Aggregate all the changelog notices from the PRs and add them to the changelog file
+22. - [ ] Open a PR on master with the changes to the changelog file and the development versions bump. See [example PR here](https://github.com/bitcoindevkit/bdk-ffi/pull/317).
+23. - [ ] Make release on GitHub (set as pre-release and generate auto release notes between the previous tag and the new one)
+24. - [ ] Trigger manual releases for all 4 libraries (for Swift, simply add the version number in the text field when running the workflow manually. Note that the version number must not contain the `v`, i.e. `0.26.0`)
+25. - [ ] Bump the versions on master from `0.9.0-SNAPSHOT` to `0.10.0-SNAPSHOT`, `0.6.0.dev0` to `0.7.0.dev0`
+26. - [ ] Build and publish API docs for JVM, Android, and Java on the website
 ```bash!
 ./gradlew dokkaHtml    # bdk-jvm (Dokka)
 ./gradlew dokkaJavadoc # bdk-jvm (java-style documentation)
 ./gradlew dokkaHtml    # bdk-android (Dokka)
 ```
-25. - [ ] Tweet about the library
-26. - [ ] Post in the announcement channel
+27. - [ ] Tweet about the library
+28. - [ ] Post in the announcement channel

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [v0.28.0]
-- Update BDK to version 0.27.1 [#341]
+- Update BDK to version 0.28.0 [#341]
+- Drop support of pypy releases of Python libraries [#351]
+- Drop support for Python 3.6 and 3.7 [#351]
+- Drop support for very old Linux versions that do not support the manylinux_2_17_x86_64 platform tag [#351]
 - APIs changed:
   - Expose Address payload and network properties. [#325]
   - Add SignOptions to Wallet.sign() params. [#326]
@@ -19,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#334]: https://github.com/bitcoindevkit/bdk-ffi/pull/334
 [#337]: https://github.com/bitcoindevkit/bdk-ffi/pull/337
 [#341]: https://github.com/bitcoindevkit/bdk-ffi/pull/341
+[#351]: https://github.com/bitcoindevkit/bdk-ffi/pull/351
 
 ## [v0.27.1]
 - Update BDK to version 0.27.1 [#312]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,27 @@
 # Changelog
-All notable changes to this project prior to release **0.9.0** are documented in this file. Future
-changelog information can be found in each release's git tag and can be viewed with `git tag -ln100 "v*"`.
-Changelog info is also documented on the [GitHub releases](https://github.com/bitcoindevkit/bdk-ffi/releases)
-page. See [DEVELOPMENT_CYCLE.md](DEVELOPMENT_CYCLE.md) for more details.
+Changelog information can also be found in each release's git tag (which can be viewed with `git tag -ln100 "v*"`), as well as on the [GitHub releases](https://github.com/bitcoindevkit/bdk-ffi/releases) page. See [DEVELOPMENT_CYCLE.md](DEVELOPMENT_CYCLE.md) for more details.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.28.0]
+- Update BDK to version 0.27.1 [#341]
+- APIs changed:
+  - Expose Address payload and network properties. [#325]
+  - Add SignOptions to Wallet.sign() params. [#326]
+  - address field on `AddressInfo` type is now of type `Address` [#333]
+  - new PartiallySignedTransaction.json_serialize() function to get JSON serialized value of all PSBT fields. [#334]
+  - Add from_script constructor to `Address` type [#337]
+
+[#325]: https://github.com/bitcoindevkit/bdk-ffi/pull/325
+[#326]: https://github.com/bitcoindevkit/bdk-ffi/pull/326
+[#333]: https://github.com/bitcoindevkit/bdk-ffi/pull/333
+[#334]: https://github.com/bitcoindevkit/bdk-ffi/pull/334
+[#337]: https://github.com/bitcoindevkit/bdk-ffi/pull/337
+[#341]: https://github.com/bitcoindevkit/bdk-ffi/pull/341
+
 ## [v0.27.1]
-- Update BDK to latest version 0.27.1 [#312]
+- Update BDK to version 0.27.1 [#312]
 - APIs changed
   - `PartiallySignedTransaction.extract_tx()` returns a `Transaction` instead of the transaction bytes. [#296]
   - `Blockchain.broadcast()` takes a `Transaction` instead of a `PartiallySignedTransaction`. [#296]
@@ -23,7 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#312]: https://github.com/bitcoindevkit/bdk-ffi/pull/312
 
 ## [v0.26.0]
-- Update BDK to latest version 0.26.0 [#288]
+- Update BDK to version 0.26.0 [#288]
 - APIs changed
   - The descriptor and change_descriptor arguments on the wallet constructor now take a `Descriptor` instead of a `String`. [#260]
   - TxBuilder.drain_to() argument is now `Script` instead of address `String`. [#279]
@@ -46,7 +59,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#288]: https://github.com/bitcoindevkit/bdk-ffi/pull/288
 
 ## [v0.25.0]
-- Update BDK to latest version 0.25.0 [#272]
+- Update BDK to version 0.25.0 [#272]
 - APIs Added:
   - from_string() constructors now available on DescriptorSecretKey and DescriptorPublicKey [#247]
 
@@ -54,7 +67,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#272]: https://github.com/bitcoindevkit/bdk-ffi/pull/272
 
 ## [v0.11.0]
-- Update BDK to latest version 0.24.0 [#221]
+- Update BDK to version 0.24.0 [#221]
 - APIs changed
   - The constructor on the DescriptorSecretKey type now takes a Mnemonic instead of a String.
 - APIs added
@@ -70,7 +83,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#221]: https://github.com/bitcoindevkit/bdk-ffi/pull/221
 
 ## [v0.10.0]
-- Update BDK to latest version 0.23.0 [#204]
+- Update BDK to version 0.23.0 [#204]
 - Update uniffi-rs to latest version 0.21.0 [#216]
 - Breaking Changes
   - Changed `TxBuilder.finish()` to return new `TxBuilderResult` [#209]
@@ -103,7 +116,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - APIs Added [#154]
   - `generate_mnemonic()`, returns string mnemonic
   - `interface DescriptorSecretKey`
-    - `new(Network, string_mnenoinc, password)`, contructs DescriptorSecretKey
+    - `new(Network, string_mnenoinc, password)`, constructs DescriptorSecretKey
     - `derive(DerivationPath)`, derives and returns child DescriptorSecretKey
     - `extend(DerivationPath)`, extends and returns DescriptorSecretKey
     - `as_public()`, returns DescriptorSecretKey as DescriptorPublicKey
@@ -183,8 +196,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [BIP 0174]:https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki#encoding
 
-## [v0.2.0]
-
+[v0.28.0]: https://github.com/bitcoindevkit/bdk-ffi/compare/v0.27.1...v0.28.0
 [v0.27.1]: https://github.com/bitcoindevkit/bdk-ffi/compare/v0.26.0...v0.27.1
 [v0.26.0]: https://github.com/bitcoindevkit/bdk-ffi/compare/v0.25.0...v0.26.0
 [v0.25.0]: https://github.com/bitcoindevkit/bdk-ffi/compare/v0.11.0...v0.25.0

--- a/bdk-android/gradle.properties
+++ b/bdk-android/gradle.properties
@@ -2,4 +2,4 @@ org.gradle.jvmargs=-Xmx1536m
 android.useAndroidX=true
 android.enableJetifier=true
 kotlin.code.style=official
-libraryVersion=0.28.0-SNAPSHOT
+libraryVersion=0.29.0-SNAPSHOT

--- a/bdk-jvm/gradle.properties
+++ b/bdk-jvm/gradle.properties
@@ -1,4 +1,4 @@
 org.gradle.jvmargs=-Xmx1536m
 android.enableJetifier=true
 kotlin.code.style=official
-libraryVersion=0.28.0-SNAPSHOT
+libraryVersion=0.29.0-SNAPSHOT

--- a/bdk-python/setup.py
+++ b/bdk-python/setup.py
@@ -51,7 +51,7 @@ print(f"Wallet balance is: {balance.total}")
 
 setup(
     name="bdkpython",
-    version="0.28.0.dev0",
+    version="0.29.0.dev0",
     description="The Python language bindings for the Bitcoin Development Kit",
     long_description=LONG_DESCRIPTION,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
This PR does three things:

1. Bump the development versions of bdk-android, bdk-jvm, and bdk-python.
2. Update the changelog.
3. Update the release_minor_version and release_patch_version workflows.