### PR TITLE
Update library version to 0.29.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,7 +147,7 @@ dependencies = [
 
 [[package]]
 name = "bdk-ffi"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "assert_matches",
  "bdk",

--- a/bdk-ffi/Cargo.toml
+++ b/bdk-ffi/Cargo.toml
@@ -1,14 +1,12 @@
 [package]
 name = "bdk-ffi"
-version = "0.28.0"
+version = "0.29.0"
 authors = ["Steve Myers <steve@notmandatory.org>", "Sudarsan Balaji <sudarsan.balaji@artfuldev.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
 
 [lib]
 crate-type = ["lib", "staticlib", "cdylib"]
-#crate-type = ["staticlib", "cdylib"]
-#crate-type = ["cdylib"]
 name = "bdkffi"
 
 [[bin]]


### PR DESCRIPTION
### Description
This PR bumps the bdk-ffi library version to 0.29.0

### Notes to the reviewers
This one is fairly simple because the version of BDK doesn't increase.

### Changelog notice
No changelog notice for this PR.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
