### PR TITLE
Use walleterror for error handling in try_get_internal_address

### DIFF
--- a/bdk-ffi/src/bdk.udl
+++ b/bdk-ffi/src/bdk.udl
@@ -28,6 +28,11 @@ interface WalletCreationError {
 };
 
 [Error]
+interface PersistenceError {
+  Write(string e);
+};
+
+[Error]
 interface EsploraError {
   Ureq(string error_message);
   UreqTransport(string error_message);
@@ -118,7 +123,7 @@ interface Wallet {
 
   AddressInfo get_address(AddressIndex address_index);
 
-  [Throws=Alpha3Error]
+  [Throws=PersistenceError]
   AddressInfo try_get_internal_address(AddressIndex address_index);
 
   Network network();

--- a/bdk-ffi/src/lib.rs
+++ b/bdk-ffi/src/lib.rs
@@ -33,6 +33,7 @@ use crate::wallet::TxBuilder;
 use crate::wallet::Update;
 use crate::wallet::Wallet;
 
+use crate::error::PersistenceError;
 use crate::error::WalletCreationError;
 use bdk::bitcoin::Network;
 use bdk::keys::bip39::WordCount;

--- a/bdk-ffi/src/wallet.rs
+++ b/bdk-ffi/src/wallet.rs
@@ -1,6 +1,6 @@
 use crate::bitcoin::{OutPoint, PartiallySignedTransaction, Transaction};
 use crate::descriptor::Descriptor;
-use crate::error::{Alpha3Error, CalculateFeeError, WalletCreationError};
+use crate::error::{Alpha3Error, CalculateFeeError, PersistenceError, WalletCreationError};
 use crate::types::ScriptAmount;
 use crate::types::{Balance, FeeRate};
 use crate::Script;
@@ -67,13 +67,12 @@ impl Wallet {
     pub fn try_get_internal_address(
         &self,
         address_index: AddressIndex,
-    ) -> Result<AddressInfo, Alpha3Error> {
-        self.get_wallet()
-            .try_get_internal_address(address_index.into())
-            .map_or_else(
-                |_| Err(Alpha3Error::Generic),
-                |address_info| Ok(address_info.into()),
-            )
+    ) -> Result<AddressInfo, PersistenceError> {
+        let address_info = self
+            .get_wallet()
+            .try_get_internal_address(address_index.into())?
+            .into();
+        Ok(address_info)
     }
 
     pub fn network(&self) -> Network {


### PR DESCRIPTION
I've just been looking thru what functions we currently use (or I use in a sample iOS project) that have Alpha3Error so I can turn those into more specific errors.

<!-- Erase any parts of this template not applicable to your Pull Request. -->

### Description

Adds `PersistenceError` and replaces the use of `Alpha3Error` with `PersistenceError ` in the [try_get_internal_address](https://docs.rs/bdk/1.0.0-alpha.6/bdk/wallet/struct.Wallet.html#method.try_get_internal_address) function. 

I added a unit test for `PersistenceError` as well.

### Notes to the reviewers

### Changelog notice

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [x] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
