### PR TITLE
Bump rust dependencies to alpha 6 versions

### DIFF
--- a/bdk-ffi/Cargo.lock
+++ b/bdk-ffi/Cargo.lock
@@ -138,9 +138,9 @@ dependencies = [
 
 [[package]]
 name = "bdk"
-version = "1.0.0-alpha.5"
+version = "1.0.0-alpha.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21101f7c9d9fb1c3ece2da4e351c5885b4a72ae9a623fd0f6a0791e62fb12ea5"
+checksum = "4d2d7e0429201a21a4fcd586995b8dd452a15d7c31e88a68a978441a1c17dc8f"
 dependencies = [
  "bdk_chain",
  "bip39",
@@ -165,9 +165,9 @@ dependencies = [
 
 [[package]]
 name = "bdk_chain"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbde024deaffc2ad0cf4e88b0bd84409fe03a16e39f579aa7161cff79f491b71"
+checksum = "861d328b7a29fe93e9244b48156a38d1a2e01be50153e77d936c299da5f6dcf7"
 dependencies = [
  "bitcoin",
  "miniscript",
@@ -176,9 +176,9 @@ dependencies = [
 
 [[package]]
 name = "bdk_esplora"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0208259118f26aaf6b598c8c6d89a2d03c6fa3dd97ebc29e4192e83e4ad4257"
+checksum = "d8d3b3f593d5fb57db374e14489dcd0da0ed6292c6d8989a1f2b381f1cbbc74b"
 dependencies = [
  "bdk_chain",
  "esplora-client",

--- a/bdk-ffi/Cargo.toml
+++ b/bdk-ffi/Cargo.toml
@@ -18,8 +18,8 @@ path = "uniffi-bindgen.rs"
 default = ["uniffi/cli"]
 
 [dependencies]
-bdk = { version = "1.0.0-alpha.5", features = ["all-keys", "keys-bip39"] }
-bdk_esplora = { version = "0.7.0", default-features = false, features = ["std", "blocking"] }
+bdk = { version = "1.0.0-alpha.6", features = ["all-keys", "keys-bip39"] }
+bdk_esplora = { version = "0.8.0", default-features = false, features = ["std", "blocking"] }
 
 # TODO 22: The bdk_esplora crate uses esplora_client which uses reqwest for async. By default it uses the system
 #          openssl library, which is creating problems for cross-compilation. I'd rather use rustls, but it's hidden


### PR DESCRIPTION
<!-- Erase any parts of this template not applicable to your Pull Request. -->

### Description

Bump rust dependencies to [alpha 6 versions](https://github.com/bitcoindevkit/bdk/releases/tag/v1.0.0-alpha.6)

### Notes to the reviewers

No breaking changes to existing codebase.



### Changelog notice

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
