### PR TITLE
Add sent_and_received method on Wallet

### DIFF
--- a/bdk-ffi/src/bdk.udl
+++ b/bdk-ffi/src/bdk.udl
@@ -107,6 +107,8 @@ interface Wallet {
 
   [Throws=BdkError]
   boolean sign(PartiallySignedTransaction psbt);
+
+  SentAndReceivedValues sent_and_received([ByRef] Transaction tx);
 };
 
 interface Update {};
@@ -245,6 +247,11 @@ interface EsploraClient {
 dictionary ScriptAmount {
   Script script;
   u64 amount;
+};
+
+dictionary SentAndReceivedValues {
+    u64 sent;
+    u64 received;
 };
 
 // ------------------------------------------------------------------------

--- a/bdk-ffi/src/lib.rs
+++ b/bdk-ffi/src/lib.rs
@@ -23,6 +23,7 @@ use crate::types::AddressInfo;
 use crate::types::Balance;
 use crate::types::LocalUtxo;
 use crate::types::ScriptAmount;
+use crate::wallet::SentAndReceivedValues;
 use crate::wallet::TxBuilder;
 use crate::wallet::Update;
 use crate::wallet::Wallet;

--- a/bdk-ffi/src/wallet.rs
+++ b/bdk-ffi/src/wallet.rs
@@ -1,4 +1,4 @@
-use crate::bitcoin::{OutPoint, PartiallySignedTransaction};
+use crate::bitcoin::{OutPoint, PartiallySignedTransaction, Transaction};
 use crate::descriptor::Descriptor;
 use crate::types::Balance;
 use crate::types::ScriptAmount;
@@ -93,6 +93,16 @@ impl Wallet {
             .sign(&mut psbt, SignOptions::default())
             .map_err(|e| BdkError::Generic(e.to_string()))
     }
+
+    pub fn sent_and_received(&self, tx: &Transaction) -> SentAndReceivedValues {
+        let (sent, received): (u64, u64) = self.get_wallet().sent_and_received(&tx.clone().into());
+        SentAndReceivedValues { sent, received }
+    }
+}
+
+pub struct SentAndReceivedValues {
+    pub sent: u64,
+    pub received: u64,
 }
 
 pub struct Update(pub(crate) BdkUpdate);


### PR DESCRIPTION
<!-- Erase any parts of this template not applicable to your Pull Request. -->

### Description

Adds the functionality for [sent_and_received](https://docs.rs/bdk/1.0.0-alpha.2/bdk/wallet/struct.Wallet.html#method.sent_and_received)

`sent_and_received` was a new method added in [BDK](https://github.com/bitcoindevkit/bdk/pull/1048).

Computes total input value going from script pubkeys in the wallet (sent) and the total output value going to script pubkeys in the wallet (received) in the tx passed into the function.

For _sent_ the function needs historical information about the outputs being spent (which are assumed to be indexed), while for _received_ it can rely solely on the tx's outputs without needing prior indexing of spent outputs.

### Notes to the reviewers

At the moment I decided to not add a code comment above the `sent_and_received` function in the `wallet.rs` file; my thinking was I would like to add a code comment similar to what is in the BDK documentation, but since the BDK documentation is still evolving I wouldn't want to add a code comment in bdk-ffi now but never get back around to updating it as the BDK documentation changes, and thus have a misleading code comment in the future.

### Changelog notice

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
