### PR TITLE
Use Byref in udl instead of Arc in Rust code when possible

### DIFF
--- a/bdk-ffi/src/bdk.udl
+++ b/bdk-ffi/src/bdk.udl
@@ -100,7 +100,7 @@ interface Wallet {
 
   Balance get_balance();
 
-  boolean is_mine(Script script);
+  boolean is_mine([ByRef] Script script);
 
   [Throws=BdkError]
   void apply_update(Update update);
@@ -118,7 +118,7 @@ interface Update {};
 interface TxBuilder {
   constructor();
 
-  TxBuilder add_recipient(Script script, u64 amount);
+  TxBuilder add_recipient([ByRef] Script script, u64 amount);
 
   TxBuilder set_recipients(sequence<ScriptAmount> recipients);
 
@@ -142,7 +142,7 @@ interface TxBuilder {
 
   TxBuilder drain_wallet();
 
-  TxBuilder drain_to(Script script);
+  TxBuilder drain_to([ByRef] Script script);
 
   TxBuilder enable_rbf();
 
@@ -187,16 +187,16 @@ interface DerivationPath {
 };
 
 interface DescriptorSecretKey {
-  constructor(Network network, Mnemonic mnemonic, string? password);
+  constructor(Network network, [ByRef] Mnemonic mnemonic, string? password);
 
   [Name=from_string, Throws=BdkError]
   constructor(string secret_key);
 
   [Throws=BdkError]
-  DescriptorSecretKey derive(DerivationPath path);
+  DescriptorSecretKey derive([ByRef] DerivationPath path);
 
   [Throws=BdkError]
-  DescriptorSecretKey extend(DerivationPath path);
+  DescriptorSecretKey extend([ByRef] DerivationPath path);
 
   DescriptorPublicKey as_public();
 
@@ -210,10 +210,10 @@ interface DescriptorPublicKey {
   constructor(string public_key);
 
   [Throws=BdkError]
-  DescriptorPublicKey derive(DerivationPath path);
+  DescriptorPublicKey derive([ByRef] DerivationPath path);
 
   [Throws=BdkError]
-  DescriptorPublicKey extend(DerivationPath path);
+  DescriptorPublicKey extend([ByRef] DerivationPath path);
 
   string as_string();
 };
@@ -223,28 +223,28 @@ interface Descriptor {
   constructor(string descriptor, Network network);
 
   [Name=new_bip44]
-  constructor(DescriptorSecretKey secret_key, KeychainKind keychain, Network network);
+  constructor([ByRef] DescriptorSecretKey secret_key, KeychainKind keychain, Network network);
 
   [Name=new_bip44_public]
-  constructor(DescriptorPublicKey public_key, string fingerprint, KeychainKind keychain, Network network);
+  constructor([ByRef] DescriptorPublicKey public_key, string fingerprint, KeychainKind keychain, Network network);
 
   [Name=new_bip49]
-  constructor(DescriptorSecretKey secret_key, KeychainKind keychain, Network network);
+  constructor([ByRef] DescriptorSecretKey secret_key, KeychainKind keychain, Network network);
 
   [Name=new_bip49_public]
-  constructor(DescriptorPublicKey public_key, string fingerprint, KeychainKind keychain, Network network);
+  constructor([ByRef] DescriptorPublicKey public_key, string fingerprint, KeychainKind keychain, Network network);
 
   [Name=new_bip84]
-  constructor(DescriptorSecretKey secret_key, KeychainKind keychain, Network network);
+  constructor([ByRef] DescriptorSecretKey secret_key, KeychainKind keychain, Network network);
 
   [Name=new_bip84_public]
-  constructor(DescriptorPublicKey public_key, string fingerprint, KeychainKind keychain, Network network);
+  constructor([ByRef] DescriptorPublicKey public_key, string fingerprint, KeychainKind keychain, Network network);
 
   [Name=new_bip86]
-  constructor(DescriptorSecretKey secret_key, KeychainKind keychain, Network network);
+  constructor([ByRef] DescriptorSecretKey secret_key, KeychainKind keychain, Network network);
 
   [Name=new_bip86_public]
-  constructor(DescriptorPublicKey public_key, string fingerprint, KeychainKind keychain, Network network);
+  constructor([ByRef] DescriptorPublicKey public_key, string fingerprint, KeychainKind keychain, Network network);
 
   string as_string();
 
@@ -262,7 +262,7 @@ interface EsploraClient {
   Update scan(Wallet wallet, u64 stop_gap, u64 parallel_requests);
 
   [Throws=BdkError]
-  void broadcast(Transaction transaction);
+  void broadcast([ByRef] Transaction transaction);
 };
 
 // ------------------------------------------------------------------------

--- a/bdk-ffi/src/descriptor.rs
+++ b/bdk-ffi/src/descriptor.rs
@@ -15,7 +15,6 @@ use bdk::Error as BdkError;
 use bdk::KeychainKind;
 
 use std::str::FromStr;
-use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct Descriptor {
@@ -35,7 +34,7 @@ impl Descriptor {
     }
 
     pub(crate) fn new_bip44(
-        secret_key: Arc<DescriptorSecretKey>,
+        secret_key: &DescriptorSecretKey,
         keychain_kind: KeychainKind,
         network: Network,
     ) -> Self {
@@ -62,7 +61,7 @@ impl Descriptor {
     }
 
     pub(crate) fn new_bip44_public(
-        public_key: Arc<DescriptorPublicKey>,
+        public_key: &DescriptorPublicKey,
         fingerprint: String,
         keychain_kind: KeychainKind,
         network: Network,
@@ -93,7 +92,7 @@ impl Descriptor {
     }
 
     pub(crate) fn new_bip49(
-        secret_key: Arc<DescriptorSecretKey>,
+        secret_key: &DescriptorSecretKey,
         keychain_kind: KeychainKind,
         network: Network,
     ) -> Self {
@@ -120,7 +119,7 @@ impl Descriptor {
     }
 
     pub(crate) fn new_bip49_public(
-        public_key: Arc<DescriptorPublicKey>,
+        public_key: &DescriptorPublicKey,
         fingerprint: String,
         keychain_kind: KeychainKind,
         network: Network,
@@ -151,7 +150,7 @@ impl Descriptor {
     }
 
     pub(crate) fn new_bip84(
-        secret_key: Arc<DescriptorSecretKey>,
+        secret_key: &DescriptorSecretKey,
         keychain_kind: KeychainKind,
         network: Network,
     ) -> Self {
@@ -178,7 +177,7 @@ impl Descriptor {
     }
 
     pub(crate) fn new_bip84_public(
-        public_key: Arc<DescriptorPublicKey>,
+        public_key: &DescriptorPublicKey,
         fingerprint: String,
         keychain_kind: KeychainKind,
         network: Network,
@@ -209,7 +208,7 @@ impl Descriptor {
     }
 
     pub(crate) fn new_bip86(
-        secret_key: Arc<DescriptorSecretKey>,
+        secret_key: &DescriptorSecretKey,
         keychain_kind: KeychainKind,
         network: Network,
     ) -> Self {
@@ -236,7 +235,7 @@ impl Descriptor {
     }
 
     pub(crate) fn new_bip86_public(
-        public_key: Arc<DescriptorPublicKey>,
+        public_key: &DescriptorPublicKey,
         fingerprint: String,
         keychain_kind: KeychainKind,
         network: Network,
@@ -288,83 +287,73 @@ mod test {
     use bdk::descriptor::DescriptorError::Key;
     use bdk::keys::KeyError::InvalidNetwork;
 
-    use std::sync::Arc;
-
     fn get_descriptor_secret_key() -> DescriptorSecretKey {
         let mnemonic = Mnemonic::from_string("chaos fabric time speed sponsor all flat solution wisdom trophy crack object robot pave observe combine where aware bench orient secret primary cable detect".to_string()).unwrap();
-        DescriptorSecretKey::new(Network::Testnet, Arc::new(mnemonic), None)
+        DescriptorSecretKey::new(Network::Testnet, &mnemonic, None)
     }
 
     #[test]
     fn test_descriptor_templates() {
-        let master: Arc<DescriptorSecretKey> = Arc::new(get_descriptor_secret_key());
+        let master: DescriptorSecretKey = get_descriptor_secret_key();
         println!("Master: {:?}", master.as_string());
         // tprv8ZgxMBicQKsPdWuqM1t1CDRvQtQuBPyfL6GbhQwtxDKgUAVPbxmj71pRA8raTqLrec5LyTs5TqCxdABcZr77bt2KyWA5bizJHnC4g4ysm4h
         let handmade_public_44 = master
-            .derive(Arc::new(
-                DerivationPath::new("m/44h/1h/0h".to_string()).unwrap(),
-            ))
+            .derive(&DerivationPath::new("m/44h/1h/0h".to_string()).unwrap())
             .unwrap()
             .as_public();
         println!("Public 44: {}", handmade_public_44.as_string());
         // Public 44: [d1d04177/44'/1'/0']tpubDCoPjomfTqh1e7o1WgGpQtARWtkueXQAepTeNpWiitS3Sdv8RKJ1yvTrGHcwjDXp2SKyMrTEca4LoN7gEUiGCWboyWe2rz99Kf4jK4m2Zmx/*
         let handmade_public_49 = master
-            .derive(Arc::new(
-                DerivationPath::new("m/49h/1h/0h".to_string()).unwrap(),
-            ))
+            .derive(&DerivationPath::new("m/49h/1h/0h".to_string()).unwrap())
             .unwrap()
             .as_public();
         println!("Public 49: {}", handmade_public_49.as_string());
         // Public 49: [d1d04177/49'/1'/0']tpubDC65ZRvk1NDddHrVAUAZrUPJ772QXzooNYmPywYF9tMyNLYKf5wpKE7ZJvK9kvfG3FV7rCsHBNXy1LVKW95jrmC7c7z4hq7a27aD2sRrAhR/*
         let handmade_public_84 = master
-            .derive(Arc::new(
-                DerivationPath::new("m/84h/1h/0h".to_string()).unwrap(),
-            ))
+            .derive(&DerivationPath::new("m/84h/1h/0h".to_string()).unwrap())
             .unwrap()
             .as_public();
         println!("Public 84: {}", handmade_public_84.as_string());
         // Public 84: [d1d04177/84'/1'/0']tpubDDNxbq17egjFk2edjv8oLnzxk52zny9aAYNv9CMqTzA4mQDiQq818sEkNe9Gzmd4QU8558zftqbfoVBDQorG3E4Wq26tB2JeE4KUoahLkx6/*
         let handmade_public_86 = master
-            .derive(Arc::new(
-                DerivationPath::new("m/86h/1h/0h".to_string()).unwrap(),
-            ))
+            .derive(&DerivationPath::new("m/86h/1h/0h".to_string()).unwrap())
             .unwrap()
             .as_public();
         println!("Public 86: {}", handmade_public_86.as_string());
         // Public 86: [d1d04177/86'/1'/0']tpubDCJzjbcGbdEfXMWaL6QmgVmuSfXkrue7m2YNoacWwyc7a2XjXaKojRqNEbo41CFL3PyYmKdhwg2fkGpLX4SQCbQjCGxAkWHJTw9WEeenrJb/*
         let template_private_44 =
-            Descriptor::new_bip44(master.clone(), KeychainKind::External, Network::Testnet);
+            Descriptor::new_bip44(&master, KeychainKind::External, Network::Testnet);
         let template_private_49 =
-            Descriptor::new_bip49(master.clone(), KeychainKind::External, Network::Testnet);
+            Descriptor::new_bip49(&master, KeychainKind::External, Network::Testnet);
         let template_private_84 =
-            Descriptor::new_bip84(master.clone(), KeychainKind::External, Network::Testnet);
+            Descriptor::new_bip84(&master, KeychainKind::External, Network::Testnet);
         let template_private_86 =
-            Descriptor::new_bip86(master, KeychainKind::External, Network::Testnet);
+            Descriptor::new_bip86(&master, KeychainKind::External, Network::Testnet);
         // the extended public keys are the same when creating them manually as they are with the templates
         println!("Template 49: {}", template_private_49.as_string());
         println!("Template 44: {}", template_private_44.as_string());
         println!("Template 84: {}", template_private_84.as_string());
         println!("Template 86: {}", template_private_86.as_string());
         let template_public_44 = Descriptor::new_bip44_public(
-            handmade_public_44,
+            &handmade_public_44,
             "d1d04177".to_string(),
             KeychainKind::External,
             Network::Testnet,
         );
         let template_public_49 = Descriptor::new_bip49_public(
-            handmade_public_49,
+            &handmade_public_49,
             "d1d04177".to_string(),
             KeychainKind::External,
             Network::Testnet,
         );
         let template_public_84 = Descriptor::new_bip84_public(
-            handmade_public_84,
+            &handmade_public_84,
             "d1d04177".to_string(),
             KeychainKind::External,
             Network::Testnet,
         );
         let template_public_86 = Descriptor::new_bip86_public(
-            handmade_public_86,
+            &handmade_public_86,
             "d1d04177".to_string(),
             KeychainKind::External,
             Network::Testnet,

--- a/bdk-ffi/src/esplora.rs
+++ b/bdk-ffi/src/esplora.rs
@@ -1,11 +1,12 @@
 use crate::wallet::{Update, Wallet};
-use std::ops::Deref;
 
+use bdk::bitcoin::Transaction as BdkTransaction;
 use bdk::wallet::Update as BdkUpdate;
 use bdk::Error as BdkError;
 use bdk_esplora::esplora_client::{BlockingClient, Builder};
 use bdk_esplora::EsploraExt;
 
+use crate::bitcoin::Transaction;
 use std::sync::Arc;
 
 pub struct EsploraClient(BlockingClient);
@@ -57,8 +58,8 @@ impl EsploraClient {
 
     // pub fn sync();
 
-    pub fn broadcast(&self, transaction: Arc<crate::bitcoin::Transaction>) -> Result<(), BdkError> {
-        let bdk_transaction: bdk::bitcoin::Transaction = transaction.deref().clone().into();
+    pub fn broadcast(&self, transaction: &Transaction) -> Result<(), BdkError> {
+        let bdk_transaction: BdkTransaction = transaction.clone().into();
         self.0
             .broadcast(&bdk_transaction)
             .map_err(|e| BdkError::Generic(e.to_string()))

--- a/bdk-ffi/src/keys.rs
+++ b/bdk-ffi/src/keys.rs
@@ -79,7 +79,7 @@ pub struct DescriptorSecretKey {
 }
 
 impl DescriptorSecretKey {
-    pub(crate) fn new(network: Network, mnemonic: Arc<Mnemonic>, password: Option<String>) -> Self {
+    pub(crate) fn new(network: Network, mnemonic: &Mnemonic, password: Option<String>) -> Self {
         let mnemonic = mnemonic.inner.clone();
         let xkey: ExtendedKey = (mnemonic, password).into_extended_key().unwrap();
         let descriptor_secret_key = BdkDescriptorSecretKey::XPrv(DescriptorXKey {
@@ -101,7 +101,7 @@ impl DescriptorSecretKey {
         })
     }
 
-    pub(crate) fn derive(&self, path: Arc<DerivationPath>) -> Result<Arc<Self>, BdkError> {
+    pub(crate) fn derive(&self, path: &DerivationPath) -> Result<Arc<Self>, BdkError> {
         let secp = Secp256k1::new();
         let descriptor_secret_key = &self.inner;
         let path = path.inner_mutex.lock().unwrap().deref().clone();
@@ -131,7 +131,7 @@ impl DescriptorSecretKey {
         }
     }
 
-    pub(crate) fn extend(&self, path: Arc<DerivationPath>) -> Result<Arc<Self>, BdkError> {
+    pub(crate) fn extend(&self, path: &DerivationPath) -> Result<Arc<Self>, BdkError> {
         let descriptor_secret_key = &self.inner;
         let path = path.inner_mutex.lock().unwrap().deref().clone();
         match descriptor_secret_key {
@@ -201,7 +201,7 @@ impl DescriptorPublicKey {
         })
     }
 
-    pub(crate) fn derive(&self, path: Arc<DerivationPath>) -> Result<Arc<Self>, BdkError> {
+    pub(crate) fn derive(&self, path: &DerivationPath) -> Result<Arc<Self>, BdkError> {
         let secp = Secp256k1::new();
         let descriptor_public_key = &self.inner;
         let path = path.inner_mutex.lock().unwrap().deref().clone();
@@ -232,7 +232,7 @@ impl DescriptorPublicKey {
         }
     }
 
-    pub(crate) fn extend(&self, path: Arc<DerivationPath>) -> Result<Arc<Self>, BdkError> {
+    pub(crate) fn extend(&self, path: &DerivationPath) -> Result<Arc<Self>, BdkError> {
         let descriptor_public_key = &self.inner;
         let path = path.inner_mutex.lock().unwrap().deref().clone();
         match descriptor_public_key {
@@ -261,7 +261,7 @@ impl DescriptorPublicKey {
         self.inner.to_string()
     }
 }
-//
+
 // // The goal of these tests to to ensure `bdk-ffi` intermediate code correctly calls `bdk` APIs.
 // // These tests should not be used to verify `bdk` behavior that is already tested in the `bdk`
 // // crate.
@@ -275,39 +275,39 @@ mod test {
 
     fn get_inner() -> DescriptorSecretKey {
         let mnemonic = Mnemonic::from_string("chaos fabric time speed sponsor all flat solution wisdom trophy crack object robot pave observe combine where aware bench orient secret primary cable detect".to_string()).unwrap();
-        DescriptorSecretKey::new(Network::Testnet.into(), Arc::new(mnemonic), None)
+        DescriptorSecretKey::new(Network::Testnet.into(), &mnemonic, None)
     }
 
     fn derive_dsk(
         key: &DescriptorSecretKey,
         path: &str,
     ) -> Result<Arc<DescriptorSecretKey>, BdkError> {
-        let path = Arc::new(DerivationPath::new(path.to_string()).unwrap());
-        key.derive(path)
+        let path = DerivationPath::new(path.to_string()).unwrap();
+        key.derive(&path)
     }
 
     fn extend_dsk(
         key: &DescriptorSecretKey,
         path: &str,
     ) -> Result<Arc<DescriptorSecretKey>, BdkError> {
-        let path = Arc::new(DerivationPath::new(path.to_string()).unwrap());
-        key.extend(path)
+        let path = DerivationPath::new(path.to_string()).unwrap();
+        key.extend(&path)
     }
 
     fn derive_dpk(
         key: &DescriptorPublicKey,
         path: &str,
     ) -> Result<Arc<DescriptorPublicKey>, BdkError> {
-        let path = Arc::new(DerivationPath::new(path.to_string()).unwrap());
-        key.derive(path)
+        let path = DerivationPath::new(path.to_string()).unwrap();
+        key.derive(&path)
     }
 
     fn extend_dpk(
         key: &DescriptorPublicKey,
         path: &str,
     ) -> Result<Arc<DescriptorPublicKey>, BdkError> {
-        let path = Arc::new(DerivationPath::new(path.to_string()).unwrap());
-        key.extend(path)
+        let path = DerivationPath::new(path.to_string()).unwrap();
+        key.extend(&path)
     }
 
     #[test]
@@ -347,7 +347,7 @@ mod test {
         assert_eq!(extended_dpk.as_string(), "tpubD6NzVbkrYhZ4WywdEfYbbd62yuvqLjAZuPsNyvzCNV85JekAEMbKHWSHLF9h3j45SxewXDcLv328B1SEZrxg4iwGfmdt1pDFjZiTkGiFqGa/0/*");
         let wif = "L2wTu6hQrnDMiFNWA5na6jB12ErGQqtXwqpSL7aWquJaZG8Ai3ch";
         let extended_key = DescriptorSecretKey::from_string(wif.to_string()).unwrap();
-        let result = extended_key.derive(Arc::new(DerivationPath::new("m/0".to_string()).unwrap()));
+        let result = extended_key.derive(&DerivationPath::new("m/0".to_string()).unwrap());
         dbg!(&result);
         assert!(result.is_err());
     }

--- a/bdk-ffi/src/wallet.rs
+++ b/bdk-ffi/src/wallet.rs
@@ -70,7 +70,7 @@ impl Wallet {
             .map_err(|e| BdkError::Generic(e.to_string()))
     }
 
-    pub fn is_mine(&self, script: Arc<Script>) -> bool {
+    pub fn is_mine(&self, script: &Script) -> bool {
         // TODO: Both of the following lines work. Which is better?
         self.get_wallet().is_mine(&script.0)
         // self.get_wallet().is_mine(script.0.clone().as_script())
@@ -332,7 +332,7 @@ impl TxBuilder {
     }
 
     /// Add a recipient to the internal list.
-    pub(crate) fn add_recipient(&self, script: Arc<Script>, amount: u64) -> Arc<Self> {
+    pub(crate) fn add_recipient(&self, script: &Script, amount: u64) -> Arc<Self> {
         let mut recipients: Vec<(BdkScriptBuf, u64)> = self.recipients.clone();
         recipients.append(&mut vec![(script.0.clone(), amount)]);
 
@@ -455,7 +455,7 @@ impl TxBuilder {
     /// either provide the utxos that the transaction should spend via add_utxos, or set drain_wallet to spend all of them.
     /// When bumping the fees of a transaction made with this option, you probably want to use BumpFeeTxBuilder.allow_shrinking
     /// to allow this output to be reduced to pay for the extra fees.
-    pub(crate) fn drain_to(&self, script: Arc<Script>) -> Arc<Self> {
+    pub(crate) fn drain_to(&self, script: &Script) -> Arc<Self> {
         Arc::new(TxBuilder {
             drain_to: Some(script.0.clone()),
             ..self.clone()


### PR DESCRIPTION
This PR refactors the codebase to use the [ByRef] declaration in the udl file instead of `Arc`s in the Rust code where arguments are passed that can be borrowed values.

Closes #433

All tests pass locally, including the Rust tests which required a bit of fixing.