### PR TITLE
(post-BDK1.0) Update bdk-swift framework info.plist for xcode 15.3 reqs

### DIFF
--- a/bdk-swift/bdkFFI.xcframework/Info.plist
+++ b/bdk-swift/bdkFFI.xcframework/Info.plist
@@ -16,6 +16,8 @@
 			</array>
 			<key>SupportedPlatform</key>
 			<string>macos</string>
+			<key>LSMinimumSystemVersion</key>
+    			<string>12.0</string>
 		</dict>
 		<dict>
 			<key>LibraryIdentifier</key>
@@ -31,6 +33,8 @@
 			<string>ios</string>
 			<key>SupportedPlatformVariant</key>
 			<string>simulator</string>
+			<key>MinimumOSVersion</key>
+    			<string>15.0</string>
 		</dict>
 		<dict>
 			<key>LibraryIdentifier</key>
@@ -43,6 +47,8 @@
 			</array>
 			<key>SupportedPlatform</key>
 			<string>ios</string>
+			<key>MinimumOSVersion</key>
+    			<string>15.0</string>
 		</dict>
 	</array>
 	<key>CFBundlePackageType</key>

--- a/bdk-swift/bdkFFI.xcframework/ios-arm64/bdkFFI.framework/Info.plist
+++ b/bdk-swift/bdkFFI.xcframework/ios-arm64/bdkFFI.framework/Info.plist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleIdentifier</key>
+    <string>com.bitcoindevkit.bdkFFI</string>
+    <key>CFBundleName</key>
+    <string>bdkFFI</string>
+    <key>CFBundleVersion</key>
+    <string>1.0.0</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0.0</string>
+    <key>CFBundleExecutable</key>
+    <string>bdkFFI</string>
+    <key>MinimumOSVersion</key>
+    <string>100</string>
+</dict>
+</plist>

--- a/bdk-swift/bdkFFI.xcframework/ios-arm64_x86_64-simulator/bdkFFI.framework/Info.plist
+++ b/bdk-swift/bdkFFI.xcframework/ios-arm64_x86_64-simulator/bdkFFI.framework/Info.plist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleIdentifier</key>
+    <string>com.bitcoindevkit.bdkFFI</string>
+    <key>CFBundleName</key>
+    <string>bdkFFI</string>
+    <key>CFBundleVersion</key>
+    <string>1.0.0</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0.0</string>
+    <key>CFBundleExecutable</key>
+    <string>bdkFFI</string>
+    <key>MinimumOSVersion</key>
+    <string>15.0</string>
+</dict>
+</plist>

--- a/bdk-swift/bdkFFI.xcframework/macos-arm64_x86_64/bdkFFI.framework/Info.plist
+++ b/bdk-swift/bdkFFI.xcframework/macos-arm64_x86_64/bdkFFI.framework/Info.plist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleIdentifier</key>
+    <string>com.bitcoindevkit.bdkFFI</string>
+    <key>CFBundleName</key>
+    <string>bdkFFI</string>
+    <key>CFBundleVersion</key>
+    <string>1.0.0</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0.0</string>
+    <key>CFBundleExecutable</key>
+    <string>bdkFFI</string>
+    <key>LSMinimumSystemVersion</key>
+    <string>12.0</string>
+</dict>
+</plist>


### PR DESCRIPTION
<!-- Erase any parts of this template not applicable to your Pull Request. -->

### Description

_Resolves #463 for post-BDK1.0_

Xcode 15.3 introduced a requirement that all `.framework` bundles must include an `Info.plist` file containing essential metadata, including a `CFBundleIdentifier`. This requirement led to an error when attempting to build projects using the `bdk-ffi/bdk-swift` framework, specifically reporting a missing CFBundleIdentifier in the Info.plist of the `bdkFFI.framework`.

#### Issue

The issue addressed in this update is the need for distinct `Info.plist` files within each `.framework` directory inside the `bdkFFI.xcframework`, diverging from the `.xcframework's` root `Info.plist`. The `.xcframework`'s root `Info.plist` is designed to describe the structure and contents of the `.xcframework` itself, including identifiers and paths for its constituent `.framework` bundles across different platforms and architectures.

However, each embedded `.framework` requires its own `Info.plist` that specifies essential metadata specific to that framework instance.

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Changelog notice

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated the minimum OS requirement to `12.0` for macOS, `15.0` for iOS simulator, and `15.0` for iOS supported platforms in the `bdkFFI` framework.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->