### PR TITLE
Expose a whole lot of errors

### DIFF
--- a/bdk-ffi/Cargo.lock
+++ b/bdk-ffi/Cargo.lock
@@ -161,6 +161,7 @@ dependencies = [
  "bdk",
  "bdk_esplora",
  "bdk_file_store",
+ "bitcoin-internals 0.2.0",
  "thiserror",
  "uniffi",
 ]
@@ -243,6 +244,12 @@ name = "bitcoin-internals"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f9997f8650dd818369931b5672a18dbef95324d0513aa99aae758de8ce86e5b"
+
+[[package]]
+name = "bitcoin-internals"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9425c3bf7089c983facbae04de54513cce73b41c7f9ff8c845b54e7bc64ebbfb"
 
 [[package]]
 name = "bitcoin-private"
@@ -393,7 +400,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cb1f7f2489cce83bc3bd92784f9ba5271eeb6e729b975895fc541f78cbfcdca"
 dependencies = [
  "bitcoin",
- "bitcoin-internals",
+ "bitcoin-internals 0.1.0",
  "log",
  "serde",
  "ureq",

--- a/bdk-ffi/Cargo.toml
+++ b/bdk-ffi/Cargo.toml
@@ -24,6 +24,7 @@ bdk_esplora = { version = "0.10.0", default-features = false, features = ["std",
 bdk_file_store = { version = "0.8.0" }
 
 uniffi = { version = "=0.26.1" }
+bitcoin-internals = { version = "0.2.0", features = ["alloc"] }
 thiserror = "1.0.58"
 
 [build-dependencies]

--- a/bdk-ffi/src/bdk.udl
+++ b/bdk-ffi/src/bdk.udl
@@ -71,6 +71,17 @@ interface AddressError {
   OtherAddressError();
 };
 
+[Error]
+interface TransactionError {
+  Io();
+  OversizedVectorAllocation();
+  InvalidChecksum(string expected, string actual);
+  NonMinimalVarInt();
+  ParseFailed();
+  UnsupportedSegwitFlag(u8 flag);
+  OtherTransactionError();
+};
+
 // ------------------------------------------------------------------------
 // bdk crate - types module
 // ------------------------------------------------------------------------
@@ -394,7 +405,7 @@ interface Address {
 };
 
 interface Transaction {
-  [Throws=Alpha3Error]
+  [Throws=TransactionError]
   constructor(sequence<u8> transaction_bytes);
 
   string txid();

--- a/bdk-ffi/src/bdk.udl
+++ b/bdk-ffi/src/bdk.udl
@@ -82,6 +82,12 @@ interface TransactionError {
   OtherTransactionError();
 };
 
+[Error]
+interface PsbtParseError {
+  PsbtEncoding(string e);
+  Base64Encoding(string e);
+};
+
 // ------------------------------------------------------------------------
 // bdk crate - types module
 // ------------------------------------------------------------------------
@@ -424,7 +430,7 @@ interface Transaction {
 };
 
 interface PartiallySignedTransaction {
-  [Throws=Alpha3Error]
+  [Throws=PsbtParseError]
   constructor(string psbt_base64);
 
   string serialize();

--- a/bdk-ffi/src/bdk.udl
+++ b/bdk-ffi/src/bdk.udl
@@ -88,6 +88,22 @@ interface PsbtParseError {
   Base64Encoding(string e);
 };
 
+[Error]
+interface DescriptorError {
+    InvalidHdKeyPath();
+    InvalidDescriptorChecksum();
+    HardenedDerivationXpub();
+    MultiPath();
+    Key(string e);
+    Policy(string e);
+    InvalidDescriptorCharacter(string char);
+    Bip32(string e);
+    Base58(string e);
+    Pk(string e);
+    Miniscript(string e);
+    Hex(string e);
+};
+
 // ------------------------------------------------------------------------
 // bdk crate - types module
 // ------------------------------------------------------------------------
@@ -309,7 +325,7 @@ interface DescriptorPublicKey {
 };
 
 interface Descriptor {
-  [Throws=Alpha3Error]
+  [Throws=DescriptorError]
   constructor(string descriptor, Network network);
 
   [Name=new_bip44]

--- a/bdk-ffi/src/bdk.udl
+++ b/bdk-ffi/src/bdk.udl
@@ -52,6 +52,25 @@ enum FeeRateError {
   "ArithmeticOverflow"
 };
 
+[Error]
+interface AddressError {
+  Base58();
+  Bech32();
+  EmptyBech32Payload();
+  InvalidBech32Variant();
+  InvalidWitnessVersion(u8 version);
+  UnparsableWitnessVersion();
+  MalformedWitnessVersion();
+  InvalidWitnessProgramLength(u64 length);
+  InvalidSegwitV0ProgramLength(u64 length);
+  UncompressedPubkey();
+  ExcessiveScriptSize();
+  UnrecognizedScript();
+  UnknownAddressType(string s);
+  NetworkValidation(Network required, Network found, string address);
+  OtherAddressError();
+};
+
 // ------------------------------------------------------------------------
 // bdk crate - types module
 // ------------------------------------------------------------------------
@@ -360,7 +379,7 @@ enum WordCount {
 };
 
 interface Address {
-  [Throws=Alpha3Error]
+  [Throws=AddressError]
   constructor(string address, Network network);
 
   Network network();

--- a/bdk-ffi/src/bitcoin.rs
+++ b/bdk-ffi/src/bitcoin.rs
@@ -41,14 +41,9 @@ pub struct Address {
 }
 
 impl Address {
-    pub fn new(address: String, network: Network) -> Result<Self, Alpha3Error> {
-        let parsed_address = address
-            .parse::<bdk::bitcoin::Address<NetworkUnchecked>>()
-            .map_err(|_| Alpha3Error::Generic)?;
-
-        let network_checked_address = parsed_address
-            .require_network(network)
-            .map_err(|_| Alpha3Error::Generic)?;
+    pub fn new(address: String, network: Network) -> Result<Self, AddressError> {
+        let parsed_address = address.parse::<bdk::bitcoin::Address<NetworkUnchecked>>()?;
+        let network_checked_address = parsed_address.require_network(network)?;
 
         Ok(Address {
             inner: network_checked_address,

--- a/bdk-ffi/src/bitcoin.rs
+++ b/bdk-ffi/src/bitcoin.rs
@@ -1,4 +1,5 @@
-use crate::error::Alpha3Error;
+use crate::error::{Alpha3Error, TransactionError};
+use crate::error::AddressError;
 
 use bdk::bitcoin::address::{NetworkChecked, NetworkUnchecked};
 use bdk::bitcoin::blockdata::script::ScriptBuf as BdkScriptBuf;
@@ -116,10 +117,9 @@ pub struct Transaction {
 }
 
 impl Transaction {
-    pub fn new(transaction_bytes: Vec<u8>) -> Result<Self, Alpha3Error> {
+    pub fn new(transaction_bytes: Vec<u8>) -> Result<Self, TransactionError> {
         let mut decoder = Cursor::new(transaction_bytes);
-        let tx: BdkTransaction =
-            BdkTransaction::consensus_decode(&mut decoder).map_err(|_| Alpha3Error::Generic)?;
+        let tx: BdkTransaction = BdkTransaction::consensus_decode(&mut decoder)?;
         Ok(Transaction { inner: tx })
     }
 

--- a/bdk-ffi/src/bitcoin.rs
+++ b/bdk-ffi/src/bitcoin.rs
@@ -1,5 +1,4 @@
-use crate::error::{PsbtParseError, TransactionError};
-use crate::error::AddressError;
+use crate::error::{AddressError, PsbtParseError, TransactionError};
 
 use bdk::bitcoin::address::{NetworkChecked, NetworkUnchecked};
 use bdk::bitcoin::blockdata::script::ScriptBuf as BdkScriptBuf;
@@ -198,7 +197,6 @@ impl PartiallySignedTransaction {
     pub(crate) fn new(psbt_base64: String) -> Result<Self, PsbtParseError> {
         let psbt: BdkPartiallySignedTransaction =
             BdkPartiallySignedTransaction::from_str(&psbt_base64)?;
-        // .map_err(|_| Alpha3Error::Generic)?;
 
         Ok(PartiallySignedTransaction {
             inner: Mutex::new(psbt),

--- a/bdk-ffi/src/bitcoin.rs
+++ b/bdk-ffi/src/bitcoin.rs
@@ -1,4 +1,4 @@
-use crate::error::{Alpha3Error, TransactionError};
+use crate::error::{PsbtParseError, TransactionError};
 use crate::error::AddressError;
 
 use bdk::bitcoin::address::{NetworkChecked, NetworkUnchecked};
@@ -195,10 +195,10 @@ pub struct PartiallySignedTransaction {
 }
 
 impl PartiallySignedTransaction {
-    pub(crate) fn new(psbt_base64: String) -> Result<Self, Alpha3Error> {
+    pub(crate) fn new(psbt_base64: String) -> Result<Self, PsbtParseError> {
         let psbt: BdkPartiallySignedTransaction =
-            BdkPartiallySignedTransaction::from_str(&psbt_base64)
-                .map_err(|_| Alpha3Error::Generic)?;
+            BdkPartiallySignedTransaction::from_str(&psbt_base64)?;
+        // .map_err(|_| Alpha3Error::Generic)?;
 
         Ok(PartiallySignedTransaction {
             inner: Mutex::new(psbt),

--- a/bdk-ffi/src/descriptor.rs
+++ b/bdk-ffi/src/descriptor.rs
@@ -1,4 +1,4 @@
-use crate::error::Alpha3Error;
+use crate::error::DescriptorError;
 use crate::keys::DescriptorPublicKey;
 use crate::keys::DescriptorSecretKey;
 
@@ -23,7 +23,7 @@ pub struct Descriptor {
 }
 
 impl Descriptor {
-    pub(crate) fn new(descriptor: String, network: Network) -> Result<Self, Alpha3Error> {
+    pub(crate) fn new(descriptor: String, network: Network) -> Result<Self, DescriptorError> {
         let secp = Secp256k1::new();
         let (extended_descriptor, key_map) = descriptor.into_wallet_descriptor(&secp, network)?;
         Ok(Self {
@@ -276,8 +276,6 @@ mod test {
     use crate::*;
     use assert_matches::assert_matches;
 
-    use crate::Alpha3Error;
-
     fn get_descriptor_secret_key() -> DescriptorSecretKey {
         let mnemonic = Mnemonic::from_string("chaos fabric time speed sponsor all flat solution wisdom trophy crack object robot pave observe combine where aware bench orient secret primary cable detect".to_string()).unwrap();
         DescriptorSecretKey::new(Network::Testnet, &mnemonic, None)
@@ -392,8 +390,8 @@ mod test {
     fn test_descriptor_from_string() {
         let descriptor1 = Descriptor::new("wpkh(tprv8hwWMmPE4BVNxGdVt3HhEERZhondQvodUY7Ajyseyhudr4WabJqWKWLr4Wi2r26CDaNCQhhxEftEaNzz7dPGhWuKFU4VULesmhEfZYyBXdE/0/*)".to_string(), Network::Testnet);
         let descriptor2 = Descriptor::new("wpkh(tprv8hwWMmPE4BVNxGdVt3HhEERZhondQvodUY7Ajyseyhudr4WabJqWKWLr4Wi2r26CDaNCQhhxEftEaNzz7dPGhWuKFU4VULesmhEfZYyBXdE/0/*)".to_string(), Network::Bitcoin);
-        // Creating a Descriptor using an extended key that doesn't match the network provided will throw and InvalidNetwork Error
+        // Creating a Descriptor using an extended key that doesn't match the network provided will throw a DescriptorError::Key with inner InvalidNetwork error
         assert!(descriptor1.is_ok());
-        assert_matches!(descriptor2.unwrap_err(), Alpha3Error::Generic)
+        assert_matches!(descriptor2.unwrap_err(), DescriptorError::Key { .. });
     }
 }

--- a/bdk-ffi/src/esplora.rs
+++ b/bdk-ffi/src/esplora.rs
@@ -1,12 +1,12 @@
 use crate::error::{Alpha3Error, EsploraError};
 use crate::wallet::{Update, Wallet};
 
+use crate::bitcoin::Transaction;
 use bdk::bitcoin::Transaction as BdkTransaction;
 use bdk::wallet::Update as BdkUpdate;
 use bdk_esplora::esplora_client::{BlockingClient, Builder};
 use bdk_esplora::EsploraExt;
 
-use crate::bitcoin::Transaction;
 use std::sync::Arc;
 
 pub struct EsploraClient(BlockingClient);

--- a/bdk-ffi/src/lib.rs
+++ b/bdk-ffi/src/lib.rs
@@ -16,6 +16,7 @@ use crate::descriptor::Descriptor;
 use crate::error::AddressError;
 use crate::error::Alpha3Error;
 use crate::error::CalculateFeeError;
+use crate::error::DescriptorError;
 use crate::error::EsploraError;
 use crate::error::FeeRateError;
 use crate::error::PersistenceError;

--- a/bdk-ffi/src/lib.rs
+++ b/bdk-ffi/src/lib.rs
@@ -19,6 +19,7 @@ use crate::error::CalculateFeeError;
 use crate::error::EsploraError;
 use crate::error::FeeRateError;
 use crate::error::PersistenceError;
+use crate::error::TransactionError;
 use crate::error::WalletCreationError;
 use crate::esplora::EsploraClient;
 use crate::keys::DerivationPath;

--- a/bdk-ffi/src/lib.rs
+++ b/bdk-ffi/src/lib.rs
@@ -19,6 +19,7 @@ use crate::error::CalculateFeeError;
 use crate::error::EsploraError;
 use crate::error::FeeRateError;
 use crate::error::PersistenceError;
+use crate::error::PsbtParseError;
 use crate::error::TransactionError;
 use crate::error::WalletCreationError;
 use crate::esplora::EsploraClient;

--- a/bdk-ffi/src/lib.rs
+++ b/bdk-ffi/src/lib.rs
@@ -13,6 +13,7 @@ use crate::bitcoin::Script;
 use crate::bitcoin::Transaction;
 use crate::bitcoin::TxOut;
 use crate::descriptor::Descriptor;
+use crate::error::AddressError;
 use crate::error::Alpha3Error;
 use crate::error::CalculateFeeError;
 use crate::error::EsploraError;

--- a/bdk-ffi/src/types.rs
+++ b/bdk-ffi/src/types.rs
@@ -1,5 +1,6 @@
-use crate::bitcoin::{Address, OutPoint, Script, Transaction, TxOut};
 use crate::error::FeeRateError;
+
+use crate::bitcoin::{Address, OutPoint, Script, Transaction, TxOut};
 
 use bdk::bitcoin::FeeRate as BdkFeeRate;
 use bdk::bitcoin::Transaction as BdkTransaction;


### PR DESCRIPTION
### Description
This PR adds all the boilerplate code related to 4 new error types: AddressError and TransactionError, PsbtParseError, and DescriptorError.

### Notes to the reviewers
- New dependency on bitcoin-internals
- consensus::encode::Error -> TransactionError. Not sure if there are other places we might use this error, in which case we should name it the same as its Rust counterpart. But as is it just felt weird not to name it TransactionError. 

### Changelog notice
```md
Added:
  - The Address constructor now returns an AddressError when throwing [#485]
  - The Transaction constructor now returns a TransactionError when throwing [#485]
  - The PartiallySignedTransaction constructor now returns a PsbtParseError when throwing {#485]
  - The Descriptor constructor now returns a DescriptorError when throwing [#485]
 
[#485]: https://github.com/bitcoindevkit/bdk-ffi/pull/485
```

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added new error handling capabilities across various components for improved robustness.
	- Introduced new error types like `AddressError`, `TransactionError`, `PsbtParseError`, `DescriptorError`, and `FeeRateError`.
	- Enhanced `FeeRate` struct with methods for more precise fee rate calculations.

- **Bug Fixes**
	- Updated error handling in `Address`, `Transaction`, and `Descriptor` components to use specific error types for better clarity and troubleshooting.

- **Refactor**
	- Renamed errors and updated error handling across multiple files to standardize and simplify codebase.
	- Reordered import statements in `esplora.rs` for clearer code structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->