### PR TITLE
Bump bdk to alpha 8

### DIFF
--- a/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/LiveTxBuilderTest.kt
+++ b/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/LiveTxBuilderTest.kt
@@ -35,7 +35,7 @@ class LiveTxBuilderTest {
         val recipient: Address = Address("tb1qrnfslnrve9uncz9pzpvf83k3ukz22ljgees989", Network.TESTNET)
         val psbt: PartiallySignedTransaction = TxBuilder()
             .addRecipient(recipient.scriptPubkey(), 4200uL)
-            .feeRate(FeeRate.fromSatPerVb(2.0f))
+            .feeRate(FeeRate.fromSatPerVb(2uL))
             .finish(wallet)
 
         println(psbt.serialize())
@@ -63,7 +63,7 @@ class LiveTxBuilderTest {
 
         val psbt: PartiallySignedTransaction = TxBuilder()
             .setRecipients(allRecipients)
-            .feeRate(FeeRate.fromSatPerVb(4.0f))
+            .feeRate(FeeRate.fromSatPerVb(4uL))
             .changePolicy(ChangeSpendPolicy.CHANGE_FORBIDDEN)
             .enableRbf()
             .finish(wallet)

--- a/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/LiveWalletTest.kt
+++ b/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/LiveWalletTest.kt
@@ -79,7 +79,7 @@ class LiveWalletTest {
         println("Tx fee is: ${txFee}")
 
         val feeRate: FeeRate = wallet.calculateFeeRate(tx)
-        println("Tx fee rate is: ${feeRate.asSatPerVb()} sat/vB")
+        println("Tx fee rate is: ${feeRate.toSatPerVbCeil()} sat/vB")
 
         esploraClient.broadcast(tx)
     }

--- a/bdk-ffi/Cargo.lock
+++ b/bdk-ffi/Cargo.lock
@@ -138,9 +138,9 @@ dependencies = [
 
 [[package]]
 name = "bdk"
-version = "1.0.0-alpha.7"
+version = "1.0.0-alpha.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3898b68da1d179ec68acaaefe29b3ea952800ebf5809cad1e3a3cc5504ccc6d4"
+checksum = "06494244111d4f934f40f2a46883bcec3ea5d573fe30d310623e08a27adac849"
 dependencies = [
  "bdk_chain",
  "bip39",
@@ -155,7 +155,7 @@ dependencies = [
 
 [[package]]
 name = "bdk-ffi"
-version = "1.0.0-alpha.7"
+version = "1.0.0-alpha.8"
 dependencies = [
  "assert_matches",
  "bdk",
@@ -178,9 +178,9 @@ dependencies = [
 
 [[package]]
 name = "bdk_esplora"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a218fdf700ba98cf68f3b678af004b6770a04329bd1de4c0ce52382cecb2e0e9"
+checksum = "9abd2ce171d0a10c44b847c0e4aaf2e6eb81d7b3f5ac8bde4e0e0b77edfc313f"
 dependencies = [
  "bdk_chain",
  "esplora-client",
@@ -188,9 +188,9 @@ dependencies = [
 
 [[package]]
 name = "bdk_file_store"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0efb7e3263bc937977d798a0a5f1c64467de5998380b8dc5003f5924b2af3398"
+checksum = "403e8a1b6671585d1d5466cd5414e51d9f38c9079137ab79d4b83b56b21b03ac"
 dependencies = [
  "bdk_chain",
  "bincode",

--- a/bdk-ffi/Cargo.toml
+++ b/bdk-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk-ffi"
-version = "1.0.0-alpha.7"
+version = "1.0.0-alpha.8"
 homepage = "https://bitcoindevkit.org"
 repository = "https://github.com/bitcoindevkit/bdk"
 edition = "2018"
@@ -18,10 +18,10 @@ path = "uniffi-bindgen.rs"
 default = ["uniffi/cli"]
 
 [dependencies]
-bdk = { version = "1.0.0-alpha.7", features = ["all-keys", "keys-bip39"] }
-bdk_esplora = { version = "0.9.0", default-features = false, features = ["std", "blocking"] }
-# bdk_esplora = { version = "0.9.0", default-features = false, features = ["std", "blocking", "async-https-rustls"] }
-bdk_file_store = { version = "0.7.0" }
+bdk = { version = "1.0.0-alpha.8", features = ["all-keys", "keys-bip39"] }
+bdk_esplora = { version = "0.10.0", default-features = false, features = ["std", "blocking"] }
+# bdk_esplora = { version = "0.10.0", default-features = false, features = ["std", "blocking", "async-https-rustls"] }
+bdk_file_store = { version = "0.8.0" }
 
 uniffi = { version = "=0.26.1" }
 thiserror = "1.0.58"

--- a/bdk-ffi/src/bdk.udl
+++ b/bdk-ffi/src/bdk.udl
@@ -47,6 +47,11 @@ interface EsploraError {
   HeaderHashNotFound();
 };
 
+[Error]
+enum FeeRateError {
+  "ArithmeticOverflow"
+};
+
 // ------------------------------------------------------------------------
 // bdk crate - types module
 // ------------------------------------------------------------------------
@@ -100,15 +105,17 @@ dictionary TxOut {
 // ------------------------------------------------------------------------
 
 interface FeeRate {
-  [Name=from_sat_per_vb]
-  constructor(f32 sat_per_vb);
+  [Name=from_sat_per_vb, Throws=FeeRateError]
+  constructor(u64 sat_per_vb);
 
   [Name=from_sat_per_kwu]
-  constructor(f32 sat_per_kwu);
+  constructor(u64 sat_per_kwu);
 
-  f32 as_sat_per_vb();
+  u64 to_sat_per_vb_ceil();
 
-  f32 sat_per_kwu();
+  u64 to_sat_per_vb_floor();
+
+  u64 to_sat_per_kwu();
 };
 
 enum ChangeSpendPolicy {
@@ -189,7 +196,7 @@ interface TxBuilder {
 };
 
 interface BumpFeeTxBuilder {
-  constructor(string txid, f32 fee_rate);
+  constructor(string txid, FeeRate fee_rate);
 
   BumpFeeTxBuilder allow_shrinking(Script script_pubkey);
 

--- a/bdk-ffi/src/error.rs
+++ b/bdk-ffi/src/error.rs
@@ -101,6 +101,12 @@ pub enum EsploraError {
     HeaderHashNotFound,
 }
 
+#[derive(Debug, thiserror::Error)]
+pub enum FeeRateError {
+    #[error("arithmetic overflow on feerate")]
+    ArithmeticOverflow,
+}
+
 impl From<BdkFileError> for WalletCreationError {
     fn from(error: BdkFileError) -> Self {
         match error {

--- a/bdk-ffi/src/lib.rs
+++ b/bdk-ffi/src/lib.rs
@@ -16,6 +16,7 @@ use crate::descriptor::Descriptor;
 use crate::error::Alpha3Error;
 use crate::error::CalculateFeeError;
 use crate::error::EsploraError;
+use crate::error::FeeRateError;
 use crate::esplora::EsploraClient;
 use crate::keys::DerivationPath;
 use crate::keys::DescriptorPublicKey;

--- a/bdk-ffi/src/types.rs
+++ b/bdk-ffi/src/types.rs
@@ -4,31 +4,39 @@ use bdk::wallet::AddressIndex as BdkAddressIndex;
 use bdk::wallet::AddressInfo as BdkAddressInfo;
 use bdk::wallet::Balance as BdkBalance;
 use bdk::KeychainKind;
-
 use bdk::LocalOutput as BdkLocalOutput;
 
-use bdk::FeeRate as BdkFeeRate;
+use bdk::bitcoin::FeeRate as BdkFeeRate;
 
+use crate::error::FeeRateError;
 use std::sync::Arc;
 
 #[derive(Clone, Debug)]
 pub struct FeeRate(pub BdkFeeRate);
 
 impl FeeRate {
-    pub fn from_sat_per_vb(sat_per_vb: f32) -> Self {
-        FeeRate(BdkFeeRate::from_sat_per_vb(sat_per_vb))
+    pub fn from_sat_per_vb(sat_per_vb: u64) -> Result<Self, FeeRateError> {
+        let fee_rate: Option<BdkFeeRate> = BdkFeeRate::from_sat_per_vb(sat_per_vb);
+        match fee_rate {
+            Some(fee_rate) => Ok(FeeRate(fee_rate)),
+            None => Err(FeeRateError::ArithmeticOverflow),
+        }
     }
 
-    pub fn from_sat_per_kwu(sat_per_kwu: f32) -> Self {
+    pub fn from_sat_per_kwu(sat_per_kwu: u64) -> Self {
         FeeRate(BdkFeeRate::from_sat_per_kwu(sat_per_kwu))
     }
 
-    pub fn as_sat_per_vb(&self) -> f32 {
-        self.0.as_sat_per_vb()
+    pub fn to_sat_per_vb_ceil(&self) -> u64 {
+        self.0.to_sat_per_vb_ceil()
     }
 
-    pub fn sat_per_kwu(&self) -> f32 {
-        self.0.sat_per_kwu()
+    pub fn to_sat_per_vb_floor(&self) -> u64 {
+        self.0.to_sat_per_vb_floor()
+    }
+
+    pub fn to_sat_per_kwu(&self) -> u64 {
+        self.0.to_sat_per_kwu()
     }
 }
 

--- a/bdk-jvm/lib/src/test/kotlin/org/bitcoindevkit/LiveTxBuilderTest.kt
+++ b/bdk-jvm/lib/src/test/kotlin/org/bitcoindevkit/LiveTxBuilderTest.kt
@@ -33,7 +33,7 @@ class LiveTxBuilderTest {
         val recipient: Address = Address("tb1qrnfslnrve9uncz9pzpvf83k3ukz22ljgees989", Network.TESTNET)
         val psbt: PartiallySignedTransaction = TxBuilder()
             .addRecipient(recipient.scriptPubkey(), 4200uL)
-            .feeRate(FeeRate.fromSatPerVb(2.0f))
+            .feeRate(FeeRate.fromSatPerVb(2uL))
             .finish(wallet)
 
         println(psbt.serialize())
@@ -62,7 +62,7 @@ class LiveTxBuilderTest {
 
         val psbt: PartiallySignedTransaction = TxBuilder()
             .setRecipients(allRecipients)
-            .feeRate(FeeRate.fromSatPerVb(4.0f))
+            .feeRate(FeeRate.fromSatPerVb(4uL))
             .changePolicy(ChangeSpendPolicy.CHANGE_FORBIDDEN)
             .enableRbf()
             .finish(wallet)

--- a/bdk-jvm/lib/src/test/kotlin/org/bitcoindevkit/LiveWalletTest.kt
+++ b/bdk-jvm/lib/src/test/kotlin/org/bitcoindevkit/LiveWalletTest.kt
@@ -61,7 +61,7 @@ class LiveWalletTest {
 
         val psbt: PartiallySignedTransaction = TxBuilder()
             .addRecipient(recipient.scriptPubkey(), 4200uL)
-            .feeRate(FeeRate.fromSatPerVb(2.0f))
+            .feeRate(FeeRate.fromSatPerVb(2uL))
             .finish(wallet)
 
         println(psbt.serialize())
@@ -77,7 +77,7 @@ class LiveWalletTest {
         println("Tx fee is: ${txFee}")
 
         val feeRate: FeeRate = wallet.calculateFeeRate(tx)
-        println("Tx fee rate is: ${feeRate.asSatPerVb()} sat/vB")
+        println("Tx fee rate is: ${feeRate.toSatPerVbCeil()} sat/vB")
 
         esploraClient.broadcast(tx)
     }

--- a/bdk-python/tests/test_live_tx_builder.py
+++ b/bdk-python/tests/test_live_tx_builder.py
@@ -34,7 +34,7 @@ class LiveTxBuilderTest(unittest.TestCase):
             network = bdk.Network.TESTNET
         )
         
-        psbt = bdk.TxBuilder().add_recipient(script=recipient.script_pubkey(), amount=4200).fee_rate(fee_rate=bdk.FeeRate.from_sat_per_vb(2.0)).finish(wallet)
+        psbt = bdk.TxBuilder().add_recipient(script=recipient.script_pubkey(), amount=4200).fee_rate(fee_rate=bdk.FeeRate.from_sat_per_vb(2)).finish(wallet)
         
         self.assertTrue(psbt.serialize().startswith("cHNi"), "The PSBT should start with cHNi")
 
@@ -76,7 +76,7 @@ class LiveTxBuilderTest(unittest.TestCase):
             bdk.ScriptAmount(recipient2.script_pubkey, 4200)
         )
         
-        psbt: bdk.PartiallySignedTransaction = bdk.TxBuilder().set_recipients(all_recipients).fee_rate(fee_rate=bdk.FeeRate.from_sat_per_vb(2.0)).enable_rbf().finish(wallet)
+        psbt: bdk.PartiallySignedTransaction = bdk.TxBuilder().set_recipients(all_recipients).fee_rate(fee_rate=bdk.FeeRate.from_sat_per_vb(2)).enable_rbf().finish(wallet)
         wallet.sign(psbt)
         
         self.assertTrue(psbt.serialize().startswith("cHNi"), "The PSBT should start with cHNi")

--- a/bdk-python/tests/test_live_wallet.py
+++ b/bdk-python/tests/test_live_wallet.py
@@ -64,7 +64,7 @@ class LiveWalletTest(unittest.TestCase):
             network = bdk.Network.TESTNET
         )
         
-        psbt = bdk.TxBuilder().add_recipient(script=recipient.script_pubkey(), amount=4200).fee_rate(fee_rate=bdk.FeeRate.from_sat_per_vb(2.0)).finish(wallet)
+        psbt = bdk.TxBuilder().add_recipient(script=recipient.script_pubkey(), amount=4200).fee_rate(fee_rate=bdk.FeeRate.from_sat_per_vb(2)).finish(wallet)
         # print(psbt.serialize())
         self.assertTrue(psbt.serialize().startswith("cHNi"), "The PSBT should start with cHNi")
         
@@ -75,7 +75,7 @@ class LiveWalletTest(unittest.TestCase):
         fee = wallet.calculate_fee(tx)
         print(f"Transaction Fee: {fee}")
         fee_rate = wallet.calculate_fee_rate(tx)
-        print(f"Transaction Fee Rate: {fee_rate.as_sat_per_vb()} sat/vB")
+        print(f"Transaction Fee Rate: {fee_rate.to_sat_per_vb_ceil()} sat/vB")
         
         esploraClient.broadcast(tx)
     

--- a/bdk-swift/Tests/BitcoinDevKitTests/LiveTxBuilderTests.swift
+++ b/bdk-swift/Tests/BitcoinDevKitTests/LiveTxBuilderTests.swift
@@ -47,7 +47,7 @@ final class LiveTxBuilderTests: XCTestCase {
         let recipient: Address = try Address(address: "tb1qrnfslnrve9uncz9pzpvf83k3ukz22ljgees989", network: .testnet)
         let psbt: PartiallySignedTransaction = try TxBuilder()
             .addRecipient(script: recipient.scriptPubkey(), amount: 4200)
-            .feeRate(feeRate: FeeRate.fromSatPerVb(satPerVb: 2.0))
+            .feeRate(feeRate: FeeRate.fromSatPerVb(satPerVb: 2))
             .finish(wallet: wallet)
 
         print(psbt.serialize())
@@ -88,7 +88,7 @@ final class LiveTxBuilderTests: XCTestCase {
 
         let psbt: PartiallySignedTransaction = try TxBuilder()
             .setRecipients(recipients: allRecipients)
-            .feeRate(feeRate: FeeRate.fromSatPerVb(satPerVb: 4.0))
+            .feeRate(feeRate: FeeRate.fromSatPerVb(satPerVb: 4))
             .changePolicy(changePolicy: ChangeSpendPolicy.changeForbidden)
             .enableRbf()
             .finish(wallet: wallet)

--- a/bdk-swift/Tests/BitcoinDevKitTests/LiveWalletTests.swift
+++ b/bdk-swift/Tests/BitcoinDevKitTests/LiveWalletTests.swift
@@ -81,7 +81,7 @@ final class LiveWalletTests: XCTestCase {
         let psbt: PartiallySignedTransaction = try
             TxBuilder()
                 .addRecipient(script: recipient.scriptPubkey(), amount: 4200)
-                .feeRate(feeRate: FeeRate.fromSatPerVb(satPerVb: 2.0))
+                .feeRate(feeRate: FeeRate.fromSatPerVb(satPerVb: 2))
                 .finish(wallet: wallet)
 
         print(psbt.serialize())
@@ -95,7 +95,7 @@ final class LiveWalletTests: XCTestCase {
         let fee: UInt64 = try wallet.calculateFee(tx: tx)
         print("Transaction Fee: \(fee)")
         let feeRate: FeeRate = try wallet.calculateFeeRate(tx: tx)
-        print("Transaction Fee Rate: \(feeRate.asSatPerVb()) sat/vB")
+        print("Transaction Fee Rate: \(feeRate.toSatPerVbCeil()) sat/vB")
 
         try esploraClient.broadcast(transaction: tx)
     }


### PR DESCRIPTION
This PR upgrades bdk to alpha 8 as well as bdk_esplora to 0.10.0 and bdk_file_store to 0.8.0.

It required the FeeRate object to be fiddled with a little bit because bdk now uses the bitcoin::FeeRate, which uses u64s instead of f32 in most places. The names of the methods are also changed a little bit, and the `from_sat_per_vb` constructor actually returns None when the input produces an arithmetic overflow. I decided to return an error instead, to keep the struct simple (having a None in there would require the FeeRate object to be different in nature than what we currently have, and I think an error is appropriate in this case anyway). Happy to hear questions/thoughts on this, because it's a slight deviation from the Rust API.

Merge after 471, 479, 480 and 481.