### PR TITLE
Enable using swift local build script from bdk-swift directory

### DIFF
--- a/.github/workflows/test-swift.yaml
+++ b/.github/workflows/test-swift.yaml
@@ -19,7 +19,8 @@ jobs:
         uses: actions/checkout@v3
 
       - name: "Build Swift package"
-        run: bash ./bdk-swift/build-local-swift.sh
+        working-directory: bdk-swift
+        run: bash ./build-local-swift.sh
 
       - name: "Run Swift tests"
         working-directory: bdk-swift

--- a/bdk-swift/build-local-swift.sh
+++ b/bdk-swift/build-local-swift.sh
@@ -3,18 +3,15 @@
 # The results of this script can be used for locally testing your SPM package adding a local package
 # to your application pointing at the bdk-swift directory.
 
-# Run the script from the repo root directory, ie: ./bdk-swift/build-local-swift.sh
-
 rustup install 1.73.0
 rustup component add rust-src
-rustup target add aarch64-apple-ios      # iOS ARM64
+rustup target add aarch64-apple-ios      # iOS arm64
 rustup target add x86_64-apple-ios       # iOS x86_64
 rustup target add aarch64-apple-ios-sim  # simulator mac M1
 rustup target add aarch64-apple-darwin   # mac M1
 rustup target add x86_64-apple-darwin    # mac x86_64
 
-pushd bdk-ffi
-mkdir -p Sources/BitcoinDevKit
+cd ../bdk-ffi/ || exit
 cargo run --bin uniffi-bindgen generate src/bdk.udl --language swift --out-dir ../bdk-swift/Sources/BitcoinDevKit --no-format
 
 cargo build --package bdk-ffi --profile release-smaller --target x86_64-apple-darwin
@@ -28,8 +25,7 @@ lipo target/aarch64-apple-ios-sim/release-smaller/libbdkffi.a target/x86_64-appl
 mkdir -p target/lipo-macos/release-smaller
 lipo target/aarch64-apple-darwin/release-smaller/libbdkffi.a target/x86_64-apple-darwin/release-smaller/libbdkffi.a -create -output target/lipo-macos/release-smaller/libbdkffi.a
 
-popd
-pushd bdk-swift
+cd ../bdk-swift/ || exit
 mv Sources/BitcoinDevKit/bdk.swift Sources/BitcoinDevKit/BitcoinDevKit.swift
 cp Sources/BitcoinDevKit/bdkFFI.h bdkFFI.xcframework/ios-arm64/bdkFFI.framework/Headers
 cp Sources/BitcoinDevKit/bdkFFI.h bdkFFI.xcframework/ios-arm64_x86_64-simulator/bdkFFI.framework/Headers
@@ -39,5 +35,3 @@ cp ../bdk-ffi/target/lipo-ios-sim/release-smaller/libbdkffi.a bdkFFI.xcframework
 cp ../bdk-ffi/target/lipo-macos/release-smaller/libbdkffi.a bdkFFI.xcframework/macos-arm64_x86_64/bdkFFI.framework/bdkFFI
 rm Sources/BitcoinDevKit/bdkFFI.h
 rm Sources/BitcoinDevKit/bdkFFI.modulemap
-#rm bdkFFI.xcframework.zip || true
-#zip -9 -r bdkFFI.xcframework.zip bdkFFI.xcframework


### PR DESCRIPTION
This PR fixes #423.

Our local build script for Swift needed to be called from the root directory, unlike the build workflows for Kotlin and Python. This PR fixes that.

One thing to check: does that impact the bdk-swift release workflow? Should confirm because I think the CI workflows might need to be adjusted there as well.