### PR TITLE
chore: update libraries to official release versions

### DIFF
--- a/bdk-android/gradle.properties
+++ b/bdk-android/gradle.properties
@@ -2,4 +2,4 @@ org.gradle.jvmargs=-Xmx1536m
 android.useAndroidX=true
 android.enableJetifier=true
 kotlin.code.style=official
-libraryVersion=0.30.0-SNAPSHOT
+libraryVersion=0.30.0

--- a/bdk-jvm/gradle.properties
+++ b/bdk-jvm/gradle.properties
@@ -1,4 +1,4 @@
 org.gradle.jvmargs=-Xmx1536m
 android.enableJetifier=true
 kotlin.code.style=official
-libraryVersion=0.30.0-SNAPSHOT
+libraryVersion=0.30.0

--- a/bdk-python/setup.py
+++ b/bdk-python/setup.py
@@ -51,7 +51,7 @@ print(f"Wallet balance is: {balance.total}")
 
 setup(
     name="bdkpython",
-    version="0.30.0.dev0",
+    version="0.30.0",
     description="The Python language bindings for the Bitcoin Development Kit",
     long_description=LONG_DESCRIPTION,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
This PR bumps the snapshot (Android and JVM) and dev (Python) versions to official release versions.