### PR TITLE
Serialize a raw transaction into bytes

### DIFF
--- a/bdk-ffi/src/bdk.udl
+++ b/bdk-ffi/src/bdk.udl
@@ -458,6 +458,8 @@ interface Transaction {
   boolean is_lock_time_enabled();
 
   i32 version();
+
+  sequence<u8> serialize();
 };
 
 interface Psbt {

--- a/bdk-ffi/src/bitcoin.rs
+++ b/bdk-ffi/src/bitcoin.rs
@@ -3,7 +3,9 @@ use crate::error::{AddressError, PsbtParseError, TransactionError};
 use bdk::bitcoin::address::{NetworkChecked, NetworkUnchecked};
 use bdk::bitcoin::blockdata::script::ScriptBuf as BdkScriptBuf;
 use bdk::bitcoin::blockdata::transaction::TxOut as BdkTxOut;
+use bdk::bitcoin::consensus::encode::serialize;
 use bdk::bitcoin::consensus::Decodable;
+use bdk::bitcoin::psbt::ExtractTxError;
 use bdk::bitcoin::Address as BdkAddress;
 use bdk::bitcoin::Network;
 use bdk::bitcoin::OutPoint as BdkOutPoint;
@@ -11,7 +13,6 @@ use bdk::bitcoin::Psbt as BdkPsbt;
 use bdk::bitcoin::Transaction as BdkTransaction;
 use bdk::bitcoin::Txid;
 
-use bdk::bitcoin::psbt::ExtractTxError;
 use std::io::Cursor;
 use std::str::FromStr;
 use std::sync::{Arc, Mutex};
@@ -139,10 +140,6 @@ impl Transaction {
         self.inner.vsize() as u64
     }
 
-    // fn serialize(&self) -> Vec<u8> {
-    //     self.inner.serialize()
-    // }
-
     pub fn is_coinbase(&self) -> bool {
         self.inner.is_coinbase()
     }
@@ -157,6 +154,10 @@ impl Transaction {
 
     pub fn version(&self) -> i32 {
         self.inner.version.0
+    }
+
+    pub fn serialize(&self) -> Vec<u8> {
+        serialize(&self.inner)
     }
 
     // fn lock_time(&self) -> u32 {


### PR DESCRIPTION
This is a method we had on the old gal (0.31.X) and took out because it was moved around in the rust-bitcoin crate and I didn't see it out of the gate and decided to leave it for a further PR.

### Changelog notice

```md
Added:
  - The Transaction type can now be serialized as raw bytes [#496]
 
[#496]: https://github.com/bitcoindevkit/bdk-ffi/pull/496
```

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
