### PR TITLE
Add broadcast method on Esplora client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,7 @@ bdk.kt
 
 # Swift related
 /.build
-/.swiftpm
+.swiftpm
 /Packages
 /*.xcodeproj
 xcuserdata/

--- a/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/LiveWalletTest.kt
+++ b/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/LiveWalletTest.kt
@@ -3,6 +3,7 @@ package org.bitcoindevkit
 import org.junit.Test
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.runner.RunWith
+import kotlin.test.assertTrue
 
 @RunWith(AndroidJUnit4::class)
 class LiveWalletTest {
@@ -19,5 +20,39 @@ class LiveWalletTest {
         println("Balance: $balance")
 
         assert(wallet.getBalance().total() > 0uL)
+    }
+
+    @Test
+    fun testBroadcastTransaction() {
+        val descriptor = Descriptor("wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/0/*)", Network.TESTNET)
+        val wallet = Wallet.newNoPersist(descriptor, null, Network.TESTNET)
+        val esploraClient = EsploraClient("https://mempool.space/testnet/api")
+        val update = esploraClient.scan(wallet, 10uL, 1uL)
+
+        wallet.applyUpdate(update)
+        println("Balance: ${wallet.getBalance().total()}")
+        println("New address: ${wallet.getAddress(AddressIndex.New).address}")
+
+        assert(wallet.getBalance().total() > 0uL) {
+            "Wallet balance must be greater than 0! Please send funds to ${wallet.getAddress(AddressIndex.New).address} and try again."
+        }
+
+        val recipient: Address = Address("tb1qrnfslnrve9uncz9pzpvf83k3ukz22ljgees989", Network.TESTNET)
+
+        val psbt: PartiallySignedTransaction = TxBuilder()
+            .addRecipient(recipient.scriptPubkey(), 4200uL)
+            .feeRate(4.0f)
+            .finish(wallet)
+
+        println(psbt.serialize())
+        assertTrue(psbt.serialize().startsWith("cHNi"), "PSBT should start with 'cHNi'")
+
+        val walletDidSign = wallet.sign(psbt)
+        assertTrue(walletDidSign)
+
+        val tx: Transaction = psbt.extractTx()
+
+        println("Txid is: ${tx.txid()}")
+        esploraClient.broadcast(tx)
     }
 }

--- a/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/LiveWalletTest.kt
+++ b/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/LiveWalletTest.kt
@@ -15,6 +15,8 @@ class LiveWalletTest {
         val update = esploraClient.scan(wallet, 10uL, 1uL)
         wallet.applyUpdate(update)
         println("Balance: ${wallet.getBalance().total()}")
+        val balance: Balance = wallet.getBalance()
+        println("Balance: $balance")
 
         assert(wallet.getBalance().total() > 0uL)
     }

--- a/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/OfflineDescriptorTest.kt
+++ b/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/OfflineDescriptorTest.kt
@@ -1,6 +1,7 @@
 package org.bitcoindevkit
 
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.runner.RunWith
 import kotlin.test.assertEquals

--- a/bdk-ffi/src/bdk.udl
+++ b/bdk-ffi/src/bdk.udl
@@ -221,6 +221,9 @@ interface EsploraClient {
 
   [Throws=BdkError]
   Update scan(Wallet wallet, u64 stop_gap, u64 parallel_requests);
+
+  [Throws=BdkError]
+  void broadcast(Transaction transaction);
 };
 
 // ------------------------------------------------------------------------

--- a/bdk-ffi/src/bdk.udl
+++ b/bdk-ffi/src/bdk.udl
@@ -43,6 +43,12 @@ enum BdkError {
   "Psbt",
 };
 
+enum ChangeSpendPolicy {
+  "ChangeAllowed",
+  "OnlyChange",
+  "ChangeForbidden"
+};
+
 interface Balance {
   u64 immature();
 
@@ -95,7 +101,23 @@ interface TxBuilder {
 
   TxBuilder add_recipient(Script script, u64 amount);
 
+  TxBuilder set_recipients(sequence<ScriptAmount> script_amount);
+
+  TxBuilder add_unspendable(OutPoint unspendable);
+
+  TxBuilder add_utxo(OutPoint outpoint);
+
+  TxBuilder change_policy(ChangeSpendPolicy change_policy);
+
+  TxBuilder do_not_spend_change();
+
+  TxBuilder only_spend_change();
+
+  TxBuilder manually_selected_only();
+
   TxBuilder fee_rate(float sat_per_vbyte);
+
+  TxBuilder drain_wallet();
 
   [Throws=BdkError]
   PartiallySignedTransaction finish([ByRef] Wallet wallet);
@@ -199,6 +221,15 @@ interface EsploraClient {
 };
 
 // ------------------------------------------------------------------------
+// bdk-ffi-defined types
+// ------------------------------------------------------------------------
+
+dictionary ScriptAmount {
+  Script script;
+  u64 amount;
+};
+
+// ------------------------------------------------------------------------
 // bdk crate - bitcoin re-exports
 // ------------------------------------------------------------------------
 
@@ -262,4 +293,9 @@ interface PartiallySignedTransaction {
   string serialize();
 
   Transaction extract_tx();
+};
+
+dictionary OutPoint {
+  string txid;
+  u32 vout;
 };

--- a/bdk-ffi/src/bdk.udl
+++ b/bdk-ffi/src/bdk.udl
@@ -92,6 +92,9 @@ interface Wallet {
 
   [Throws=BdkError]
   void apply_update(Update update);
+
+  [Throws=BdkError]
+  boolean sign(PartiallySignedTransaction psbt);
 };
 
 interface Update {};

--- a/bdk-ffi/src/bitcoin.rs
+++ b/bdk-ffi/src/bitcoin.rs
@@ -4,7 +4,9 @@ use bdk::bitcoin::consensus::Decodable;
 use bdk::bitcoin::network::constants::Network as BdkNetwork;
 use bdk::bitcoin::psbt::PartiallySignedTransaction as BdkPartiallySignedTransaction;
 use bdk::bitcoin::Address as BdkAddress;
+use bdk::bitcoin::OutPoint as BdkOutPoint;
 use bdk::bitcoin::Transaction as BdkTransaction;
+use bdk::bitcoin::Txid;
 use bdk::Error as BdkError;
 
 use std::io::Cursor;
@@ -280,6 +282,24 @@ impl From<BdkPartiallySignedTransaction> for PartiallySignedTransaction {
     fn from(psbt: BdkPartiallySignedTransaction) -> Self {
         PartiallySignedTransaction {
             inner: Mutex::new(psbt),
+        }
+    }
+}
+
+/// A reference to a transaction output.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct OutPoint {
+    /// The referenced transaction's txid.
+    pub txid: String,
+    /// The index of the referenced output in its transaction's vout.
+    pub vout: u32,
+}
+
+impl From<&OutPoint> for BdkOutPoint {
+    fn from(outpoint: &OutPoint) -> Self {
+        BdkOutPoint {
+            txid: Txid::from_str(&outpoint.txid).unwrap(),
+            vout: outpoint.vout,
         }
     }
 }

--- a/bdk-ffi/src/bitcoin.rs
+++ b/bdk-ffi/src/bitcoin.rs
@@ -209,6 +209,12 @@ impl From<BdkTransaction> for Transaction {
     }
 }
 
+impl From<Transaction> for BdkTransaction {
+    fn from(tx: Transaction) -> Self {
+        tx.inner
+    }
+}
+
 pub struct PartiallySignedTransaction {
     pub(crate) inner: Mutex<BdkPartiallySignedTransaction>,
 }

--- a/bdk-ffi/src/esplora.rs
+++ b/bdk-ffi/src/esplora.rs
@@ -1,4 +1,5 @@
 use crate::wallet::{Update, Wallet};
+use std::ops::Deref;
 
 use bdk::wallet::Update as BdkUpdate;
 use bdk::Error as BdkError;
@@ -56,7 +57,12 @@ impl EsploraClient {
 
     // pub fn sync();
 
-    // pub fn broadcast();
+    pub fn broadcast(&self, transaction: Arc<crate::bitcoin::Transaction>) -> Result<(), BdkError> {
+        let bdk_transaction: bdk::bitcoin::Transaction = transaction.deref().clone().into();
+        self.0
+            .broadcast(&bdk_transaction)
+            .map_err(|e| BdkError::Generic(e.to_string()))
+    }
 
     // pub fn estimate_fee();
 }

--- a/bdk-ffi/src/lib.rs
+++ b/bdk-ffi/src/lib.rs
@@ -7,6 +7,7 @@ mod wallet;
 // TODO 6: Why are these imports required?
 use crate::bitcoin::Address;
 use crate::bitcoin::Network;
+use crate::bitcoin::OutPoint;
 use crate::bitcoin::PartiallySignedTransaction;
 use crate::bitcoin::Script;
 use crate::bitcoin::Transaction;
@@ -21,6 +22,7 @@ use crate::wallet::Update;
 use crate::wallet::Wallet;
 
 use bdk::keys::bip39::WordCount;
+use bdk::wallet::tx_builder::ChangeSpendPolicy;
 use bdk::wallet::AddressIndex as BdkAddressIndex;
 use bdk::wallet::AddressInfo as BdkAddressInfo;
 use bdk::wallet::Balance as BdkBalance;
@@ -32,10 +34,10 @@ use std::sync::Arc;
 uniffi::include_scaffolding!("bdk");
 
 /// A output script and an amount of satoshis.
-// pub struct ScriptAmount {
-//     pub script: Arc<Script>,
-//     pub amount: u64,
-// }
+pub struct ScriptAmount {
+    pub script: Arc<Script>,
+    pub amount: u64,
+}
 
 /// A derived address and the index it was found at.
 pub struct AddressInfo {

--- a/bdk-ffi/src/wallet.rs
+++ b/bdk-ffi/src/wallet.rs
@@ -7,8 +7,8 @@ use std::collections::HashSet;
 use bdk::bitcoin::blockdata::script::ScriptBuf as BdkScriptBuf;
 use bdk::bitcoin::OutPoint as BdkOutPoint;
 use bdk::wallet::Update as BdkUpdate;
-use bdk::{SignOptions, Wallet as BdkWallet};
 use bdk::{Error as BdkError, FeeRate};
+use bdk::{SignOptions, Wallet as BdkWallet};
 
 use bdk::wallet::tx_builder::ChangeSpendPolicy;
 use std::sync::{Arc, Mutex, MutexGuard};
@@ -88,10 +88,9 @@ impl Wallet {
         // sign_options: Option<SignOptions>,
     ) -> Result<bool, BdkError> {
         let mut psbt = psbt.inner.lock().unwrap();
-        self.get_wallet().sign(
-            &mut psbt,
-            SignOptions::default(),
-        ).map_err(|e| BdkError::Generic(e.to_string()))
+        self.get_wallet()
+            .sign(&mut psbt, SignOptions::default())
+            .map_err(|e| BdkError::Generic(e.to_string()))
     }
 }
 

--- a/bdk-jvm/lib/src/test/kotlin/org/bitcoindevkit/LiveWalletTest.kt
+++ b/bdk-jvm/lib/src/test/kotlin/org/bitcoindevkit/LiveWalletTest.kt
@@ -1,6 +1,7 @@
 package org.bitcoindevkit
 
 import kotlin.test.Test
+import kotlin.test.assertTrue
 
 class LiveWalletTest {
     @Test
@@ -14,5 +15,39 @@ class LiveWalletTest {
         println("Balance: ${wallet.getBalance().total()}")
 
         assert(wallet.getBalance().total() > 0uL)
+    }
+
+    @Test
+    fun testBroadcastTransaction() {
+        val descriptor = Descriptor("wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/0/*)", Network.TESTNET)
+        val wallet = Wallet.newNoPersist(descriptor, null, Network.TESTNET)
+        val esploraClient = EsploraClient("https://mempool.space/testnet/api")
+        val update = esploraClient.scan(wallet, 10uL, 1uL)
+
+        wallet.applyUpdate(update)
+        println("Balance: ${wallet.getBalance().total()}")
+        println("New address: ${wallet.getAddress(AddressIndex.New).address.asString()}")
+
+        assert(wallet.getBalance().total() > 0uL) {
+            "Wallet balance must be greater than 0! Please send funds to ${wallet.getAddress(AddressIndex.New).address} and try again."
+        }
+
+        val recipient: Address = Address("tb1qrnfslnrve9uncz9pzpvf83k3ukz22ljgees989", Network.TESTNET)
+
+        val psbt: PartiallySignedTransaction = TxBuilder()
+            .addRecipient(recipient.scriptPubkey(), 4200uL)
+            .feeRate(2.0f)
+            .finish(wallet)
+
+        println(psbt.serialize())
+        assertTrue(psbt.serialize().startsWith("cHNi"), "PSBT should start with 'cHNi'")
+
+        val walletDidSign = wallet.sign(psbt)
+        assertTrue(walletDidSign)
+
+        val tx: Transaction = psbt.extractTx()
+
+        println("Txid is: ${tx.txid()}")
+        esploraClient.broadcast(tx)
     }
 }

--- a/bdk-python/tests/test_live_wallet.py
+++ b/bdk-python/tests/test_live_wallet.py
@@ -23,6 +23,41 @@ class TestLiveWallet(unittest.TestCase):
 
         self.assertGreater(wallet.get_balance().total(), 0)
 
+    def test_broadcast_transaction(self):
+        descriptor: bdk.Descriptor = bdk.Descriptor(
+            "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/0/*)",
+            bdk.Network.TESTNET
+        )
+        wallet: bdk.Wallet = bdk.Wallet.new_no_persist(
+            descriptor,
+            None,
+            bdk.Network.TESTNET
+        )
+        esploraClient: bdk.EsploraClient = bdk.EsploraClient(url = "https://mempool.space/testnet/api")
+        update = esploraClient.scan(
+            wallet = wallet,
+            stop_gap = 10,
+            parallel_requests = 1
+        )
+        wallet.apply_update(update)
+
+        self.assertGreater(wallet.get_balance().total(), 0)
+
+        recipient = bdk.Address(
+            address = "tb1qrnfslnrve9uncz9pzpvf83k3ukz22ljgees989",
+            network = bdk.Network.TESTNET
+        )
+
+        psbt = bdk.TxBuilder().add_recipient(script=recipient.script_pubkey(), amount=4200).fee_rate(2.0).finish(wallet)
+        # print(psbt.serialize())
+        self.assertTrue(psbt.serialize().startswith("cHNi"), "The PSBT should start with cHNi")
+
+        walletDidSign = wallet.sign(psbt)
+        self.assertTrue(walletDidSign)
+        tx = psbt.extract_tx()
+        
+        esploraClient.broadcast(tx)
+    
     
 if __name__ == '__main__':
     unittest.main()

--- a/bdk-swift/Tests/BitcoinDevKitTests/LiveTxBuilderTests.swift
+++ b/bdk-swift/Tests/BitcoinDevKitTests/LiveTxBuilderTests.swift
@@ -4,7 +4,7 @@ import XCTest
 final class LiveTxBuilderTests: XCTestCase {
     func testTxBuilder() throws {
         let descriptor = try Descriptor(
-            descriptor: "wpkh([c258d2e4/84h/1h/0h]tpubDDYkZojQFQjht8Tm4jsS3iuEmKjTiEGjG6KnuFNKKJb5A6ZUCUZKdvLdSDWofKi4ToRCwb9poe1XdqfUnP4jaJjCB2Zwv11ZLgSbnZSNecE/0/*)",
+            descriptor: "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/0/*)",
             network: Network.testnet
         )
         let wallet = try Wallet.newNoPersist(

--- a/bdk-swift/Tests/BitcoinDevKitTests/LiveWalletTests.swift
+++ b/bdk-swift/Tests/BitcoinDevKitTests/LiveWalletTests.swift
@@ -4,7 +4,7 @@ import XCTest
 final class LiveWalletTests: XCTestCase {
     func testSyncedBalance() throws {
         let descriptor = try Descriptor(
-            descriptor: "wpkh([c258d2e4/84h/1h/0h]tpubDDYkZojQFQjht8Tm4jsS3iuEmKjTiEGjG6KnuFNKKJb5A6ZUCUZKdvLdSDWofKi4ToRCwb9poe1XdqfUnP4jaJjCB2Zwv11ZLgSbnZSNecE/0/*)",
+            descriptor: "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/0/*)",
             network: Network.testnet
         )
         let wallet = try Wallet.newNoPersist(
@@ -21,5 +21,45 @@ final class LiveWalletTests: XCTestCase {
         try wallet.applyUpdate(update: update)
 
         XCTAssertGreaterThan(wallet.getBalance().total(), UInt64(0))
+    }
+    
+    func testBroadcastTransaction() throws {
+        let descriptor = try Descriptor(
+            descriptor: "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/0/*)",
+            network: Network.testnet
+        )
+        let wallet = try Wallet.newNoPersist(
+            descriptor: descriptor,
+            changeDescriptor: nil,
+            network: .testnet
+        )
+        let esploraClient = EsploraClient(url: "https://mempool.space/testnet/api")
+        let update = try esploraClient.scan(
+            wallet: wallet,
+            stopGap: 10,
+            parallelRequests: 1
+        )
+        try wallet.applyUpdate(update: update)
+
+        XCTAssertGreaterThan(wallet.getBalance().total(), UInt64(0), "Wallet must have positive balance, please add funds")
+        
+        print("Balance: \(wallet.getBalance().total())")
+
+        let recipient: Address = try Address(address: "tb1qrnfslnrve9uncz9pzpvf83k3ukz22ljgees989", network: .testnet)
+        let psbt: PartiallySignedTransaction = try
+            TxBuilder()
+                .addRecipient(script: recipient.scriptPubkey(), amount: 4200)
+                .feeRate(satPerVbyte: 2.0)
+                .finish(wallet: wallet)
+
+        print(psbt.serialize())
+        XCTAssertTrue(psbt.serialize().hasPrefix("cHNi"), "PSBT should start with cHNI")
+        
+        let walletDidSign: Bool = try wallet.sign(psbt: psbt)
+        XCTAssertTrue(walletDidSign, "Wallet did not sign transaction")
+        
+        let tx: Transaction = psbt.extractTx()
+        print(tx.txid())
+        try esploraClient.broadcast(transaction: tx)
     }
 }


### PR DESCRIPTION
This PR adds the `broadcast()` method on the blocking Esplora client with accompanying tests. I think together with the work of the past few weeks this completes a nice bundle ready for a release. Sync, balance, build a tx, sign.

### Checklists

#### All Submissions:
* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:
* [x] I've added tests for the new feature
