### PR TITLE
chore: update library version to 0.30.0

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -51,6 +51,7 @@ jobs:
         run: |
           cargo update -p hashlink --precise "0.8.1"
           cargo update -p tokio --precise "1.29.1"
+          cargo update -p flate2 --precise "1.0.26"
       - name: Build
         run: cargo build
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,7 +194,7 @@ dependencies = [
 
 [[package]]
 name = "bdk-ffi"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "assert_matches",
  "bdk",

--- a/bdk-ffi/Cargo.toml
+++ b/bdk-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk-ffi"
-version = "0.29.0"
+version = "0.30.0"
 authors = ["Steve Myers <steve@notmandatory.org>", "Sudarsan Balaji <sudarsan.balaji@artfuldev.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
### Description
This PR bumps the bdk-ffi library version to 0.30.0

### Notes to the reviewers
This one is simple because the version of BDK doesn't increase.

### Changelog notice
No changelog notice for this PR.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing