### PR TITLE
Add weight method on transaction type

### DIFF
--- a/bdk-ffi/src/bdk.udl
+++ b/bdk-ffi/src/bdk.udl
@@ -526,6 +526,8 @@ interface Transaction {
   i32 version();
 
   sequence<u8> serialize();
+
+  u64 weight();
 };
 
 interface Psbt {

--- a/bdk-ffi/src/bitcoin.rs
+++ b/bdk-ffi/src/bitcoin.rs
@@ -129,9 +129,9 @@ impl Transaction {
         self.inner.txid().to_string()
     }
 
-    // fn weight(&self) -> u64 {
-    //     self.inner.weight() as u64
-    // }
+    pub fn weight(&self) -> u64 {
+        self.inner.weight().to_wu()
+    }
 
     pub fn total_size(&self) -> u64 {
         self.inner.total_size() as u64


### PR DESCRIPTION
The new `weight()` method returns a `Weight` type, which might be interesting to expose at some point, but I figured in this case it was useful to have at least what we had before (the method just returning a u64), so I pulled that weight out of the weight type and return it raw.

Easy win.