### PR TITLE
Expose the `add_foreign_utxo` method on TxBuilder type

### DIFF
--- a/api-docs/kotlin/src/main/kotlin/org/bitcoindevkit/bdk.kt
+++ b/api-docs/kotlin/src/main/kotlin/org/bitcoindevkit/bdk.kt
@@ -981,8 +981,17 @@ enum class WitnessVersion {
 
 /**
  * A key-value map for an input of the corresponding index in the unsigned transaction.
+ *
+ *  @constructor Create a new PSBT Input from a JSON String.
  */
-class Input() {}
+class Input(inputJson: String) {
+
+    /**
+     * Serialize the PSBT Input data structure as a JSON String.
+     *
+     */
+    fun jsonSerialize(): String;
+}
 
 /**
  * Mnemonic phrases are a human-readable version of the private keys. Supported number of words are 12, 15, 18, 21 and 24.

--- a/bdk-ffi/src/bdk.udl
+++ b/bdk-ffi/src/bdk.udl
@@ -318,6 +318,10 @@ interface PartiallySignedTransaction {
 };
 
 interface Input {
+  [Name=from_json,Throws=BdkError]
+  constructor(string input_json);
+
+  string json_serialize();
 };
 
 interface PsbtSighashType {

--- a/bdk-ffi/src/bdk.udl
+++ b/bdk-ffi/src/bdk.udl
@@ -314,6 +314,36 @@ interface PartiallySignedTransaction {
   string json_serialize();
 };
 
+interface Input {
+};
+
+interface PsbtSighashType {
+  [Name=from_ecdsa]
+  constructor(EcdsaSighashType ecdsa_hash_ty);
+
+  [Name=from_schnorr]
+  constructor(SchnorrSighashType schnorr_hash_ty);
+};
+
+enum EcdsaSighashType {
+  "All",
+  "None",
+  "Single",
+  "AllPlusAnyoneCanPay",
+  "NonePlusAnyoneCanPay",
+  "SinglePlusAnyoneCanPay",
+};
+
+enum SchnorrSighashType {
+  "Default",
+  "All",
+  "None",
+  "Single",
+  "AllPlusAnyoneCanPay",
+  "NonePlusAnyoneCanPay",
+  "SinglePlusAnyoneCanPay",
+};
+
 dictionary TxBuilderResult {
   PartiallySignedTransaction psbt;
   TransactionDetails transaction_details;

--- a/bdk-ffi/src/bdk.udl
+++ b/bdk-ffi/src/bdk.udl
@@ -363,9 +363,11 @@ interface TxBuilder {
 
   TxBuilder add_unspendable(OutPoint unspendable);
 
+  TxBuilder add_utxos(sequence<OutPoint> outpoints);
+
   TxBuilder add_utxo(OutPoint outpoint);
 
-  TxBuilder add_utxos(sequence<OutPoint> outpoints);
+  TxBuilder add_foreign_utxo(OutPoint outpoint, Input psbt_input, u64 satisfaction_weight);
 
   TxBuilder do_not_spend_change();
 
@@ -480,7 +482,7 @@ interface Descriptor {
   constructor(DescriptorPublicKey public_key, string fingerprint, KeychainKind keychain, Network network);
 
   [Throws=BdkError]
-  u32 max_satisfaction_weight();
+  u64 max_satisfaction_weight();
 
   string as_string();
 

--- a/bdk-ffi/src/bdk.udl
+++ b/bdk-ffi/src/bdk.udl
@@ -236,6 +236,9 @@ interface Wallet {
   sequence<LocalUtxo> list_unspent();
 
   [Throws=BdkError]
+  Input get_psbt_input(LocalUtxo utxo, PsbtSighashType? sighash_type, boolean only_witness_utxo);
+
+  [Throws=BdkError]
   sequence<TransactionDetails> list_transactions(boolean include_raw);
 
   [Throws=BdkError]

--- a/bdk-ffi/src/bdk.udl
+++ b/bdk-ffi/src/bdk.udl
@@ -475,6 +475,9 @@ interface Descriptor {
   [Name=new_bip84_public]
   constructor(DescriptorPublicKey public_key, string fingerprint, KeychainKind keychain, Network network);
 
+  [Throws=BdkError]
+  u32 max_satisfaction_weight();
+
   string as_string();
 
   string as_string_private();

--- a/bdk-ffi/src/descriptor.rs
+++ b/bdk-ffi/src/descriptor.rs
@@ -193,10 +193,10 @@ impl Descriptor {
     ///
     /// # Errors
     /// When the descriptor is impossible to satisfy (ex: sh(OP_FALSE)).
-    pub(crate) fn max_satisfaction_weight(&self) -> Result<u32, BdkError> {
+    pub(crate) fn max_satisfaction_weight(&self) -> Result<u64, BdkError> {
         self.extended_descriptor
             .max_satisfaction_weight()
-            .map(|w| u32::try_from(w).unwrap())
+            .map(|w| u64::try_from(w).unwrap())
             .map_err(BdkError::Miniscript)
     }
 

--- a/bdk-ffi/src/lib.rs
+++ b/bdk-ffi/src/lib.rs
@@ -12,7 +12,9 @@ use crate::database::DatabaseConfig;
 use crate::descriptor::Descriptor;
 use crate::keys::DerivationPath;
 use crate::keys::{DescriptorPublicKey, DescriptorSecretKey, Mnemonic};
+use crate::psbt::Input;
 use crate::psbt::PartiallySignedTransaction;
+use crate::psbt::PsbtSighashType;
 use crate::wallet::SignOptions;
 use crate::wallet::{BumpFeeTxBuilder, TxBuilder, Wallet};
 use bdk::bitcoin::blockdata::script::Script as BdkScript;
@@ -24,6 +26,7 @@ use bdk::bitcoin::util::address::{Payload as BdkPayload, WitnessVersion};
 use bdk::bitcoin::{
     Address as BdkAddress, Network, OutPoint as BdkOutPoint, Transaction as BdkTransaction, Txid,
 };
+use bdk::bitcoin::{EcdsaSighashType, SchnorrSighashType};
 use bdk::blockchain::Progress as BdkProgress;
 use bdk::database::any::{SledDbConfiguration, SqliteDbConfiguration};
 use bdk::keys::bip39::WordCount;

--- a/bdk-ffi/src/lib.rs
+++ b/bdk-ffi/src/lib.rs
@@ -164,6 +164,15 @@ impl From<&OutPoint> for BdkOutPoint {
     }
 }
 
+impl From<OutPoint> for BdkOutPoint {
+    fn from(outpoint: OutPoint) -> Self {
+        BdkOutPoint {
+            txid: Txid::from_str(&outpoint.txid).unwrap(),
+            vout: outpoint.vout,
+        }
+    }
+}
+
 pub struct Balance {
     // All coinbase outputs not yet matured
     pub immature: u64,
@@ -212,6 +221,15 @@ impl From<&BdkTxOut> for TxOut {
     }
 }
 
+impl From<TxOut> for BdkTxOut {
+    fn from(tx_out: TxOut) -> Self {
+        BdkTxOut {
+            value: tx_out.value,
+            script_pubkey: tx_out.script_pubkey.script.clone(),
+        }
+    }
+}
+
 pub struct LocalUtxo {
     outpoint: OutPoint,
     txout: TxOut,
@@ -232,6 +250,17 @@ impl From<BdkLocalUtxo> for LocalUtxo {
                     script: local_utxo.txout.script_pubkey,
                 }),
             },
+            keychain: local_utxo.keychain,
+            is_spent: local_utxo.is_spent,
+        }
+    }
+}
+
+impl From<LocalUtxo> for BdkLocalUtxo {
+    fn from(local_utxo: LocalUtxo) -> Self {
+        BdkLocalUtxo {
+            outpoint: local_utxo.outpoint.into(),
+            txout: local_utxo.txout.into(),
             keychain: local_utxo.keychain,
             is_spent: local_utxo.is_spent,
         }

--- a/bdk-ffi/src/psbt.rs
+++ b/bdk-ffi/src/psbt.rs
@@ -83,12 +83,26 @@ impl PartiallySignedTransaction {
 /// transaction.
 #[derive(Debug)]
 pub(crate) struct Input {
-    _inner: BdkInput,
+    inner: BdkInput,
+}
+
+impl Input {
+    /// Create a new PSBT Input from a JSON String.
+    pub(crate) fn from_json(input_json: String) -> Result<Self, BdkError> {
+        let input = serde_json::from_str(input_json.as_str())?;
+        Ok(Self { inner: input })
+    }
+
+    /// Serialize the PSBT Input data structure as a JSON String.
+    pub(crate) fn json_serialize(&self) -> String {
+        let input = &self.inner;
+        serde_json::to_string(input).unwrap()
+    }
 }
 
 impl From<BdkInput> for Input {
     fn from(input: BdkInput) -> Self {
-        Input { _inner: input }
+        Input { inner: input }
     }
 }
 

--- a/bdk-ffi/src/psbt.rs
+++ b/bdk-ffi/src/psbt.rs
@@ -83,7 +83,13 @@ impl PartiallySignedTransaction {
 /// transaction.
 #[derive(Debug)]
 pub(crate) struct Input {
-    inner: BdkInput,
+    _inner: BdkInput,
+}
+
+impl From<BdkInput> for Input {
+    fn from(input: BdkInput) -> Self {
+        Input { _inner: input }
+    }
 }
 
 /// A Signature hash type for the corresponding input. As of taproot upgrade, the signature hash
@@ -106,6 +112,12 @@ impl PsbtSighashType {
         PsbtSighashType {
             inner: BdkPsbtSighashType::from(schnorr_hash_ty),
         }
+    }
+}
+
+impl From<&PsbtSighashType> for BdkPsbtSighashType {
+    fn from(psbt_hash_ty: &PsbtSighashType) -> Self {
+        psbt_hash_ty.inner
     }
 }
 

--- a/bdk-ffi/src/psbt.rs
+++ b/bdk-ffi/src/psbt.rs
@@ -79,9 +79,8 @@ impl PartiallySignedTransaction {
     }
 }
 
-/// A key-value map for an input of the corresponding index in the unsigned
-/// transaction.
-#[derive(Debug)]
+/// A key-value map for an input of the corresponding index in the unsigned transaction.
+#[derive(Clone, Debug)]
 pub(crate) struct Input {
     inner: BdkInput,
 }
@@ -103,6 +102,12 @@ impl Input {
 impl From<BdkInput> for Input {
     fn from(input: BdkInput) -> Self {
         Input { inner: input }
+    }
+}
+
+impl From<Input> for BdkInput {
+    fn from(input: Input) -> Self {
+        input.inner
     }
 }
 

--- a/bdk-ffi/src/wallet.rs
+++ b/bdk-ffi/src/wallet.rs
@@ -15,7 +15,7 @@ use std::sync::{Arc, Mutex, MutexGuard};
 use crate::blockchain::Blockchain;
 use crate::database::DatabaseConfig;
 use crate::descriptor::Descriptor;
-use crate::psbt::PartiallySignedTransaction;
+use crate::psbt::{Input, PartiallySignedTransaction, PsbtSighashType};
 use crate::{
     AddressIndex, AddressInfo, Balance, BdkError, LocalUtxo, OutPoint, Progress, ProgressHolder,
     RbfValue, Script, ScriptAmount, TransactionDetails, TxBuilderResult,
@@ -155,6 +155,22 @@ impl Wallet {
     pub(crate) fn list_unspent(&self) -> Result<Vec<LocalUtxo>, BdkError> {
         let unspents: Vec<BdkLocalUtxo> = self.get_wallet().list_unspent()?;
         Ok(unspents.into_iter().map(LocalUtxo::from).collect())
+    }
+
+    /// Get the corresponding PSBT Input for a LocalUtxo.
+    pub(crate) fn get_psbt_input(
+        &self,
+        utxo: LocalUtxo,
+        sighash_type: Option<Arc<PsbtSighashType>>,
+        only_witness_utxo: bool,
+    ) -> Result<Arc<Input>, BdkError> {
+        self.get_wallet()
+            .get_psbt_input(
+                utxo.into(),
+                sighash_type.map(|s| s.deref().into()),
+                only_witness_utxo,
+            )
+            .map(|i| Arc::new(i.into()))
     }
 }
 


### PR DESCRIPTION
### Description
This PR fixes #329.

### Notes to the reviewers
Not ready for review yet.

### Changelog notice
```md
APIs Added:
    - Add TxBuilder.add_foreign_utxo method [#358]

[#358]: https://github.com/bitcoindevkit/bdk-ffi/pull/358
```

* [x] I've signed all my commits
* [ ] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [ ] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:
* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature