### PR TITLE
feat: use FeeRate type in TxBuilder

### DIFF
--- a/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/LiveTxBuilderTest.kt
+++ b/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/LiveTxBuilderTest.kt
@@ -21,7 +21,7 @@ class LiveTxBuilderTest {
         val recipient: Address = Address("tb1qrnfslnrve9uncz9pzpvf83k3ukz22ljgees989", Network.TESTNET)
         val psbt: PartiallySignedTransaction = TxBuilder()
             .addRecipient(recipient.scriptPubkey(), 4200uL)
-            .feeRate(2.0f)
+            .feeRate(FeeRate.fromSatPerVb(2.0f))
             .finish(wallet)
 
         println(psbt.serialize())
@@ -49,7 +49,7 @@ class LiveTxBuilderTest {
 
         val psbt: PartiallySignedTransaction = TxBuilder()
             .setRecipients(allRecipients)
-            .feeRate(4.0f)
+            .feeRate(FeeRate.fromSatPerVb(4.0f))
             .changePolicy(ChangeSpendPolicy.CHANGE_FORBIDDEN)
             .enableRbf()
             .finish(wallet)

--- a/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/LiveWalletTest.kt
+++ b/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/LiveWalletTest.kt
@@ -49,7 +49,7 @@ class LiveWalletTest {
 
         val psbt: PartiallySignedTransaction = TxBuilder()
             .addRecipient(recipient.scriptPubkey(), 4200uL)
-            .feeRate(4.0f)
+            .feeRate(FeeRate.fromSatPerVb(4.0f))
             .finish(wallet)
 
         println(psbt.serialize())

--- a/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/OfflineDescriptorTest.kt
+++ b/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/OfflineDescriptorTest.kt
@@ -4,7 +4,6 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.runner.RunWith
-import kotlin.test.assertEquals
 
 @RunWith(AndroidJUnit4::class)
 class OfflineDescriptorTest {

--- a/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/OfflineWalletTest.kt
+++ b/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/OfflineWalletTest.kt
@@ -3,6 +3,7 @@ package org.bitcoindevkit
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
+import kotlin.test.assertFalse
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.runner.RunWith
 

--- a/bdk-ffi/src/bdk.udl
+++ b/bdk-ffi/src/bdk.udl
@@ -68,7 +68,14 @@ dictionary TxOut {
 // ------------------------------------------------------------------------
 
 interface FeeRate {
+  [Name=from_sat_per_vb]
+  constructor(f32 sat_per_vb);
+
+  [Name=from_sat_per_kwu]
+  constructor(f32 sat_per_kwu);
+
   f32 as_sat_per_vb();
+
   f32 sat_per_kwu();
 };
 
@@ -132,7 +139,7 @@ interface TxBuilder {
 
   TxBuilder manually_selected_only();
 
-  TxBuilder fee_rate(float sat_per_vbyte);
+  TxBuilder fee_rate([ByRef] FeeRate fee_rate);
 
   TxBuilder fee_absolute(u64 fee);
 

--- a/bdk-ffi/src/types.rs
+++ b/bdk-ffi/src/types.rs
@@ -11,9 +11,18 @@ use bdk::FeeRate as BdkFeeRate;
 
 use std::sync::Arc;
 
+#[derive(Clone, Debug)]
 pub struct FeeRate(pub BdkFeeRate);
 
 impl FeeRate {
+    pub fn from_sat_per_vb(sat_per_vb: f32) -> Self {
+        FeeRate(BdkFeeRate::from_sat_per_vb(sat_per_vb))
+    }
+
+    pub fn from_sat_per_kwu(sat_per_kwu: f32) -> Self {
+        FeeRate(BdkFeeRate::from_sat_per_kwu(sat_per_kwu))
+    }
+
     pub fn as_sat_per_vb(&self) -> f32 {
         self.0.as_sat_per_vb()
     }

--- a/bdk-ffi/src/wallet.rs
+++ b/bdk-ffi/src/wallet.rs
@@ -309,7 +309,7 @@ pub struct TxBuilder {
     pub(crate) unspendable: HashSet<OutPoint>,
     pub(crate) change_policy: ChangeSpendPolicy,
     pub(crate) manually_selected_only: bool,
-    pub(crate) fee_rate: Option<f32>,
+    pub(crate) fee_rate: Option<FeeRate>,
     pub(crate) fee_absolute: Option<u64>,
     pub(crate) drain_wallet: bool,
     pub(crate) drain_to: Option<BdkScriptBuf>,
@@ -412,9 +412,9 @@ impl TxBuilder {
         })
     }
 
-    pub(crate) fn fee_rate(&self, sat_per_vb: f32) -> Arc<Self> {
+    pub(crate) fn fee_rate(&self, fee_rate: &FeeRate) -> Arc<Self> {
         Arc::new(TxBuilder {
-            fee_rate: Some(sat_per_vb),
+            fee_rate: Some(fee_rate.clone()),
             ..self.clone()
         })
     }
@@ -486,8 +486,8 @@ impl TxBuilder {
         if self.manually_selected_only {
             tx_builder.manually_selected_only();
         }
-        if let Some(sat_per_vb) = self.fee_rate {
-            tx_builder.fee_rate(BdkFeeRate::from_sat_per_vb(sat_per_vb));
+        if let Some(fee_rate) = &self.fee_rate {
+            tx_builder.fee_rate(fee_rate.0);
         }
         if let Some(fee_amount) = self.fee_absolute {
             tx_builder.fee_absolute(fee_amount);

--- a/bdk-jvm/lib/src/test/kotlin/org/bitcoindevkit/LiveTxBuilderTest.kt
+++ b/bdk-jvm/lib/src/test/kotlin/org/bitcoindevkit/LiveTxBuilderTest.kt
@@ -18,7 +18,7 @@ class LiveTxBuilderTest {
         val recipient: Address = Address("tb1qrnfslnrve9uncz9pzpvf83k3ukz22ljgees989", Network.TESTNET)
         val psbt: PartiallySignedTransaction = TxBuilder()
             .addRecipient(recipient.scriptPubkey(), 4200uL)
-            .feeRate(2.0f)
+            .feeRate(FeeRate.fromSatPerVb(2.0f))
             .finish(wallet)
 
         println(psbt.serialize())
@@ -47,7 +47,7 @@ class LiveTxBuilderTest {
 
         val psbt: PartiallySignedTransaction = TxBuilder()
             .setRecipients(allRecipients)
-            .feeRate(4.0f)
+            .feeRate(FeeRate.fromSatPerVb(4.0f))
             .changePolicy(ChangeSpendPolicy.CHANGE_FORBIDDEN)
             .enableRbf()
             .finish(wallet)

--- a/bdk-jvm/lib/src/test/kotlin/org/bitcoindevkit/LiveWalletTest.kt
+++ b/bdk-jvm/lib/src/test/kotlin/org/bitcoindevkit/LiveWalletTest.kt
@@ -45,7 +45,7 @@ class LiveWalletTest {
 
         val psbt: PartiallySignedTransaction = TxBuilder()
             .addRecipient(recipient.scriptPubkey(), 4200uL)
-            .feeRate(2.0f)
+            .feeRate(FeeRate.fromSatPerVb(2.0f))
             .finish(wallet)
 
         println(psbt.serialize())

--- a/bdk-python/tests/test_live_tx_builder.py
+++ b/bdk-python/tests/test_live_tx_builder.py
@@ -28,7 +28,7 @@ class TestLiveTxBuilder(unittest.TestCase):
             network = bdk.Network.TESTNET
         )
 
-        psbt = bdk.TxBuilder().add_recipient(script=recipient.script_pubkey(), amount=4200).fee_rate(2.0).finish(wallet)
+        psbt = bdk.TxBuilder().add_recipient(script=recipient.script_pubkey(), amount=4200).fee_rate(fee_rate=bdk.FeeRate.from_sat_per_vb(2.0)).finish(wallet)
         # print(psbt.serialize())
         
         self.assertTrue(psbt.serialize().startswith("cHNi"), "The PSBT should start with cHNi")
@@ -70,7 +70,7 @@ class TestLiveTxBuilder(unittest.TestCase):
             bdk.ScriptAmount(recipient2.script_pubkey, 4200)
         )
 
-        psbt: bdk.PartiallySignedTransaction = bdk.TxBuilder().set_recipients(all_recipients).fee_rate(4.0).change_policy(bdk.ChangeSpendPolicy.CHANGE_FORBIDDEN).enable_rbf().finish(wallet)
+        psbt: bdk.PartiallySignedTransaction = bdk.TxBuilder().add_recipient(script=recipient.script_pubkey(), amount=4200).fee_rate(fee_rate=bdk.FeeRate.from_sat_per_vb(2.0)).finish(wallet)
         wallet.sign(psbt)
 
         self.assertTrue(psbt.serialize().startswith("cHNi"), "The PSBT should start with cHNi")

--- a/bdk-python/tests/test_live_wallet.py
+++ b/bdk-python/tests/test_live_wallet.py
@@ -57,7 +57,7 @@ class TestLiveWallet(unittest.TestCase):
             network = bdk.Network.TESTNET
         )
 
-        psbt = bdk.TxBuilder().add_recipient(script=recipient.script_pubkey(), amount=4200).fee_rate(2.0).finish(wallet)
+        psbt = bdk.TxBuilder().add_recipient(script=recipient.script_pubkey(), amount=4200).fee_rate(fee_rate=bdk.FeeRate.from_sat_per_vb(2.0)).finish(wallet)
         # print(psbt.serialize())
         self.assertTrue(psbt.serialize().startswith("cHNi"), "The PSBT should start with cHNi")
 

--- a/bdk-swift/Tests/BitcoinDevKitTests/LiveTxBuilderTests.swift
+++ b/bdk-swift/Tests/BitcoinDevKitTests/LiveTxBuilderTests.swift
@@ -25,7 +25,7 @@ final class LiveTxBuilderTests: XCTestCase {
         let recipient: Address = try Address(address: "tb1qrnfslnrve9uncz9pzpvf83k3ukz22ljgees989", network: .testnet)
         let psbt: PartiallySignedTransaction = try TxBuilder()
             .addRecipient(script: recipient.scriptPubkey(), amount: 4200)
-            .feeRate(satPerVbyte: 2.0)
+            .feeRate(feeRate: FeeRate.fromSatPerVb(satPerVb: 2.0))
             .finish(wallet: wallet)
 
         print(psbt.serialize())
@@ -65,7 +65,7 @@ final class LiveTxBuilderTests: XCTestCase {
 
         let psbt: PartiallySignedTransaction = try TxBuilder()
             .setRecipients(recipients: allRecipients)
-            .feeRate(satPerVbyte: 4.0)
+            .feeRate(feeRate: FeeRate.fromSatPerVb(satPerVb: 4.0))
             .changePolicy(changePolicy: ChangeSpendPolicy.changeForbidden)
             .enableRbf()
             .finish(wallet: wallet)

--- a/bdk-swift/Tests/BitcoinDevKitTests/LiveWalletTests.swift
+++ b/bdk-swift/Tests/BitcoinDevKitTests/LiveWalletTests.swift
@@ -58,7 +58,7 @@ final class LiveWalletTests: XCTestCase {
         let psbt: PartiallySignedTransaction = try
             TxBuilder()
                 .addRecipient(script: recipient.scriptPubkey(), amount: 4200)
-                .feeRate(satPerVbyte: 2.0)
+                .feeRate(feeRate: FeeRate.fromSatPerVb(satPerVb: 2.0))
                 .finish(wallet: wallet)
 
         print(psbt.serialize())


### PR DESCRIPTION
<!-- Erase any parts of this template not applicable to your Pull Request. -->

### Description

Use new FeeRate type in TxBuilder per https://github.com/bitcoindevkit/bdk-ffi/pull/437#discussion_r1434450464 in https://github.com/bitcoindevkit/bdk-ffi/pull/437

"For another PR, but now that we have the FeeRate type, let's use it in the TxBuilder the same way it's used in Rust bdk."

### Notes to the reviewers

I think I've completed the requested changes via:
- Updated `wallet.rs` to use `FeeRate` type in `TxBuilder`
- Added `from_sat_per_vb` + `from_sat_per_kwu` for the ability to construct a `FeeRate`
- Updated tests across all 4 platforms (using the new `from_sat_per_vb`)

### Changelog notice

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [x] I'm linking the issue being fixed by this PR
