### PR TITLE
fix: handle parsing and network errors in address new

### DIFF
--- a/bdk-ffi/src/bitcoin.rs
+++ b/bdk-ffi/src/bitcoin.rs
@@ -74,12 +74,16 @@ pub struct Address {
 
 impl Address {
     pub fn new(address: String, network: Network) -> Result<Self, BdkError> {
+        let parsed_address = address
+            .parse::<bdk::bitcoin::Address<NetworkUnchecked>>()
+            .map_err(|e| BdkError::Generic(e.to_string()))?;
+
+        let network_checked_address = parsed_address
+            .require_network(network.into())
+            .map_err(|e| BdkError::Generic(e.to_string()))?;
+
         Ok(Address {
-            inner: address
-                .parse::<bdk::bitcoin::Address<NetworkUnchecked>>()
-                .unwrap() // TODO 11: Handle error correctly by rethrowing it as a BdkError
-                .require_network(network.into())
-                .map_err(|e| BdkError::Generic(e.to_string()))?,
+            inner: network_checked_address,
         })
     }
 


### PR DESCRIPTION
<!-- Erase any parts of this template not applicable to your Pull Request. -->

### Description

Fixes "TODO 11".

Instead of panicking if the parsing fails, handle the error by propagating; avoids panicking and allows the caller of Address::new to handle the BdkError as necessary.

### Notes to the reviewers

Already using the ? operator so it seemed more idiomatic to continue with this style (instead of `match`), but open to changing this if needed.

### Changelog notice

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
