### PR TITLE
Android build small fixes

### DIFF
--- a/bdk-android/justfile
+++ b/bdk-android/justfile
@@ -8,4 +8,4 @@ build:
   ./gradlew buildAndroidLib
 
 publishlocal:
-  ./gradlew publishToMavenLocal --exclude-task signMavenPublication
+  ./gradlew publishToMavenLocal -P localBuild

--- a/bdk-android/lib/build.gradle.kts
+++ b/bdk-android/lib/build.gradle.kts
@@ -114,6 +114,10 @@ afterEvaluate {
 }
 
 signing {
+    if (project.hasProperty("localBuild")) {
+        isRequired = false
+    }
+
     val signingKeyId: String? by project
     val signingKey: String? by project
     val signingPassword: String? by project
@@ -121,8 +125,7 @@ signing {
     sign(publishing.publications)
 }
 
-// This task dependency ensures that we build the bindings
-// binaries before running the tests
+// This task dependency ensures that we build the bindings binaries before running the tests
 tasks.withType<KotlinCompile> {
     dependsOn("buildAndroidLib")
 }

--- a/bdk-android/lib/build.gradle.kts
+++ b/bdk-android/lib/build.gradle.kts
@@ -38,6 +38,20 @@ android {
     }
 }
 
+kotlin {
+    tasks.withType<KotlinCompile>().configureEach {
+        kotlinOptions {
+            jvmTarget = "17"
+        }
+    }
+}
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(17))
+    }
+}
+
 dependencies {
     implementation("net.java.dev.jna:jna:5.14.0@aar")
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk7")

--- a/bdk-android/lib/build.gradle.kts
+++ b/bdk-android/lib/build.gradle.kts
@@ -105,6 +105,12 @@ afterEvaluate {
             }
         }
     }
+    
+    // This is required because we must ensure the moveNativeAndroidLibs task is executed after
+    // the mergeReleaseJniLibFolders (hard requirement introduced by our upgrade to Gradle 8.7)
+    tasks.named("mergeReleaseJniLibFolders") {
+        dependsOn(":lib:moveNativeAndroidLibs")
+    }
 }
 
 signing {

--- a/bdk-android/lib/src/main/AndroidManifest.xml
+++ b/bdk-android/lib/src/main/AndroidManifest.xml
@@ -1,6 +1,3 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="org.bitcoindevkit">
-
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
   <uses-permission android:name="android.permission.INTERNET" />
-
 </manifest>

--- a/bdk-android/plugins/src/main/kotlin/org/bitcoindevkit/plugins/UniFfiAndroidPlugin.kt
+++ b/bdk-android/plugins/src/main/kotlin/org/bitcoindevkit/plugins/UniFfiAndroidPlugin.kt
@@ -113,6 +113,8 @@ internal class UniFfiAndroidPlugin : Plugin<Project> {
         val moveNativeAndroidLibs by tasks.register<Copy>("moveNativeAndroidLibs") {
 
             dependsOn(buildAndroidAarch64Binary)
+            dependsOn(buildAndroidArmv7Binary)
+            dependsOn(buildAndroidX86_64Binary)
 
             into("${project.projectDir}/../lib/src/main/jniLibs/")
 

--- a/bdk-android/settings.gradle.kts
+++ b/bdk-android/settings.gradle.kts
@@ -13,5 +13,6 @@ pluginManagement {
 dependencyResolutionManagement {
     repositories {
         mavenCentral()
+        google()
     }
 }

--- a/bdk-jvm/justfile
+++ b/bdk-jvm/justfile
@@ -11,4 +11,4 @@ build:
   ./gradlew buildJvmLib
 
 publishlocal:
-  ./gradlew publishToMavenLocal --exclude-task signMavenPublication
+  ./gradlew publishToMavenLocal -P localBuild

--- a/bdk-jvm/lib/build.gradle.kts
+++ b/bdk-jvm/lib/build.gradle.kts
@@ -107,6 +107,10 @@ afterEvaluate {
 }
 
 signing {
+    if (project.hasProperty("localBuild")) {
+        isRequired = false
+    }
+
     val signingKeyId: String? by project
     val signingKey: String? by project
     val signingPassword: String? by project


### PR DESCRIPTION
Our upgrade to Gradle 8.7 introduced some small issues when publishing the bdk-android and bdk-jvm libraries locally which were not discovered by the CI. This PR fixes them.