### PR TITLE
Fix live tests

### DIFF
--- a/bdk-swift/Tests/BitcoinDevKitTests/LiveTxBuilderTests.swift
+++ b/bdk-swift/Tests/BitcoinDevKitTests/LiveTxBuilderTests.swift
@@ -2,12 +2,22 @@ import XCTest
 @testable import BitcoinDevKit
 
 final class LiveTxBuilderTests: XCTestCase {
+    var dbFilePath: URL!
+
+    override func setUpWithError() throws {
+        super.setUp()
+        let fileManager = FileManager.default
+        let documentDirectory = fileManager.urls(for: .documentDirectory, in: .userDomainMask).first!
+        let uniqueDbFileName = "bdk_persistence_\(UUID().uuidString).db"
+        dbFilePath = documentDirectory.appendingPathComponent(uniqueDbFileName)
+
+        if fileManager.fileExists(atPath: dbFilePath.path) {
+            try fileManager.removeItem(at: dbFilePath)
+        }
+    }
+
     override func tearDownWithError() throws {
         let fileManager = FileManager.default
-        let dbFileName = "bdk_persistence.db"
-        let documentDirectory = fileManager.urls(for: .documentDirectory, in: .userDomainMask).first!
-        let dbFilePath: URL = documentDirectory.appendingPathComponent(dbFileName)
-
         if fileManager.fileExists(atPath: dbFilePath.path) {
             try fileManager.removeItem(at: dbFilePath)
         }
@@ -21,7 +31,7 @@ final class LiveTxBuilderTests: XCTestCase {
         let wallet = try Wallet(
             descriptor: descriptor,
             changeDescriptor: nil,
-            persistenceBackendPath: "bdk_persistence.db",
+            persistenceBackendPath: dbFilePath.path,
             network: .testnet
         )
         let esploraClient = EsploraClient(url: "https://esplora.testnet.kuutamo.cloud/")
@@ -56,7 +66,7 @@ final class LiveTxBuilderTests: XCTestCase {
         let wallet = try Wallet(
             descriptor: descriptor,
             changeDescriptor: changeDescriptor,
-            persistenceBackendPath: "bdk_persistence.db",
+            persistenceBackendPath: dbFilePath.path,
             network: .testnet
         )
         let esploraClient = EsploraClient(url: "https://esplora.testnet.kuutamo.cloud/")

--- a/bdk-swift/Tests/BitcoinDevKitTests/LiveWalletTests.swift
+++ b/bdk-swift/Tests/BitcoinDevKitTests/LiveWalletTests.swift
@@ -2,12 +2,22 @@ import XCTest
 @testable import BitcoinDevKit
 
 final class LiveWalletTests: XCTestCase {
+    var dbFilePath: URL!
+
+    override func setUpWithError() throws {
+        super.setUp()
+        let fileManager = FileManager.default
+        let documentDirectory = fileManager.urls(for: .documentDirectory, in: .userDomainMask).first!
+        let uniqueDbFileName = "bdk_persistence_\(UUID().uuidString).db"
+        dbFilePath = documentDirectory.appendingPathComponent(uniqueDbFileName)
+
+        if fileManager.fileExists(atPath: dbFilePath.path) {
+            try fileManager.removeItem(at: dbFilePath)
+        }
+    }
+
     override func tearDownWithError() throws {
         let fileManager = FileManager.default
-        let dbFileName = "bdk_persistence.db"
-        let documentDirectory = fileManager.urls(for: .documentDirectory, in: .userDomainMask).first!
-        let dbFilePath: URL = documentDirectory.appendingPathComponent(dbFileName)
-
         if fileManager.fileExists(atPath: dbFilePath.path) {
             try fileManager.removeItem(at: dbFilePath)
         }
@@ -21,7 +31,7 @@ final class LiveWalletTests: XCTestCase {
         let wallet = try Wallet(
             descriptor: descriptor,
             changeDescriptor: nil,
-            persistenceBackendPath: "bdk_persistence.db",
+            persistenceBackendPath: dbFilePath.path,
             network: .testnet
         )
         let esploraClient = EsploraClient(url: "https://esplora.testnet.kuutamo.cloud/")
@@ -52,7 +62,7 @@ final class LiveWalletTests: XCTestCase {
         let wallet = try Wallet(
             descriptor: descriptor,
             changeDescriptor: nil,
-            persistenceBackendPath: "bdk_persistence.db",
+            persistenceBackendPath: dbFilePath.path,
             network: .testnet
         )
         let esploraClient = EsploraClient(url: "https://esplora.testnet.kuutamo.cloud/")

--- a/bdk-swift/Tests/BitcoinDevKitTests/OfflineWalletTests.swift
+++ b/bdk-swift/Tests/BitcoinDevKitTests/OfflineWalletTests.swift
@@ -2,12 +2,22 @@ import XCTest
 @testable import BitcoinDevKit
 
 final class OfflineWalletTests: XCTestCase {
+    var dbFilePath: URL!
+
+    override func setUpWithError() throws {
+        super.setUp()
+        let fileManager = FileManager.default
+        let documentDirectory = fileManager.urls(for: .documentDirectory, in: .userDomainMask).first!
+        let uniqueDbFileName = "bdk_persistence_\(UUID().uuidString).db"
+        dbFilePath = documentDirectory.appendingPathComponent(uniqueDbFileName)
+
+        if fileManager.fileExists(atPath: dbFilePath.path) {
+            try fileManager.removeItem(at: dbFilePath)
+        }
+    }
+
     override func tearDownWithError() throws {
         let fileManager = FileManager.default
-        let dbFileName = "bdk_persistence.db"
-        let documentDirectory = fileManager.urls(for: .documentDirectory, in: .userDomainMask).first!
-        let dbFilePath: URL = documentDirectory.appendingPathComponent(dbFileName)
-
         if fileManager.fileExists(atPath: dbFilePath.path) {
             try fileManager.removeItem(at: dbFilePath)
         }
@@ -18,10 +28,10 @@ final class OfflineWalletTests: XCTestCase {
             descriptor: "wpkh([c258d2e4/84h/1h/0h]tpubDDYkZojQFQjht8Tm4jsS3iuEmKjTiEGjG6KnuFNKKJb5A6ZUCUZKdvLdSDWofKi4ToRCwb9poe1XdqfUnP4jaJjCB2Zwv11ZLgSbnZSNecE/0/*)",
             network: Network.testnet
         )
-        let wallet: Wallet = try Wallet(
+        let wallet = try Wallet(
             descriptor: descriptor,
             changeDescriptor: nil,
-            persistenceBackendPath: "bdk_persistence.db",
+            persistenceBackendPath: dbFilePath.path,
             network: .testnet
         )
         let addressInfo: AddressInfo = wallet.getAddress(addressIndex: AddressIndex.new)
@@ -43,10 +53,10 @@ final class OfflineWalletTests: XCTestCase {
             descriptor: "wpkh([c258d2e4/84h/1h/0h]tpubDDYkZojQFQjht8Tm4jsS3iuEmKjTiEGjG6KnuFNKKJb5A6ZUCUZKdvLdSDWofKi4ToRCwb9poe1XdqfUnP4jaJjCB2Zwv11ZLgSbnZSNecE/0/*)",
             network: Network.testnet
         )
-        let wallet: Wallet = try Wallet(
+        let wallet = try Wallet(
             descriptor: descriptor,
             changeDescriptor: nil,
-            persistenceBackendPath: "bdk_persistence.db",
+            persistenceBackendPath: dbFilePath.path,
             network: .testnet
         )
 


### PR DESCRIPTION
<!-- Erase any parts of this template not applicable to your Pull Request. -->

### Description

This PR addresses an issue encountered in our test suite where live tests were [failing](https://github.com/bitcoindevkit/bdk-ffi/actions/runs/8034434176).

I believe it was just due to shared state conflicts caused by multiple tests using the same database file (`bdk_persistence.db`). To resolve this I've implemented a strategy where each test case generates a unique database file for its execution. This should ensure test isolation and prevents conflicts that arise from shared database access.

### Notes to the reviewers

Each test case now generates a unique database file by appending a UUID to the `bdk_persistence` filename. This file is created in the `setUpWithError` method before each test runs.

The `tearDownWithError` method has been updated to delete the unique database file after each test completes. This ensures that no leftover state or data persists to affect subsequent tests and also helps manage filesystem usage by removing unnecessary files.

### Changelog notice

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Tests**
	- Enhanced setup and cleanup procedures in test files to improve reliability and maintain a clean test environment in BitcoinDevKit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->