### PR TITLE
Post-release fixes

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -15,75 +15,73 @@ assignees: ''
 #### _Android_
 3. - [ ] Update the API docs to reflect the changes in the API
 4. - [ ] Delete the `target` directory in bdk-ffi and all previous artifacts to make sure you're building the library from scratch.
-5. - [ ] Build the library and run the tests, and adjust if necessary.
-1. - [ ] Delete the `target` directory in bdk-ffi and all `build` directories (in root, `lib`, and `plugins`) in bdk-android directory to make sure you're building the library from scratch.
-2. - [ ] Build the library and run the offline and live tests, and adjust them if necessary (note that you'll need an Android emulator running).
+5. - [ ] Delete the `target` directory in bdk-ffi and all `build` directories (in root, `lib`, and `plugins`) in bdk-android directory to make sure you're building the library from scratch.
+6. - [ ] Build the library and run the offline and live tests, and adjust them if necessary (note that you'll need an Android emulator running).
 ```shell
 # start an emulator prior to running the tests
 cd ./bdk-android/
 ./gradlew buildAndroidLib
 ./gradlew connectedAndroidTest
 ```
-6. - [ ] Update the readme if necessary
-1. - [ ] Update the readme if necessary
+7. - [ ] Update the readme if necessary
+
 #### _JVM_
-7. - [ ] Update the API docs to reflect the changes in the API
-8. - [ ] Delete the `target` directory in bdk-ffi and all previous artifacts to make sure you're building the library from scratch
-9. - [ ] Build the library and run the tests, and adjust if necessary
-2. - [ ] Delete the `target` directory in bdk-ffi and all `build` directories (in root, `lib`, and `plugins`) in bdk-android directory to make sure you're building the library from scratch.
-3. - [ ] Build the library and run the tests, and adjust if necessary
+8. - [ ] Update the API docs to reflect the changes in the API
+9. - [ ] Delete the `target` directory in bdk-ffi and all `build` directories (in root, `lib`, and `plugins`) in bdk-jvm directory to make sure you're building the library from scratch.
+10. - [ ] Build the library and run the tests, and adjust if necessary
 ```shell
 cd ./bdk-jvm/
 ./gradlew buildJvmLib
 ./gradlew test
 ```
-10. - [ ] Update the readme if necessary
-1.  - [ ] Update the readme if necessary
+11.  - [ ] Update the readme if necessary
+
 #### _Swift_
-11. - [ ] Run the tests and adjust if necessary
-1.  - [ ] Run the tests and adjust if necessary
+12. - [ ] Delete the `target` directory in bdk-ffi
+13. - [ ] Run the tests and adjust if necessary
+
 ```shell
 ./bdk-swift/build-local-swift.sh
 cd ./bdk-swift/
 swift test
 ```
-12. - [ ] Update the readme if necessary
-1.  - [ ] Update the readme if necessary
+14. - [ ] Update the readme if necessary
+
 #### _Python_
-13. - [ ] Delete the `dist`, `build`, and `bdkpython.egg-info` and rust `target` directories to make sure you are building the library from scratch without any caches
-14. - [ ] Build the library
+15. - [ ] Delete the `dist`, `build`, and `bdkpython.egg-info` and rust `target` directories to make sure you are building the library from scratch without any caches
+16. - [ ] Build the library
 ```shell
 cd ./bdk-python/
 pip3 install --requirement requirements.txt
 bash ./scripts/generate-macos-arm64.sh # run the script for your particular platform
 python3 setup.py --verbose bdist_wheel
 ```
-1.  - [ ] Run the tests and adjust if necessary
+17.  - [ ] Run the tests and adjust if necessary
 ```shell
 pip3 install ./dist/bdkpython-<yourversion>-py3-none-any.whl --force-reinstall
 python -m unittest --verbose
 ```
-1.  - [ ] Update the readme and `setup.py` if necessary
+18.  - [ ] Update the readme and `setup.py` if necessary
 
 ### Release Workflow
-17. - [ ] Update the Android, JVM, Python, and Swift libraries as per the _Specific Libraries' Workflows_ section above. Open a single PR on master for all of these changes called `Prepare language bindings libraries for 0.X release`. See [example PR here](https://github.com/bitcoindevkit/bdk-ffi/pull/315).
-18. - [ ] Create a new branch off of `master` called `release/version`
-19. - [ ] Update bdk-android version from `SNAPSHOT` version to release version
-20. - [ ] Update bdk-jvm version from `SNAPSHOT` version to release version
-21. - [ ] Update bdk-python version from `.dev` version to release version
-22. - [ ] Open a PR to that release branch that updates the Android, JVM, and Python libraries' versions in step 19, 20, and 21. See [example PR here](https://github.com/bitcoindevkit/bdk-ffi/pull/316).
-23. - [ ] Get a review and ACK and merge the PR updating all the languages to their release versions
-24. - [ ] Create the tag for the release and make sure to add the changelog info to the tag (works better if you prepare the tag message on the side in a text editor). Push the tag to GitHub.
+19. - [ ] Update the Android, JVM, Python, and Swift libraries as per the _Specific Libraries' Workflows_ section above. Open a single PR on master for all of these changes called `Prepare language bindings libraries for 0.X release`. See [example PR here](https://github.com/bitcoindevkit/bdk-ffi/pull/315).
+20.. - [ ] Create a new branch off of `master` called `release/<feature version>`, e.g. `release/0.31`
+21. - [ ] Update bdk-android version from `SNAPSHOT` version to release version
+22. - [ ] Update bdk-jvm version from `SNAPSHOT` version to release version
+23. - [ ] Update bdk-python version from `.dev` version to release version
+24. - [ ] Open a PR to that release branch that updates the Android, JVM, and Python libraries' versions in step 19, 20, and 21. See [example PR here](https://github.com/bitcoindevkit/bdk-ffi/pull/316).
+25. - [ ] Get a review and ACK and merge the PR updating all the languages to their release versions
+26. - [ ] Create the tag for the release and make sure to add the changelog info to the tag (works better if you prepare the tag message on the side in a text editor). Push the tag to GitHub.
 ```shell
 git tag v0.6.0 --sign --edit
 git push upstream v0.6.0
 ```
-25. - [ ] Trigger manual releases for all 4 libraries (for Swift, trigger the release on `master` and simply add the version number in the text field when running the workflow manually. Note that the version number must not contain the `v`, i.e. `0.26.0`)
-26. - [ ] Make sure the released libraries work and contain the artifacts you would expect 
-27. - [ ] Aggregate all the changelog notices from the PRs and add them to the changelog file
-28. - [ ] Bump the versions on master from `0.9.0-SNAPSHOT` to `0.10.0-SNAPSHOT`, `0.6.0.dev0` to `0.7.0.dev0`
-29. - [ ] Apply changes to the minor_release and patch_release issue templates if they need any
-30. - [ ] Open a PR on master with the changes in steps 29, 30, and 31. See [example PR here](https://github.com/bitcoindevkit/bdk-ffi/pull/317). Get a review and merge the PR.
-31. - [ ] Make release on GitHub (set as pre-release and generate auto release notes between the previous tag and the new one)
-32. - [ ] Post in the announcement channel
-33. - [ ] Tweet about the library
+27. - [ ] Trigger manual releases for all 4 libraries (for Swift, go on the [bdk-swift](https://github.com/bitcoindevkit/bdk-swift) trigger the release on `master` and simply add the version number and tag name in the text fields when running the workflow manually. Note that the version number must not contain the `v`, i.e. `0.26.0`, but the tag will have it, i.e. `v0.26.0`).
+28. - [ ] Make sure the released libraries work and contain the artifacts you would expect 
+29. - [ ] Aggregate all the changelog notices from the PRs and add them to the changelog file
+30. - [ ] Bump the versions on master from `0.9.0-SNAPSHOT` to `0.10.0-SNAPSHOT`, `0.6.0.dev0` to `0.7.0.dev0`
+31. - [ ] Apply changes to the minor_release and patch_release issue templates if they need any
+32. - [ ] Open a PR on master with the changes in steps 29, 30, and 31. See [example PR here](https://github.com/bitcoindevkit/bdk-ffi/pull/317). Get a review and merge the PR.
+33. - [ ] Make release on GitHub (set as pre-release and generate auto release notes between the previous tag and the new one)
+34. - [ ] Post in the announcement channel
+35. - [ ] Tweet about the library

--- a/.github/workflows/publish-android.yaml
+++ b/.github/workflows/publish-android.yaml
@@ -36,7 +36,7 @@ jobs:
           cd bdk-android
           ./gradlew buildAndroidLib
 
-      - name: "Publish to Maven Local and Maven Central"
+      - name: "Publish to Maven Central"
         env:
           ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.PGP_KEY_ID }}
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.PGP_SECRET_KEY }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Changelog information can also be found in each release's git tag (which can be 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.0-alpha.7]
+This release brings back into the 1.0 API a number of APIs from the 0.31 release, and adds the new flat file persistence feature, as well as more fine-grain errors.
+
 ## [1.0.0-alpha.2a]
 This release is the first alpha release of the 1.0 API for the bindings libraries. Here is what is now available:
 - Create and recover wallets using descriptors, including the four descriptor templates
@@ -242,6 +245,8 @@ Changelog
 
 [BIP 0174]:https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki#encoding
 
+[1.0.0-alpha.7]: https://github.com/bitcoindevkit/bdk-ffi/compare/v1.0.0-alpha.2a...v1.0.0-alpha.7
+[1.0.0-alpha.2a]: https://github.com/bitcoindevkit/bdk-ffi/compare/v0.31.0...v1.0.0-alpha.2a
 [v0.31.0]: https://github.com/bitcoindevkit/bdk-ffi/compare/v0.30.0...v0.31.0
 [v0.30.0]: https://github.com/bitcoindevkit/bdk-ffi/compare/v0.29.0...v0.30.0
 [v0.29.0]: https://github.com/bitcoindevkit/bdk-ffi/compare/v0.28.0...v0.29.0

--- a/bdk-android/gradle.properties
+++ b/bdk-android/gradle.properties
@@ -2,4 +2,4 @@ org.gradle.jvmargs=-Xmx1536m
 android.useAndroidX=true
 android.enableJetifier=true
 kotlin.code.style=official
-libraryVersion=1.0.0-alpha.2b-SNAPSHOT
+libraryVersion=1.0.0-alpha.8-SNAPSHOT

--- a/bdk-android/lib/build.gradle.kts
+++ b/bdk-android/lib/build.gradle.kts
@@ -80,6 +80,13 @@ afterEvaluate {
                             url.set("https://github.com/bitcoindevkit/bdk/blob/master/LICENSE-MIT")
                         }
                     }
+                    developers {
+                        developer {
+                            id.set("bdkdevelopers")
+                            name.set("Bitcoin Dev Kit Developers")
+                            email.set("dev@bitcoindevkit.org")
+                        }
+                    }
                     scm {
                         connection.set("scm:git:github.com/bitcoindevkit/bdk-ffi.git")
                         developerConnection.set("scm:git:ssh://github.com/bitcoindevkit/bdk-ffi.git")

--- a/bdk-jvm/gradle.properties
+++ b/bdk-jvm/gradle.properties
@@ -1,4 +1,4 @@
 org.gradle.jvmargs=-Xmx1536m
 android.enableJetifier=true
 kotlin.code.style=official
-libraryVersion=1.0.0-alpha.2b-SNAPSHOT
+libraryVersion=1.0.0-alpha.8-SNAPSHOT

--- a/bdk-jvm/lib/build.gradle.kts
+++ b/bdk-jvm/lib/build.gradle.kts
@@ -92,6 +92,13 @@ afterEvaluate {
                             url.set("https://github.com/bitcoindevkit/bdk/blob/master/LICENSE-MIT")
                         }
                     }
+                    developers {
+                        developer {
+                            id.set("bdkdevelopers")
+                            name.set("Bitcoin Dev Kit Developers")
+                            email.set("dev@bitcoindevkit.org")
+                        }
+                    }
                     scm {
                         connection.set("scm:git:github.com/bitcoindevkit/bdk-ffi.git")
                         developerConnection.set("scm:git:ssh://github.com/bitcoindevkit/bdk-ffi.git")

--- a/bdk-python/setup.py
+++ b/bdk-python/setup.py
@@ -18,7 +18,7 @@ import bdkpython as bdk
 
 setup(
     name="bdkpython",
-    version="1.0.0a2.dev1",
+    version="1.0.0a8.dev",
     description="The Python language bindings for the Bitcoin Development Kit",
     long_description=LONG_DESCRIPTION,
     long_description_content_type="text/markdown",

--- a/bdk-python/setup.py
+++ b/bdk-python/setup.py
@@ -27,6 +27,7 @@ setup(
     packages=["bdkpython"],
     package_dir={"bdkpython": "./src/bdkpython"},
     url="https://github.com/bitcoindevkit/bdk-ffi",
+    author="Bitcoin Dev Kit Developers <dev@bitcoindevkit.org>",
     license="MIT or Apache 2.0",
     # This is required to ensure the library name includes the python version, abi, and platform tags
     # See issue #350 for more information


### PR DESCRIPTION
This PR does 3 things:
- Add developer information for jvm, android, and python libraries.
- Bump the development versions of bdk-android, bdk-jvm, and bdk-python.
- Update the changelog
- Update the release issue template.

On authors information: this was information that was removed as part of an old PR changing the authors. Complete removal actually breaks the bdk-jvm and bdk-android releases ([example run here](https://github.com/bitcoindevkit/bdk-ffi/actions/runs/8443691387)). It doesn't break the Python releases, but it's good to have it there anyway.

This error actually happened back with the alpha 2 release, but somehow I never cherry-picked that commit back onto master. This PR does that.

