### PR TITLE
Use `thiserror` library to handle error creation

### DIFF
--- a/bdk-ffi/Cargo.lock
+++ b/bdk-ffi/Cargo.lock
@@ -161,6 +161,7 @@ dependencies = [
  "bdk",
  "bdk_esplora",
  "bdk_file_store",
+ "thiserror",
  "uniffi",
 ]
 
@@ -883,18 +884,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.56"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54378c645627613241d077a3a79db965db602882668f9136ac42af9ecb730ad"
+checksum = "03468839009160513471e86a034bb2c5c0e4baae3b43f79ffc55c4a5427b3297"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.56"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
+checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/bdk-ffi/Cargo.toml
+++ b/bdk-ffi/Cargo.toml
@@ -24,6 +24,7 @@ bdk_esplora = { version = "0.9.0", default-features = false, features = ["std", 
 bdk_file_store = { version = "0.7.0" }
 
 uniffi = { version = "=0.26.1" }
+thiserror = "1.0.58"
 
 [build-dependencies]
 uniffi = { version = "=0.26.1", features = ["build"] }


### PR DESCRIPTION
This PR pulls in the Rust `thiserror` library to simplify our error code. The Display trait is now auto-generated by macros, pulling the error message from the `#[error(message)]` line above the enum variant.

### Note to the reviewers
I changed the error messages slightly from what we had before by applying what I think is standard in the Rust ecosystem, lowercase messages without trailing punctuation, i.e. `negative fee value: {fee}`

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
