### PR TITLE
Bump bdk to alpha 7

### DIFF
--- a/bdk-ffi/Cargo.lock
+++ b/bdk-ffi/Cargo.lock
@@ -138,9 +138,9 @@ dependencies = [
 
 [[package]]
 name = "bdk"
-version = "1.0.0-alpha.6"
+version = "1.0.0-alpha.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d2d7e0429201a21a4fcd586995b8dd452a15d7c31e88a68a978441a1c17dc8f"
+checksum = "3898b68da1d179ec68acaaefe29b3ea952800ebf5809cad1e3a3cc5504ccc6d4"
 dependencies = [
  "bdk_chain",
  "bip39",
@@ -166,9 +166,9 @@ dependencies = [
 
 [[package]]
 name = "bdk_chain"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "861d328b7a29fe93e9244b48156a38d1a2e01be50153e77d936c299da5f6dcf7"
+checksum = "671bc4c278604f704987f649c20bd95b0c9bddf1880c75b2f9f12ad14979cd02"
 dependencies = [
  "bitcoin",
  "miniscript",
@@ -177,9 +177,9 @@ dependencies = [
 
 [[package]]
 name = "bdk_esplora"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8d3b3f593d5fb57db374e14489dcd0da0ed6292c6d8989a1f2b381f1cbbc74b"
+checksum = "a218fdf700ba98cf68f3b678af004b6770a04329bd1de4c0ce52382cecb2e0e9"
 dependencies = [
  "bdk_chain",
  "esplora-client",
@@ -187,9 +187,9 @@ dependencies = [
 
 [[package]]
 name = "bdk_file_store"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0eb85d94f0e03f63ad5c03425df5e830d52b56875bcc50c8c5e94347f7b03b9"
+checksum = "0efb7e3263bc937977d798a0a5f1c64467de5998380b8dc5003f5924b2af3398"
 dependencies = [
  "bdk_chain",
  "bincode",

--- a/bdk-ffi/Cargo.toml
+++ b/bdk-ffi/Cargo.toml
@@ -18,17 +18,10 @@ path = "uniffi-bindgen.rs"
 default = ["uniffi/cli"]
 
 [dependencies]
-bdk = { version = "1.0.0-alpha.6", features = ["all-keys", "keys-bip39"] }
-bdk_esplora = { version = "0.8.0", default-features = false, features = ["std", "blocking"] }
-bdk_file_store = { version = "0.6.0" }
-
-# TODO 22: The bdk_esplora crate uses esplora_client which uses reqwest for async. By default it uses the system
-#          openssl library, which is creating problems for cross-compilation. I'd rather use rustls, but it's hidden
-#          behind a feature flag. We need to look into whether openssl-sys is really required by bdk or if using rustls
-#          would work just as well. This here is a temporary workaround which removes the async feature on the bdk_esplora crate.
-#          See PR #1179 https://github.com/bitcoindevkit/bdk/pull/1179 for the fix in bdk.
-# bdk = { git = "https://github.com/thunderbiscuit/bdk.git", branch = "test-rust-tls", version = "1.0.0-alpha.2", features = ["all-keys", "keys-bip39"] }
-# bdk_esplora = { git = "https://github.com/thunderbiscuit/bdk.git", branch = "test-rust-tls", version = "0.4.0", package = "bdk_esplora", default-features = false, features = ["std", "blocking", "async-https-rustls"] }
+bdk = { version = "1.0.0-alpha.7", features = ["all-keys", "keys-bip39"] }
+bdk_esplora = { version = "0.9.0", default-features = false, features = ["std", "blocking"] }
+# bdk_esplora = { version = "0.9.0", default-features = false, features = ["std", "blocking", "async-https-rustls"] }
+bdk_file_store = { version = "0.7.0" }
 
 uniffi = { version = "=0.26.1" }
 


### PR DESCRIPTION
This PR:
1. Bumps the Rust bdk library to its latest version, alpha 7, the esplora client to 0.9.0, and the file store to 0.7.0.
~2. Finally closes a long-standing comment/issue where we could not use rustls for the async esplora client, preventing us from building for Android. The commit enabling the feature simply enables it, but does not build the async client itself.~ This is currently causing runtime issues. Will fix in a further PR.

### Notes to the reviewers
This bump was fairly simple.

### Checklists

#### All Submissions:
* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing