### PR TITLE
Expose Script.to_bytes() method

### DIFF
--- a/api-docs/kotlin/src/main/kotlin/org/bitcoindevkit/bdk.kt
+++ b/api-docs/kotlin/src/main/kotlin/org/bitcoindevkit/bdk.kt
@@ -829,7 +829,10 @@ data class TxBuilderResult (
 /**
  * A bitcoin script.
  */
-class Script(rawOutputScript: List<UByte>)
+class Script(rawOutputScript: List<UByte>) {
+    /** Return the script as bytes. */
+    fun toBytes(): List<UByte> {}
+}
 
 /**
  * A bitcoin address.

--- a/bdk-ffi/src/bdk.udl
+++ b/bdk-ffi/src/bdk.udl
@@ -496,4 +496,6 @@ enum WitnessVersion {
 
 interface Script {
   constructor(sequence<u8> raw_output_script);
+
+  sequence<u8> to_bytes();
 };

--- a/bdk-ffi/src/lib.rs
+++ b/bdk-ffi/src/lib.rs
@@ -438,6 +438,10 @@ impl Script {
         let script: BdkScript = BdkScript::from(raw_output_script);
         Script { script }
     }
+
+    fn to_bytes(&self) -> Vec<u8> {
+        self.script.to_bytes()
+    }
 }
 
 impl From<BdkScript> for Script {


### PR DESCRIPTION
This PR exposes the [to_bytes()](https://docs.rs/bitcoin/0.29.2/bitcoin/blockdata/script/struct.Script.html#method.to_bytes) method on the `Script` type.

Fixes #359.

### Changelog notice
```md
APIs Added:
    - Expose Script.to_bytes() method [#369]

[#369]: https://github.com/bitcoindevkit/bdk-ffi/pull/369
```

### Checklists

#### All Submissions:
* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:
* [x] I've added docs for the new feature