### PR TITLE
Bump library version to 0.31.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,7 +185,7 @@ dependencies = [
 
 [[package]]
 name = "bdk-ffi"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "assert_matches",
  "bdk",

--- a/bdk-ffi/Cargo.toml
+++ b/bdk-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk-ffi"
-version = "0.31.0"
+version = "0.31.1"
 authors = ["Steve Myers <steve@notmandatory.org>", "Sudarsan Balaji <sudarsan.balaji@artfuldev.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
This bumps the library version in Cargo.toml to 0.31.1.