### PR TITLE
Prepare language bindings libraries for 0.29 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,7 +147,7 @@ dependencies = [
 
 [[package]]
 name = "bdk-ffi"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "assert_matches",
  "bdk",

--- a/bdk-android/README.md
+++ b/bdk-android/README.md
@@ -54,19 +54,23 @@ _Note that Kotlin version `1.6.10` or later is required to build the library._
 ```shell
 git clone https://github.com/bitcoindevkit/bdk-ffi
 ```
-2. Follow the "General" bdk-ffi ["Getting Started (Developer)"] instructions.
-3. If building on macOS install required intel and m1 jvm targets
+2. Follow the "General" bdk-ffi ["Getting Started (Developer)"] instructions. 
+3. Install Rust (note that we are currently building using Rust 1.67.0):
+```shell
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+rustup default 1.67.0
+```
 4. Install required targets
- ```sh
- rustup target add x86_64-linux-android aarch64-linux-android armv7-linux-androideabi
- ```
+```sh
+rustup target add x86_64-linux-android aarch64-linux-android armv7-linux-androideabi
+```
 5. Install Android SDK and Build-Tools for API level 30+
 6. Setup `$ANDROID_SDK_ROOT` and `$ANDROID_NDK_ROOT` path variables (which are required by the
-   build tool), for example (NDK major version 21 is required):
- ```shell
- export ANDROID_SDK_ROOT=~/Android/Sdk
- export ANDROID_NDK_ROOT=$ANDROID_SDK_ROOT/ndk/21.<NDK_VERSION>
- ```
+   build tool), for example (note that currently, NDK version 21.4.7075529 is required):
+```shell
+export ANDROID_SDK_ROOT=~/Android/Sdk
+export ANDROID_NDK_ROOT=$ANDROID_SDK_ROOT/ndk/21.4.7075529
+```
 7. Build kotlin bindings
  ```sh
  # build Android library

--- a/bdk-ffi/Cargo.toml
+++ b/bdk-ffi/Cargo.toml
@@ -1,14 +1,12 @@
 [package]
 name = "bdk-ffi"
-version = "0.28.0"
+version = "0.29.0"
 authors = ["Steve Myers <steve@notmandatory.org>", "Sudarsan Balaji <sudarsan.balaji@artfuldev.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
 
 [lib]
 crate-type = ["lib", "staticlib", "cdylib"]
-#crate-type = ["staticlib", "cdylib"]
-#crate-type = ["cdylib"]
 name = "bdkffi"
 
 [[bin]]

--- a/bdk-jvm/README.md
+++ b/bdk-jvm/README.md
@@ -1,4 +1,4 @@
-# bdk-android
+# bdk-jvm
 This project builds a .jar package for the JVM platform that provide Kotlin language bindings for the [`bdk`] library. The Kotlin language bindings are created by the `bdk-ffi` project which is included in the root of this repository.
 
 ## How to Use
@@ -43,21 +43,21 @@ dependencies {
 }
 ```
 
-
 ## Example Projects
 * [Tatooine Faucet](https://github.com/thunderbiscuit/tatooine)
 
 ## How to build
 _Note that Kotlin version `1.6.10` or later is required to build the library._
-1. Install JDK 11. It must be JDK 11 (not 17), otherwise it won't build. For example, with SDKMAN!:
+1. Install JDK 11. It must be version 11 (not 17), otherwise it won't build. For example, with SDKMAN!:
 ```shell
 curl -s "https://get.sdkman.io" | bash
 source "$HOME/.sdkman/bin/sdkman-init.sh"
 sdk install java 11.0.19-tem
 ```
-2. Install rust:
+2. Install Rust (note that we are currently building using Rust 1.67.0):
 ```shell
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+rustup default 1.67.0
 ```
 3. Clone this repository.
 ```shell
@@ -68,10 +68,9 @@ git clone https://github.com/bitcoindevkit/bdk-ffi
 rustup target add x86_64-apple-darwin aarch64-apple-darwin
 ```
 5. Build kotlin bindings
- ```sh
- # build JVM library
- ./gradlew buildJvmLib
- ```
+```sh
+./gradlew buildJvmLib
+```
 
 ## How to publish to your local Maven repo
 ```shell


### PR DESCRIPTION
## Description
This PR updates documentation and tests (if required) to all 4 language bindings libraries in preparation for the `0.29` releases.

### Notes to the reviewers
- Local builds of bdk-android, bdk-jvm, bdk-python, and bdk-swift have all build correctly.
- Local tests of bdk-android, bdk-jvm, bdk-python and bdk-swift have all passed and did required no changes.

#### All Submissions:
* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing