### PR TITLE
Update CI actions to latest versions

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -13,7 +13,7 @@ jobs:
     name: Security audit
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/audit-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -19,13 +19,13 @@ jobs:
           - version: 1.61.0 # MSRV
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Generate cache key
         run: echo "${{ matrix.rust.version }} ${{ matrix.features }}" | tee .cache_key
 
       - name: Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.cargo/registry
@@ -61,7 +61,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set default toolchain
         run: rustup default nightly

--- a/.github/workflows/publish-android.yaml
+++ b/.github/workflows/publish-android.yaml
@@ -20,10 +20,10 @@ jobs:
           echo "y" | $SDKMANAGER "ndk;21.4.7075529"
 
       - name: "Check out PR branch"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: "Cache"
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.cargo/registry
@@ -32,7 +32,7 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('**/Cargo.toml','**/Cargo.lock') }}
 
       - name: "Set up JDK"
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: temurin
           java-version: 11

--- a/.github/workflows/publish-jvm.yaml
+++ b/.github/workflows/publish-jvm.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: macos-12
     steps:
       - name: "Checkout publishing branch"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: "Cache"
         uses: actions/cache@v3
@@ -19,7 +19,7 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('**/Cargo.toml','**/Cargo.lock') }}
 
       - name: "Set up JDK"
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: temurin
           java-version: 11
@@ -46,10 +46,10 @@ jobs:
     runs-on: windows-2022
     steps:
       - name: "Checkout publishing branch"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: "Set up JDK"
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: temurin
           java-version: 11
@@ -77,7 +77,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: "Checkout publishing branch"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: "Cache"
         uses: actions/cache@v3
@@ -89,7 +89,7 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('**/Cargo.toml','**/Cargo.lock') }}
 
       - name: "Set up JDK"
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: temurin
           java-version: 11

--- a/.github/workflows/publish-python.yaml
+++ b/.github/workflows/publish-python.yaml
@@ -1,4 +1,4 @@
-name: Build and publish Python wheels
+name: Publish bdkpython to PyPI
 on: [workflow_dispatch]
 
 # We use manylinux2014 because older CentOS versions used by 2010 and 1 have a very old glibc version, which
@@ -26,7 +26,7 @@ jobs:
           - cp310-cp310
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: true
       - uses: actions-rs/toolchain@v1
@@ -41,7 +41,7 @@ jobs:
         # see issue #350 for more information
         run: ${PYBIN}/python setup.py bdist_wheel --plat-name manylinux_2_17_x86_64 --verbose
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: bdkpython-manylinux2014-x86_64-${{ matrix.python }}
           path: /home/runner/work/bdk-ffi/bdk-ffi/bdk-python/dist/*.whl
@@ -60,12 +60,12 @@ jobs:
           - "3.10"
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: true
 
       - name: "Install Python"
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
 
@@ -78,7 +78,7 @@ jobs:
         run: python3 setup.py bdist_wheel --plat-name macosx_11_0_arm64 --verbose
 
       - name: "Upload artifacts"
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: bdkpython-macos-arm64-${{ matrix.python }}
           path: /Users/runner/work/bdk-ffi/bdk-ffi/bdk-python/dist/*.whl
@@ -97,12 +97,12 @@ jobs:
           - "3.10"
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: true
 
       - name: "Install Python"
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
 
@@ -114,7 +114,7 @@ jobs:
         # see issue #350 for more information
         run: python3 setup.py bdist_wheel --plat-name macosx_11_0_x86_64 --verbose
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: bdkpython-macos-x86_64-${{ matrix.python }}
           path: /Users/runner/work/bdk-ffi/bdk-ffi/bdk-python/dist/*.whl
@@ -133,10 +133,10 @@ jobs:
           - "3.10"
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
 
@@ -147,7 +147,7 @@ jobs:
         run: python setup.py bdist_wheel --verbose
 
       - name: "Upload artifacts"
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: bdkpython-win-${{ matrix.python }}
           path: D:\a\bdk-ffi\bdk-ffi\bdk-python\dist\*.whl
@@ -161,10 +161,10 @@ jobs:
     needs: [build-manylinux2014-x86_64-wheels, build-macos-arm64-wheels, build-macos-x86_64-wheels, build-windows-wheels]
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: "Download artifacts in dist/ directory"
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           path: dist/
 

--- a/.github/workflows/test-android.yaml
+++ b/.github/workflows/test-android.yaml
@@ -29,10 +29,10 @@ jobs:
           echo "y" | $SDKMANAGER "ndk;21.4.7075529"
 
       - name: "Check out PR branch"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: "Cache"
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.cargo/registry
@@ -41,7 +41,7 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('**/Cargo.toml','**/Cargo.lock') }}
 
       - name: "Set up JDK"
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: temurin
           java-version: 11

--- a/.github/workflows/test-jvm.yaml
+++ b/.github/workflows/test-jvm.yaml
@@ -14,11 +14,11 @@ jobs:
   build:
     runs-on: ubuntu-20.04
     steps:
-      - name: Check out PR branch
-        uses: actions/checkout@v2
+      - name: "Check out PR branch"
+        uses: actions/checkout@v3
 
-      - name: Cache
-        uses: actions/cache@v2
+      - name: "Cache"
+        uses: actions/cache@v3
         with:
           path: |
             ~/.cargo/registry
@@ -26,8 +26,8 @@ jobs:
             ./target
           key: ${{ runner.os }}-${{ hashFiles('**/Cargo.toml','**/Cargo.lock') }}
 
-      - name: Set up JDK
-        uses: actions/setup-java@v2
+      - name: "Set up JDK"
+        uses: actions/setup-java@v3
         with:
           distribution: temurin
           java-version: 11
@@ -35,7 +35,7 @@ jobs:
       - name: "Set default Rust version to 1.67.0"
         run: rustup default 1.67.0
 
-      - name: Run JVM tests
+      - name: "Run JVM tests"
         run: |
           cd bdk-jvm
-          ./gradlew test --console=rich
+          ./gradlew test

--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -35,7 +35,7 @@ jobs:
           - cp310-cp310
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: true
       - uses: actions-rs/toolchain@v1
@@ -57,7 +57,7 @@ jobs:
         run: ${PYBIN}/python -m unittest tests/test_bdk.py --verbose
 
       - name: "Upload artifact test"
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: bdkpython-manylinux2014-x86_64-${{ matrix.python }}
           path: /home/runner/work/bdk-ffi/bdk-ffi/bdk-python/dist/*.whl
@@ -76,12 +76,12 @@ jobs:
           - "3.10"
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: true
 
       - name: "Install Python"
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
 
@@ -100,7 +100,7 @@ jobs:
       #     python3 -m unittest tests/test_bdk.py --verbose
 
       - name: "Upload artifact test"
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: bdkpython-macos-arm64-${{ matrix.python }}
           path: /Users/runner/work/bdk-ffi/bdk-ffi/bdk-python/dist/*.whl
@@ -119,10 +119,10 @@ jobs:
           - "3.10"
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
 
@@ -141,7 +141,7 @@ jobs:
         run: python3 -m unittest tests/test_bdk.py --verbose
 
       - name: "Upload artifact test"
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: bdkpython-macos-x86_64-${{ matrix.python }}
           path: /Users/runner/work/bdk-ffi/bdk-ffi/bdk-python/dist/*.whl
@@ -160,12 +160,12 @@ jobs:
           - "3.10"
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: true
 
       - name: "Install Python"
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
 
@@ -176,7 +176,7 @@ jobs:
         run: python setup.py bdist_wheel --verbose
 
       - name: "Upload artifact test"
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: bdkpython-windows-${{ matrix.python }}
           path: D:\a\bdk-ffi\bdk-ffi\bdk-python\dist\*.whl

--- a/.github/workflows/test-swift.yaml
+++ b/.github/workflows/test-swift.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: macos-12
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: "Set default Rust version to 1.67.0"
         run: rustup default 1.67.0


### PR DESCRIPTION
This PR simply updates some of our actions from v2 to v3:
- checkout (v3)
- setup-java (v3)
- cache (v3)
- upload-artifact (v3)
- setup-python (v4)

Fixes #377.

It also brings the title of the Python release workflow in line with the others:
- `Publish bdkpython to PyPI` <- new name
- `Publish bdk-jvm to Maven Central`
- `Publish bdk-android to Maven Central`

### Checklists

#### All Submissions:
* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)

#### Bugfixes:
* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [x] I'm linking the issue being fixed by this PR
