### PR TITLE
Bump library version to alpha.7

### DIFF
--- a/bdk-ffi/Cargo.lock
+++ b/bdk-ffi/Cargo.lock
@@ -155,7 +155,7 @@ dependencies = [
 
 [[package]]
 name = "bdk-ffi"
-version = "1.0.0-alpha.2"
+version = "1.0.0-alpha.7"
 dependencies = [
  "assert_matches",
  "bdk",

--- a/bdk-ffi/Cargo.toml
+++ b/bdk-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk-ffi"
-version = "1.0.0-alpha.2"
+version = "1.0.0-alpha.7"
 homepage = "https://bitcoindevkit.org"
 repository = "https://github.com/bitcoindevkit/bdk"
 edition = "2018"


### PR DESCRIPTION
This bumps the library version in Cargo.toml to alpha 7.