### PR TITLE
Add esplora error

### DIFF
--- a/bdk-ffi/src/bdk.udl
+++ b/bdk-ffi/src/bdk.udl
@@ -27,6 +27,21 @@ interface WalletCreationError {
   LoadedNetworkDoesNotMatch(Network expected, Network? got);
 };
 
+[Error]
+interface EsploraError {
+  Ureq(string error_message);
+  UreqTransport(string error_message);
+  Http(u16 status_code);
+  Io(string error_message);
+  NoHeader();
+  Parsing(string error_message);
+  BitcoinEncoding(string error_message);
+  Hex(string error_message);
+  TransactionNotFound();
+  HeaderHeightNotFound(u32 height);
+  HeaderHashNotFound();
+};
+
 // ------------------------------------------------------------------------
 // bdk crate - types module
 // ------------------------------------------------------------------------
@@ -274,7 +289,7 @@ interface Descriptor {
 interface EsploraClient {
   constructor(string url);
 
-  [Throws=Alpha3Error]
+  [Throws=EsploraError]
   Update full_scan(Wallet wallet, u64 stop_gap, u64 parallel_requests);
 
   [Throws=Alpha3Error]

--- a/bdk-ffi/src/lib.rs
+++ b/bdk-ffi/src/lib.rs
@@ -15,6 +15,7 @@ use crate::bitcoin::TxOut;
 use crate::descriptor::Descriptor;
 use crate::error::Alpha3Error;
 use crate::error::CalculateFeeError;
+use crate::error::EsploraError;
 use crate::esplora::EsploraClient;
 use crate::keys::DerivationPath;
 use crate::keys::DescriptorPublicKey;


### PR DESCRIPTION
<!-- Erase any parts of this template not applicable to your Pull Request. -->

### Description

Adding the esplora [error](https://docs.rs/esplora-client/0.6.0/esplora_client/enum.Error.html)

### Notes to the reviewers

Added `EsploraError` for blocking client and added unit tests for each case.

Updated `full_scan` to use `EsploraError` instead of generic `Alpha3Error`.

Notable items / open questions:
- My implementation of `EsploraError` and the associated data differs slightly from the esplora_client [Error](https://docs.rs/esplora-client/0.6.0/esplora_client/enum.Error.html)
- [esplora_client](https://docs.rs/esplora-client/0.6.0/esplora_client/index.html) blocking enables [ureq](https://docs.rs/ureq/2.7.1/x86_64-unknown-linux-gnu/ureq/index.html) but async enables [reqwest](https://docs.rs/reqwest/0.11.18/x86_64-unknown-linux-gnu/reqwest/index.html)

### Changelog notice

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [x] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
