### PR TITLE
Align JVM target version for Kotlin and Java compile tasks

### DIFF
--- a/bdk-jvm/lib/build.gradle.kts
+++ b/bdk-jvm/lib/build.gradle.kts
@@ -20,8 +20,8 @@ repositories {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
     withSourcesJar()
     withJavadocJar()
 }
@@ -107,4 +107,8 @@ signing {
 // binaries before running the tests
 tasks.withType<KotlinCompile> {
     dependsOn("buildJvmLib")
+
+    kotlinOptions {
+        jvmTarget = "11"
+    }
 }


### PR DESCRIPTION
This commit resolves a build error related to mismatched JVM target versions for the Kotlin and Java compile tasks. Previously, the 'compileJava' task was targeting JVM 11, while the 'compileKotlin' task was targeting JVM 8.

Both tasks have now been set to target JVM 11, ensuring consistency and eliminating the build error.

### Notes to the reviewers
Fixes #327.

### Checklists

#### All Submissions:
* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)

#### Bugfixes:
* [x] I'm linking the issue being fixed by this PR
