### PR TITLE
Fix bdk-swift/build-local-swift.sh for aarch64-apple-ios-sim

### DIFF
--- a/.github/workflows/test-swift.yaml
+++ b/.github/workflows/test-swift.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: Build bdk-ffi for aarch64-apple-darwin
         run: cargo build --package bdk-ffi --profile release-smaller --target aarch64-apple-darwin
 
-      - name: Create lipo-ios-sim and lipo-macos
+      - name: Create lipo-macos
         run: |
           mkdir -p target/lipo-macos/release-smaller
           lipo target/aarch64-apple-darwin/release-smaller/libbdkffi.a target/x86_64-apple-darwin/release-smaller/libbdkffi.a -create -output target/lipo-macos/release-smaller/libbdkffi.a

--- a/bdk-swift/build-local-swift.sh
+++ b/bdk-swift/build-local-swift.sh
@@ -5,10 +5,10 @@
 #
 # Run the script from the repo root directory, ie: ./bdk-swift/build-local-swift.sh
 
-rustup install nightly-x86_64-apple-darwin
-rustup component add rust-src --toolchain nightly-x86_64-apple-darwin
+rustup install nightly-2023-04-10-x86_64-apple-darwin
+rustup component add rust-src --toolchain nightly-2023-04-10-x86_64-apple-darwin
 rustup target add aarch64-apple-ios x86_64-apple-ios
-rustup target add aarch64-apple-ios-sim --toolchain nightly
+rustup target add aarch64-apple-ios-sim --toolchain nightly-2023-04-10
 rustup target add aarch64-apple-darwin x86_64-apple-darwin
 
 pushd bdk-ffi
@@ -20,7 +20,7 @@ cargo build --package bdk-ffi --profile release-smaller --target x86_64-apple-da
 cargo build --package bdk-ffi --profile release-smaller --target aarch64-apple-darwin
 cargo build --package bdk-ffi --profile release-smaller --target x86_64-apple-ios
 cargo build --package bdk-ffi --profile release-smaller --target aarch64-apple-ios
-cargo +nightly build --package bdk-ffi --release -Z build-std --target aarch64-apple-ios-sim
+cargo +nightly-2023-04-10 build --package bdk-ffi --release --target aarch64-apple-ios-sim
 
 mkdir -p target/lipo-ios-sim/release-smaller
 lipo target/aarch64-apple-ios-sim/release/libbdkffi.a target/x86_64-apple-ios/release-smaller/libbdkffi.a -create -output target/lipo-ios-sim/release-smaller/libbdkffi.a

--- a/bdk-swift/build-local-swift.sh
+++ b/bdk-swift/build-local-swift.sh
@@ -20,10 +20,10 @@ cargo build --package bdk-ffi --profile release-smaller --target x86_64-apple-da
 cargo build --package bdk-ffi --profile release-smaller --target aarch64-apple-darwin
 cargo build --package bdk-ffi --profile release-smaller --target x86_64-apple-ios
 cargo build --package bdk-ffi --profile release-smaller --target aarch64-apple-ios
-cargo +nightly-2023-04-10 build --package bdk-ffi --release --target aarch64-apple-ios-sim
+cargo +nightly-2023-04-10 build --package bdk-ffi --profile release-smaller --target aarch64-apple-ios-sim
 
 mkdir -p target/lipo-ios-sim/release-smaller
-lipo target/aarch64-apple-ios-sim/release/libbdkffi.a target/x86_64-apple-ios/release-smaller/libbdkffi.a -create -output target/lipo-ios-sim/release-smaller/libbdkffi.a
+lipo target/aarch64-apple-ios-sim/release-smaller/libbdkffi.a target/x86_64-apple-ios/release-smaller/libbdkffi.a -create -output target/lipo-ios-sim/release-smaller/libbdkffi.a
 mkdir -p target/lipo-macos/release-smaller
 lipo target/aarch64-apple-darwin/release-smaller/libbdkffi.a target/x86_64-apple-darwin/release-smaller/libbdkffi.a -create -output target/lipo-macos/release-smaller/libbdkffi.a
 


### PR DESCRIPTION
### Description

Fix bdk-swift/build-local-swift.sh for aarch64-apple-ios-sim, this matches the same fix made for the `bdk-swift` publishing workflow here: bitcoindevkit/bdk-swift#44

### Notes to the reviewers

I was able to remove `-Z build-std` because `std` is now included with the `aarch64-apple-ios-sim` target, so we don't need to build it ourselves. 

Also added `--profile release-smaller` with `aarch64-applie-ios-sim`. It used to not work with `nightly` but looks like it's working now and saves about 20MB on the final xcframework zip file.

### Changelog notice

None

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing