### PR TITLE
Use new bitcoin-ffi crate for Network type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,6 +151,7 @@ version = "0.28.0"
 dependencies = [
  "assert_matches",
  "bdk",
+ "bitcoin-ffi",
  "uniffi",
 ]
 
@@ -202,6 +203,14 @@ dependencies = [
  "bitcoin_hashes",
  "secp256k1",
  "serde",
+]
+
+[[package]]
+name = "bitcoin-ffi"
+version = "0.1.0"
+dependencies = [
+ "bitcoin",
+ "uniffi",
 ]
 
 [[package]]

--- a/bdk-ffi/Cargo.toml
+++ b/bdk-ffi/Cargo.toml
@@ -20,6 +20,7 @@ default = ["uniffi/cli"]
 
 [dependencies]
 bdk = { version = "0.28", features = ["all-keys", "use-esplora-ureq", "sqlite-bundled", "rpc"] }
+bitcoin-ffi = { version = "0.1.0", path = "../../bitcoin-ffi" }
 uniffi = { version = "0.23.0" }
 
 [build-dependencies]

--- a/bdk-ffi/src/bdk.udl
+++ b/bdk-ffi/src/bdk.udl
@@ -62,13 +62,6 @@ interface AddressIndex {
   Reset(u32 index);
 };
 
-enum Network {
-  "Bitcoin",
-  "Testnet",
-  "Signet",
-  "Regtest",
-};
-
 dictionary SledDbConfiguration {
   string path;
   string tree_name;
@@ -497,3 +490,8 @@ enum WitnessVersion {
 interface Script {
   constructor(sequence<u8> raw_output_script);
 };
+
+// Types defined in bitcoin-ffi (https://github.com/tnull/bitcoin-ffi)
+
+[External="bitcoin_ffi"]
+typedef extern Network;

--- a/bdk-ffi/src/blockchain.rs
+++ b/bdk-ffi/src/blockchain.rs
@@ -1,6 +1,6 @@
 // use crate::BlockchainConfig;
 use crate::{BdkError, Transaction};
-use bdk::bitcoin::Network;
+use bitcoin_ffi::Network;
 use bdk::blockchain::any::{AnyBlockchain, AnyBlockchainConfig};
 use bdk::blockchain::rpc::Auth as BdkAuth;
 use bdk::blockchain::rpc::RpcSyncParams as BdkRpcSyncParams;

--- a/bdk-ffi/src/descriptor.rs
+++ b/bdk-ffi/src/descriptor.rs
@@ -1,7 +1,7 @@
 use crate::{BdkError, DescriptorPublicKey, DescriptorSecretKey};
 use bdk::bitcoin::secp256k1::Secp256k1;
 use bdk::bitcoin::util::bip32::Fingerprint;
-use bdk::bitcoin::Network;
+use bitcoin_ffi::Network;
 use bdk::descriptor::{ExtendedDescriptor, IntoWalletDescriptor, KeyMap};
 use bdk::keys::{
     DescriptorPublicKey as BdkDescriptorPublicKey, DescriptorSecretKey as BdkDescriptorSecretKey,

--- a/bdk-ffi/src/keys.rs
+++ b/bdk-ffi/src/keys.rs
@@ -2,7 +2,7 @@ use crate::BdkError;
 
 use bdk::bitcoin::secp256k1::Secp256k1;
 use bdk::bitcoin::util::bip32::DerivationPath as BdkDerivationPath;
-use bdk::bitcoin::Network;
+use bitcoin_ffi::Network;
 use bdk::descriptor::DescriptorXKey;
 use bdk::keys::bip39::{Language, Mnemonic as BdkMnemonic, WordCount};
 use bdk::keys::{

--- a/bdk-ffi/src/lib.rs
+++ b/bdk-ffi/src/lib.rs
@@ -22,7 +22,7 @@ use bdk::bitcoin::consensus::Decodable;
 use bdk::bitcoin::psbt::serialize::Serialize;
 use bdk::bitcoin::util::address::{Payload as BdkPayload, WitnessVersion};
 use bdk::bitcoin::{
-    Address as BdkAddress, Network, OutPoint as BdkOutPoint, Transaction as BdkTransaction, Txid,
+    Address as BdkAddress, OutPoint as BdkOutPoint, Transaction as BdkTransaction, Txid,
 };
 use bdk::blockchain::Progress as BdkProgress;
 use bdk::database::any::{SledDbConfiguration, SqliteDbConfiguration};
@@ -32,6 +32,7 @@ use bdk::wallet::AddressInfo as BdkAddressInfo;
 use bdk::LocalUtxo as BdkLocalUtxo;
 use bdk::TransactionDetails as BdkTransactionDetails;
 use bdk::{Balance as BdkBalance, BlockTime, Error as BdkError, FeeRate, KeychainKind};
+use bitcoin_ffi::Network;
 use std::convert::From;
 use std::fmt;
 use std::fmt::Debug;

--- a/bdk-ffi/src/wallet.rs
+++ b/bdk-ffi/src/wallet.rs
@@ -1,5 +1,5 @@
 use bdk::bitcoin::blockdata::script::Script as BdkScript;
-use bdk::bitcoin::{Address as BdkAddress, Network, OutPoint as BdkOutPoint, Sequence, Txid};
+use bdk::bitcoin::{Address as BdkAddress, OutPoint as BdkOutPoint, Sequence, Txid};
 use bdk::database::any::AnyDatabase;
 use bdk::database::{AnyDatabaseConfig, ConfigurableDatabase};
 use bdk::wallet::tx_builder::ChangeSpendPolicy;
@@ -7,6 +7,7 @@ use bdk::{
     FeeRate, LocalUtxo as BdkLocalUtxo, SignOptions as BdkSignOptions,
     SyncOptions as BdkSyncOptions, Wallet as BdkWallet,
 };
+use bitcoin_ffi::Network;
 use std::collections::HashSet;
 use std::ops::Deref;
 use std::str::FromStr;


### PR DESCRIPTION
Just playing around with the idea of using a new bitcoin-ffi crate where rust-bitcoin types are defined.