### PR TITLE
[swift] suppress keyword escape warnings

### DIFF
--- a/bdk-swift/Package.swift
+++ b/bdk-swift/Package.swift
@@ -29,7 +29,9 @@ let package = Package(
         .binaryTarget(name: "bdkFFI", path: "./bdkFFI.xcframework"),
         .target(
             name: "BitcoinDevKit",
-            dependencies: ["bdkFFI"]),
+            dependencies: ["bdkFFI"],
+            swiftSettings: [.unsafeFlags(["-suppress-warnings"])]
+        ),
         .testTarget(
             name: "BitcoinDevKitTests",
             dependencies: ["BitcoinDevKit"]),


### PR DESCRIPTION
### Description

This `Package.swift` config change suppresses build warnings so that users won't see these (expected) warnings when they include the `bdk-swift` package in their project:

```
/Users/steve/git/notmandatory/bdk-ffi/bdk-swift/Sources/BitcoinDevKit/BitcoinDevKit.swift:2240:13 Keyword 'index' does not need to be escaped in argument list

/Users/steve/git/notmandatory/bdk-ffi/bdk-swift/Sources/BitcoinDevKit/BitcoinDevKit.swift:2241:13 Keyword 'address' does not need to be escaped in argument list

/Users/steve/git/notmandatory/bdk-ffi/bdk-swift/Sources/BitcoinDevKit/BitcoinDevKit.swift:2242:13 Keyword 'keychain' does not need to be escaped in argument list

/Users/steve/git/notmandatory/bdk-ffi/bdk-swift/Sources/BitcoinDevKit/BitcoinDevKit.swift:2321:13 Keyword 'immature' does not need to be escaped in argument list

/Users/steve/git/notmandatory/bdk-ffi/bdk-swift/Sources/BitcoinDevKit/BitcoinDevKit.swift:2322:13 Keyword 'trustedPending' does not need to be escaped in argument list

/Users/steve/git/notmandatory/bdk-ffi/bdk-swift/Sources/BitcoinDevKit/BitcoinDevKit.swift:2323:13 Keyword 'untrustedPending' does not need to be escaped in argument list

/Users/steve/git/notmandatory/bdk-ffi/bdk-swift/Sources/BitcoinDevKit/BitcoinDevKit.swift:2324:13 Keyword 'confirmed' does not need to be escaped in argument list

etc.
```

### Notes to the reviewers

There's currently no way in Swift to suppress individual warning types.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing