### PR TITLE
Fix: rename esplora scan to full_scan

### DIFF
--- a/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/LiveTxBuilderTest.kt
+++ b/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/LiveTxBuilderTest.kt
@@ -12,7 +12,7 @@ class LiveTxBuilderTest {
         val descriptor = Descriptor("wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/0/*)", Network.TESTNET)
         val wallet = Wallet.newNoPersist(descriptor, null, Network.TESTNET)
         val esploraClient = EsploraClient("https://mempool.space/testnet/api")
-        val update = esploraClient.scan(wallet, 10uL, 1uL)
+        val update = esploraClient.fullScan(wallet, 10uL, 1uL)
         wallet.applyUpdate(update)
         println("Balance: ${wallet.getBalance().total}")
 
@@ -34,7 +34,7 @@ class LiveTxBuilderTest {
         val changeDescriptor = Descriptor("wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/1/*)", Network.TESTNET)
         val wallet = Wallet.newNoPersist(externalDescriptor, changeDescriptor, Network.TESTNET)
         val esploraClient = EsploraClient("https://mempool.space/testnet/api")
-        val update = esploraClient.scan(wallet, 10uL, 1uL)
+        val update = esploraClient.fullScan(wallet, 10uL, 1uL)
         wallet.applyUpdate(update)
         println("Balance: ${wallet.getBalance().total}")
 

--- a/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/LiveWalletTest.kt
+++ b/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/LiveWalletTest.kt
@@ -12,7 +12,7 @@ class LiveWalletTest {
         val descriptor: Descriptor = Descriptor("wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/0/*)", Network.TESTNET)
         val wallet: Wallet = Wallet.newNoPersist(descriptor, null, Network.TESTNET)
         val esploraClient: EsploraClient = EsploraClient("https://mempool.space/testnet/api")
-        val update = esploraClient.scan(wallet, 10uL, 1uL)
+        val update = esploraClient.fullScan(wallet, 10uL, 1uL)
         wallet.applyUpdate(update)
         println("Balance: ${wallet.getBalance().total}")
         val balance: Balance = wallet.getBalance()
@@ -35,7 +35,7 @@ class LiveWalletTest {
         val descriptor = Descriptor("wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/0/*)", Network.TESTNET)
         val wallet = Wallet.newNoPersist(descriptor, null, Network.TESTNET)
         val esploraClient = EsploraClient("https://mempool.space/testnet/api")
-        val update = esploraClient.scan(wallet, 10uL, 1uL)
+        val update = esploraClient.fullScan(wallet, 10uL, 1uL)
 
         wallet.applyUpdate(update)
         println("Balance: ${wallet.getBalance().total}")

--- a/bdk-ffi/Cargo.toml
+++ b/bdk-ffi/Cargo.toml
@@ -19,6 +19,7 @@ default = ["uniffi/cli"]
 
 [dependencies]
 bdk = { version = "1.0.0-alpha.3", features = ["all-keys", "keys-bip39"] }
+bdk_esplora = { version = "0.5.0", default-features = false, features = ["std", "blocking"] }
 
 # TODO 22: The bdk_esplora crate uses esplora_client which uses reqwest for async. By default it uses the system
 #          openssl library, which is creating problems for cross-compilation. I'd rather use rustls, but it's hidden
@@ -28,7 +29,6 @@ bdk = { version = "1.0.0-alpha.3", features = ["all-keys", "keys-bip39"] }
 # bdk = { git = "https://github.com/thunderbiscuit/bdk.git", branch = "test-rust-tls", version = "1.0.0-alpha.2", features = ["all-keys", "keys-bip39"] }
 # bdk_esplora = { git = "https://github.com/thunderbiscuit/bdk.git", branch = "test-rust-tls", version = "0.4.0", package = "bdk_esplora", default-features = false, features = ["std", "blocking", "async-https-rustls"] }
 
-bdk_esplora = { version = "0.5.0", default-features = false, features = ["std", "blocking"] }
 uniffi = { version = "=0.25.1" }
 
 [build-dependencies]

--- a/bdk-ffi/src/bdk.udl
+++ b/bdk-ffi/src/bdk.udl
@@ -255,7 +255,7 @@ interface EsploraClient {
   constructor(string url);
 
   [Throws=Alpha3Error]
-  Update scan(Wallet wallet, u64 stop_gap, u64 parallel_requests);
+  Update full_scan(Wallet wallet, u64 stop_gap, u64 parallel_requests);
 
   [Throws=Alpha3Error]
   void broadcast([ByRef] Transaction transaction);

--- a/bdk-ffi/src/esplora.rs
+++ b/bdk-ffi/src/esplora.rs
@@ -19,7 +19,7 @@ impl EsploraClient {
 
     // This is a temporary solution for scanning. The long-term solution involves not passing
     // the wallet to the client at all.
-    pub fn scan(
+    pub fn full_scan(
         &self,
         wallet: Arc<Wallet>,
         stop_gap: u64,

--- a/bdk-jvm/lib/src/test/kotlin/org/bitcoindevkit/LiveTxBuilderTest.kt
+++ b/bdk-jvm/lib/src/test/kotlin/org/bitcoindevkit/LiveTxBuilderTest.kt
@@ -9,7 +9,7 @@ class LiveTxBuilderTest {
         val descriptor = Descriptor("wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/0/*)", Network.TESTNET)
         val wallet = Wallet.newNoPersist(descriptor, null, Network.TESTNET)
         val esploraClient = EsploraClient("https://mempool.space/testnet/api")
-        val update = esploraClient.scan(wallet, 10uL, 1uL)
+        val update = esploraClient.fullScan(wallet, 10uL, 1uL)
         wallet.applyUpdate(update)
         println("Balance: ${wallet.getBalance().total}")
 
@@ -32,7 +32,7 @@ class LiveTxBuilderTest {
         val changeDescriptor = Descriptor("wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/1/*)", Network.TESTNET)
         val wallet = Wallet.newNoPersist(externalDescriptor, changeDescriptor, Network.TESTNET)
         val esploraClient = EsploraClient("https://mempool.space/testnet/api")
-        val update = esploraClient.scan(wallet, 10uL, 1uL)
+        val update = esploraClient.fullScan(wallet, 10uL, 1uL)
         wallet.applyUpdate(update)
         println("Balance: ${wallet.getBalance().total}")
 

--- a/bdk-jvm/lib/src/test/kotlin/org/bitcoindevkit/LiveWalletTest.kt
+++ b/bdk-jvm/lib/src/test/kotlin/org/bitcoindevkit/LiveWalletTest.kt
@@ -10,7 +10,7 @@ class LiveWalletTest {
         val wallet: Wallet = Wallet.newNoPersist(descriptor, null, Network.TESTNET)
         val esploraClient: EsploraClient = EsploraClient("https://mempool.space/testnet/api")
         // val esploraClient = EsploraClient("https://blockstream.info/testnet/api")
-        val update = esploraClient.scan(wallet, 10uL, 1uL)
+        val update = esploraClient.fullScan(wallet, 10uL, 1uL)
         wallet.applyUpdate(update)
         println("Balance: ${wallet.getBalance().total}")
 
@@ -31,7 +31,7 @@ class LiveWalletTest {
         val descriptor = Descriptor("wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/0/*)", Network.TESTNET)
         val wallet = Wallet.newNoPersist(descriptor, null, Network.TESTNET)
         val esploraClient = EsploraClient("https://mempool.space/testnet/api")
-        val update = esploraClient.scan(wallet, 10uL, 1uL)
+        val update = esploraClient.fullScan(wallet, 10uL, 1uL)
 
         wallet.applyUpdate(update)
         println("Balance: ${wallet.getBalance().total}")

--- a/bdk-python/tests/test_live_tx_builder.py
+++ b/bdk-python/tests/test_live_tx_builder.py
@@ -14,7 +14,7 @@ class TestLiveTxBuilder(unittest.TestCase):
             bdk.Network.TESTNET
         )
         esploraClient: bdk.EsploraClient = bdk.EsploraClient(url = "https://mempool.space/testnet/api")
-        update = esploraClient.scan(
+        update = esploraClient.full_scan(
             wallet = wallet,
             stop_gap = 10,
             parallel_requests = 1
@@ -48,7 +48,7 @@ class TestLiveTxBuilder(unittest.TestCase):
             bdk.Network.TESTNET
         )
         esploraClient: bdk.EsploraClient = bdk.EsploraClient(url = "https://mempool.space/testnet/api")
-        update = esploraClient.scan(
+        update = esploraClient.full_scan(
             wallet = wallet,
             stop_gap = 10,
             parallel_requests = 1

--- a/bdk-python/tests/test_live_wallet.py
+++ b/bdk-python/tests/test_live_wallet.py
@@ -14,7 +14,7 @@ class TestLiveWallet(unittest.TestCase):
             bdk.Network.TESTNET
         )
         esploraClient: bdk.EsploraClient = bdk.EsploraClient(url = "https://mempool.space/testnet/api")
-        update = esploraClient.scan(
+        update = esploraClient.full_scan(
             wallet = wallet,
             stop_gap = 10,
             parallel_requests = 1
@@ -43,7 +43,7 @@ class TestLiveWallet(unittest.TestCase):
             bdk.Network.TESTNET
         )
         esploraClient: bdk.EsploraClient = bdk.EsploraClient(url = "https://mempool.space/testnet/api")
-        update = esploraClient.scan(
+        update = esploraClient.full_scan(
             wallet = wallet,
             stop_gap = 10,
             parallel_requests = 1

--- a/bdk-swift/Tests/BitcoinDevKitTests/LiveTxBuilderTests.swift
+++ b/bdk-swift/Tests/BitcoinDevKitTests/LiveTxBuilderTests.swift
@@ -13,7 +13,7 @@ final class LiveTxBuilderTests: XCTestCase {
             network: .testnet
         )
         let esploraClient = EsploraClient(url: "https://mempool.space/testnet/api")
-        let update = try esploraClient.scan(
+        let update = try esploraClient.fullScan(
             wallet: wallet,
             stopGap: 10,
             parallelRequests: 1
@@ -47,7 +47,7 @@ final class LiveTxBuilderTests: XCTestCase {
             network: .testnet
         )
         let esploraClient = EsploraClient(url: "https://mempool.space/testnet/api")
-        let update = try esploraClient.scan(
+        let update = try esploraClient.fullScan(
             wallet: wallet,
             stopGap: 10,
             parallelRequests: 1

--- a/bdk-swift/Tests/BitcoinDevKitTests/LiveWalletTests.swift
+++ b/bdk-swift/Tests/BitcoinDevKitTests/LiveWalletTests.swift
@@ -13,7 +13,7 @@ final class LiveWalletTests: XCTestCase {
             network: .testnet
         )
         let esploraClient = EsploraClient(url: "https://mempool.space/testnet/api")
-        let update = try esploraClient.scan(
+        let update = try esploraClient.fullScan(
             wallet: wallet,
             stopGap: 10,
             parallelRequests: 1
@@ -43,7 +43,7 @@ final class LiveWalletTests: XCTestCase {
             network: .testnet
         )
         let esploraClient = EsploraClient(url: "https://mempool.space/testnet/api")
-        let update = try esploraClient.scan(
+        let update = try esploraClient.fullScan(
             wallet: wallet,
             stopGap: 10,
             parallelRequests: 1


### PR DESCRIPTION
This should have been applied on the move to alpha 3. It renames the scan method on the Esplora client to full_scan, as per the latest esplora crate version (0.5.0).

### Notes to the reviewers

Sorry I missed it on my last PR!

### Changelog notice
```txt
Changed
  - The scan method on the Esplora client is renamed to full_scan [#442]

[#442]: https://github.com/bitcoindevkit/bdk-ffi/pull/442
```

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [x] I've added tests for the new feature
