### PR TITLE
Add just files to streamline common tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,14 +26,21 @@ The below directories (a separate repository in the case of bdk-swift) include i
 | Swift    | iOS, macOS            | [bdk-swift (GitHub)]          | [Readme bdk-swift]     |                       |
 | Python   | linux, macOS, Windows | [bdk-python (PyPI)]           | [Readme bdk-python]    |                       |
 
-## Minimum Supported Rust Version (MSRV)
+## Building and Testing the Libraries
+If you are familiar with the build tools for the specific languages you wish to build the libraries for, you can use their normal build/test workflows. We also include some [just](https://just.systems/) files to simplify the work across different languages. If you have the just tool installed on your system, you can simply call the commands defined in the `justfile`s, for example:
+```sh
+cd bdk-android
 
+just build
+just offlinetests
+just publishlocal
+```
+
+## Minimum Supported Rust Version (MSRV)
 This library should compile with any combination of features with Rust 1.73.0.
 
 ## Contributing
-
-### Adding new structs and functions
-See the [UniFFI User Guide](https://mozilla.github.io/uniffi-rs/)
+To add new structs and functions, see the [UniFFI User Guide](https://mozilla.github.io/uniffi-rs/) and the [uniffi-examples](https://thunderbiscuit.github.io/uniffi-examples/) repository.
 
 ## Goals
 1. Language bindings should feel idiomatic in target languages/platforms

--- a/README.md
+++ b/README.md
@@ -35,14 +35,6 @@ This library should compile with any combination of features with Rust 1.73.0.
 ### Adding new structs and functions
 See the [UniFFI User Guide](https://mozilla.github.io/uniffi-rs/)
 
-#### For pass by value objects
-1. Create new rust struct with only fields that are supported UniFFI types
-2. Update mapping `bdk.udl` file with new `dictionary`
-
-#### For pass by reference values
-1. Create wrapper rust struct/impl with only fields that are `Sync + Send`
-2. Update mapping `bdk.udl` file with new `interface`
-
 ## Goals
 1. Language bindings should feel idiomatic in target languages/platforms
 2. Adding new targets should be easy 

--- a/bdk-android/justfile
+++ b/bdk-android/justfile
@@ -1,0 +1,11 @@
+test:
+  ./gradlew connectedAndroidTest
+
+onetest TEST:
+  ./gradlew test --tests {{TEST}}
+
+build:
+  ./gradlew buildAndroidLib
+
+publishlocal:
+  ./gradlew publishToMavenLocal --exclude-task signMavenPublication

--- a/bdk-ffi/justfile
+++ b/bdk-ffi/justfile
@@ -1,0 +1,2 @@
+test:
+  cargo test --lib

--- a/bdk-jvm/justfile
+++ b/bdk-jvm/justfile
@@ -1,0 +1,14 @@
+test:
+  ./gradlew test
+
+offlinetests:
+  ./gradlew test -P excludeConnectedTests
+
+onetest TEST:
+  ./gradlew test --tests {{TEST}}
+
+build:
+  ./gradlew buildJvmLib
+
+publishlocal:
+  ./gradlew publishToMavenLocal --exclude-task signMavenPublication

--- a/bdk-python/justfile
+++ b/bdk-python/justfile
@@ -1,0 +1,5 @@
+test:
+  python -m unittest --verbose
+
+maclocalbuild:
+  bash ./scripts/generate-macos-arm64.sh && python3 setup.py bdist_wheel --verbose

--- a/bdk-python/scripts/generate-macos-arm64.sh
+++ b/bdk-python/scripts/generate-macos-arm64.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 python3 --version
-pip install --user -r requirements.txt
+pip install -r requirements.txt
 
 echo "Generating bdk.py..."
 cd ../bdk-ffi/

--- a/bdk-python/scripts/generate-macos-x86_64.sh
+++ b/bdk-python/scripts/generate-macos-x86_64.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 python3 --version
-pip install --user -r requirements.txt
+pip install -r requirements.txt
 
 echo "Generating bdk.py..."
 cd ../bdk-ffi/

--- a/bdk-python/scripts/generate-windows.sh
+++ b/bdk-python/scripts/generate-windows.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 python3 --version
-pip install --user -r requirements.txt
+pip install -r requirements.txt
 
 echo "Generating bdk.py..."
 cd ../bdk-ffi/

--- a/bdk-swift/justfile
+++ b/bdk-swift/justfile
@@ -1,0 +1,8 @@
+build:
+  bash ./build-local-swift.sh
+
+test:
+  swift test
+
+offlinetests:
+  swift test --skip LiveWalletTests --skip LiveTxBuilderTests


### PR DESCRIPTION
This is something I've been thinking about for a while because I now use the [just](https://just.systems/) tool a lot in my daily work. Open to hear other people's thoughts.

This is a rough outline of how the tool can be used. We could discuss how to make better use of the naming for the commands and whatnot.

But basically it streamlines the building, testing, and local publishing of the library across the languages. For example, you can now call `just test` on all 4 libraries.


## Notes
- For the bdk-ffi directory, I used the `cargo test --lib` command for `test`, mostly because it's the one you call most often.
- The just tool is completely optional. You don't need it to develop, and we don't use it in the CI either. It's really just a quality of life improvement for devs that work in the codebase daily.