### PR TITLE
Bump snapshot and dev versions of libraries

### DIFF
--- a/.github/ISSUE_TEMPLATE/minor_release.md
+++ b/.github/ISSUE_TEMPLATE/minor_release.md
@@ -47,7 +47,7 @@ swift test
 ```shell
 cd ./bdk-python/
 pip3 install --requirement requirements.txt
-bash ./generate.sh
+bash ./scripts/generate-macos-arm64.sh # run the script for your particular platform
 python3 setup.py --verbose bdist_wheel
 ```
 15. - [ ] Run the tests and adjust if necessary

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ Changelog information can also be found in each release's git tag (which can be 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.30.0]
+This release has a new API and a few internal optimizations and refactorings.
+
+- APIs Added
+  - Add BIP-86 descriptor templates [#388]
+
+[#388]: https://github.com/bitcoindevkit/bdk-ffi/pull/388
+
 ## [0.29.0]
 This release has a number of new APIs, and adds support for Windows in bdk-jvm.
 
@@ -215,6 +223,7 @@ Changelog
 
 [BIP 0174]:https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki#encoding
 
+[v0.30.0]: https://github.com/bitcoindevkit/bdk-ffi/compare/v0.29.0...v0.30.0
 [v0.29.0]: https://github.com/bitcoindevkit/bdk-ffi/compare/v0.28.0...v0.29.0
 [v0.28.0]: https://github.com/bitcoindevkit/bdk-ffi/compare/v0.27.1...v0.28.0
 [v0.27.1]: https://github.com/bitcoindevkit/bdk-ffi/compare/v0.26.0...v0.27.1

--- a/bdk-android/gradle.properties
+++ b/bdk-android/gradle.properties
@@ -2,4 +2,4 @@ org.gradle.jvmargs=-Xmx1536m
 android.useAndroidX=true
 android.enableJetifier=true
 kotlin.code.style=official
-libraryVersion=0.30.0-SNAPSHOT
+libraryVersion=0.31.0-SNAPSHOT

--- a/bdk-jvm/gradle.properties
+++ b/bdk-jvm/gradle.properties
@@ -1,4 +1,4 @@
 org.gradle.jvmargs=-Xmx1536m
 android.enableJetifier=true
 kotlin.code.style=official
-libraryVersion=0.30.0-SNAPSHOT
+libraryVersion=0.31.0-SNAPSHOT

--- a/bdk-python/setup.py
+++ b/bdk-python/setup.py
@@ -51,7 +51,7 @@ print(f"Wallet balance is: {balance.total}")
 
 setup(
     name="bdkpython",
-    version="0.30.0.dev0",
+    version="0.31.0.dev0",
     description="The Python language bindings for the Bitcoin Development Kit",
     long_description=LONG_DESCRIPTION,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
This PR does three things:
1. Bump the development versions of bdk-android, bdk-jvm, and bdk-python.
2. Update the changelog.
3. Update the release_minor_version workflow.