### PR TITLE
Fix Python libraries' names to prepare for releasing

### DIFF
--- a/.github/workflows/publish-python.yaml
+++ b/.github/workflows/publish-python.yaml
@@ -39,11 +39,13 @@ jobs:
       - name: "Install requirements"
         run: ${PYBIN}/pip install -r requirements.txt
 
-      - name: "Generate bdk.py"
+      - name: "Generate bdk.py and binaries"
         run: bash generate.sh
 
       - name: "Build wheel"
-        run: ${PYBIN}/python setup.py bdist_wheel --verbose
+        # Specifying the plat-name argument is necessary to build a wheel with the correct name,
+        # see issue #350 for more information
+        run: ${PYBIN}/python setup.py bdist_wheel --plat-name manylinux_2_17_x86_64 --verbose
 
       - uses: actions/upload-artifact@v2
         with:
@@ -71,7 +73,7 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
 
-      - name: "Generate bdk.py"
+      - name: "Generate bdk.py and binaries"
         run: |
           python3 --version
           rustup target add aarch64-apple-darwin
@@ -81,7 +83,9 @@ jobs:
       - name: "Build wheel"
         env:
           ARCHFLAGS: "-arch x86_64 -arch arm64"
-        run: python3 setup.py bdist_wheel --verbose
+        # Specifying the plat-name argument is necessary to build a wheel with the correct name,
+        # see issue #350 for more information
+        run: python3 setup.py bdist_wheel --plat-name macosx_12_0_universal2 --verbose
 
       - uses: actions/upload-artifact@v2
         with:
@@ -109,7 +113,7 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
 
-      - name: "Generate bdk.py"
+      - name: "Generate bdk.py and binaries"
         run: |
           python --version
           pip install --user -r requirements.txt

--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -48,11 +48,13 @@ jobs:
       - name: "Install requirements"
         run: ${PYBIN}/pip install -r requirements.txt
 
-      - name: "Generate bdk.py"
+      - name: "Generate bdk.py and binaries"
         run: bash generate.sh
 
       - name: "Build wheel"
-        run: ${PYBIN}/python setup.py bdist_wheel --verbose
+        # Specifying the plat-name argument is necessary to build a wheel with the correct name,
+        # see issue #350 for more information
+        run: ${PYBIN}/python setup.py bdist_wheel --plat-name manylinux_2_17_x86_64 --verbose
 
       - name: "Install wheel"
         run: ${PYBIN}/pip install ./dist/*.whl
@@ -75,7 +77,9 @@ jobs:
     strategy:
       matrix:
         python:
-          - "3.8"
+          # 3.8 returns an error for the macos-12 image when we try to install the wheel:
+          # bdkpython-0.28.0.dev0-cp38-cp38-macosx_12_0_universal2.whl is not a supported wheel on this platform.
+          # - "3.8"
           - "3.9"
           - "3.10"
     steps:
@@ -87,7 +91,7 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
 
-      - name: "Generate bdk.py"
+      - name: "Generate bdk.py and binaries"
         run: | 
           python3 --version
           rustup target add aarch64-apple-darwin
@@ -97,7 +101,7 @@ jobs:
       - name: "Build wheel"
         env:
           ARCHFLAGS: "-arch x86_64 -arch arm64"
-        run: python3 setup.py bdist_wheel --verbose
+        run: python3 setup.py bdist_wheel --plat-name macosx_12_0_universal2 --verbose
 
       - name: "Install wheel"
         run: pip3 install ./dist/*.whl

--- a/bdk-python/setup.py
+++ b/bdk-python/setup.py
@@ -62,4 +62,7 @@ setup(
     url="https://github.com/bitcoindevkit/bdk-ffi",
     author="Alekos Filini <alekos.filini@gmail.com>, Steve Myers <steve@notmandatory.org>",
     license="MIT or Apache 2.0",
+    # This is required to ensure the library name includes the python version, abi, and platform tags
+    # See issue #350 for more information
+    has_ext_modules=lambda: True,
 )


### PR DESCRIPTION
## Description
See issue #350 to see why these changes are necessary for releasing our Python libraries, and [this run](https://github.com/bitcoindevkit/bdk-ffi/actions/runs/4798691517) to see it in action.

### Changelog notice
```md
- Remove support of pypy releases of Python libraries
- Remove support for Python 3.6 and 3.7
- Drop support for very old Linux versions that do not support the manylinux_2_17_x86_64 platform tag
```
