### PR TITLE
Prepare libraries for alpha 9 release

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -6,82 +6,90 @@ labels: 'release'
 assignees: ''
 ---
 
-## Create a new minor release
-## Bumping BDK Rust Version
+# Part 1: Bump BDK Rust Version
+
 1. - [ ] Open a PR with an update to `Cargo.toml` to the new bdk release candidate and ensure all CI workflows run correctly. Fix errors if necessary.
 2. - [ ] Once the new bdk release is out, update the PR to replace the release candidate with the full release and merge.
 
-### Specific Libraries' Workflows
-#### _Android_
+# Part 2: Prepare Libraries for Release Branch
+
+### _Android_
+
 3. - [ ] Update the API docs to reflect the changes in the API
-4. - [ ] Delete the `target` directory in bdk-ffi and all previous artifacts to make sure you're building the library from scratch.
-5. - [ ] Delete the `target` directory in bdk-ffi and all `build` directories (in root, `lib`, and `plugins`) in bdk-android directory to make sure you're building the library from scratch.
-6. - [ ] Build the library and run the offline and live tests, and adjust them if necessary (note that you'll need an Android emulator running).
+4. - [ ] Delete the `target` directory in bdk-ffi and all `build` directories (in root, `lib`, and `plugins`) in the bdk-android directory to make sure you're building the library from scratch.
+5. - [ ] Build the library and run the offline and live tests, and adjust them if necessary (note that you'll need an Android emulator running).
 ```shell
 # start an emulator prior to running the tests
 cd ./bdk-android/
-./gradlew buildAndroidLib
-./gradlew connectedAndroidTest
+just clean
+just build
+just test
 ```
-7. - [ ] Update the readme if necessary
+6. - [ ] Update the readme if necessary
 
-#### _JVM_
-8. - [ ] Update the API docs to reflect the changes in the API
-9. - [ ] Delete the `target` directory in bdk-ffi and all `build` directories (in root, `lib`, and `plugins`) in bdk-jvm directory to make sure you're building the library from scratch.
-10. - [ ] Build the library and run the tests, and adjust if necessary
+### _JVM_
+
+7. - [ ] Update the API docs to reflect the changes in the API
+8. - [ ] Delete the `target` directory in bdk-ffi and all `build` directories (in root, `lib`, and `plugins`) in bdk-jvm directory to make sure you're building the library from scratch.
+9. - [ ] Build the library and run the tests, and adjust if necessary
 ```shell
 cd ./bdk-jvm/
-./gradlew buildJvmLib
-./gradlew test
+just clean
+just build
+just test
 ```
-11.  - [ ] Update the readme if necessary
+10.  - [ ] Update the readme if necessary
 
-#### _Swift_
-12. - [ ] Delete the `target` directory in bdk-ffi
-13. - [ ] Run the tests and adjust if necessary
+### _Swift_
 
+11. - [ ] Delete the `target` directory in bdk-ffi
+12. - [ ] Run the tests and adjust if necessary
 ```shell
-./bdk-swift/build-local-swift.sh
 cd ./bdk-swift/
-swift test
+just clean
+just build
+just test
 ```
-14. - [ ] Update the readme if necessary
+13.  - [ ] Update the readme if necessary
 
-#### _Python_
-15. - [ ] Delete the `dist`, `build`, and `bdkpython.egg-info` and rust `target` directories to make sure you are building the library from scratch without any caches
-16. - [ ] Build the library
+### _Python_
+
+14. - [ ] Delete the `dist`, `build`, and `bdkpython.egg-info` and rust `target` directories to make sure you are building the library from scratch without any caches
+15. - [ ] Build the library
 ```shell
 cd ./bdk-python/
+just clean
 pip3 install --requirement requirements.txt
 bash ./scripts/generate-macos-arm64.sh # run the script for your particular platform
 python3 setup.py --verbose bdist_wheel
 ```
-17.  - [ ] Run the tests and adjust if necessary
+16.  - [ ] Run the tests and adjust if necessary
 ```shell
 pip3 install ./dist/bdkpython-<yourversion>-py3-none-any.whl --force-reinstall
 python -m unittest --verbose
 ```
-18.  - [ ] Update the readme and `setup.py` if necessary
+17.  - [ ] Update the readme and `setup.py` if necessary
+18. - [ ] Update the Android, JVM, Python, and Swift libraries as per the _Specific Libraries' Workflows_ section above. Open a single PR on master for all of these changes called `Prepare language bindings libraries for 0.X release`. See [example PR here](https://github.com/bitcoindevkit/bdk-ffi/pull/315).
 
-### Release Workflow
-19. - [ ] Update the Android, JVM, Python, and Swift libraries as per the _Specific Libraries' Workflows_ section above. Open a single PR on master for all of these changes called `Prepare language bindings libraries for 0.X release`. See [example PR here](https://github.com/bitcoindevkit/bdk-ffi/pull/315).
-20.. - [ ] Create a new branch off of `master` called `release/<feature version>`, e.g. `release/0.31`
-21. - [ ] Update bdk-android version from `SNAPSHOT` version to release version
-22. - [ ] Update bdk-jvm version from `SNAPSHOT` version to release version
-23. - [ ] Update bdk-python version from `.dev` version to release version
-24. - [ ] Open a PR to that release branch that updates the Android, JVM, and Python libraries' versions in step 19, 20, and 21. See [example PR here](https://github.com/bitcoindevkit/bdk-ffi/pull/316).
-25. - [ ] Get a review and ACK and merge the PR updating all the languages to their release versions
-26. - [ ] Create the tag for the release and make sure to add the changelog info to the tag (works better if you prepare the tag message on the side in a text editor). Push the tag to GitHub.
+## Part 3: Release Workflow
+
+19. - [ ] Create a new branch off of `master` called `release/<feature version>`, e.g. `release/0.31`
+20. - [ ] Update bdk-android version from `SNAPSHOT` version to release version
+21. - [ ] Update bdk-jvm version from `SNAPSHOT` version to release version
+22. - [ ] Update bdk-python version from `.dev` version to release version
+23. - [ ] Open a PR to that release branch that updates the Android, JVM, and Python libraries' versions in the three steps above. See [example PR here](https://github.com/bitcoindevkit/bdk-ffi/pull/316).
+24. - [ ] Get a review and ACK and merge the PR updating all the languages to their release versions
+25. - [ ] Create the tag for the release and make sure to add the changelog info to the tag (works better if you prepare the tag message on the side in a text editor). Push the tag to GitHub.
 ```shell
 git tag v0.6.0 --sign --edit
 git push upstream v0.6.0
 ```
-27. - [ ] Trigger manual releases for all 4 libraries (for Swift, go on the [bdk-swift](https://github.com/bitcoindevkit/bdk-swift) trigger the release on `master` and simply add the version number and tag name in the text fields when running the workflow manually. Note that the version number must not contain the `v`, i.e. `0.26.0`, but the tag will have it, i.e. `v0.26.0`).
-28. - [ ] Make sure the released libraries work and contain the artifacts you would expect 
-29. - [ ] Aggregate all the changelog notices from the PRs and add them to the changelog file
-30. - [ ] Bump the versions on master from `0.9.0-SNAPSHOT` to `0.10.0-SNAPSHOT`, `0.6.0.dev0` to `0.7.0.dev0`
-31. - [ ] Apply changes to the minor_release and patch_release issue templates if they need any
-32. - [ ] Open a PR on master with the changes in steps 29, 30, and 31. See [example PR here](https://github.com/bitcoindevkit/bdk-ffi/pull/317). Get a review and merge the PR.
-33. - [ ] Make release on GitHub (set as pre-release and generate auto release notes between the previous tag and the new one)
-34. - [ ] Post in the announcement channel
-35. - [ ] Tweet about the library
+26.  - [ ] Trigger manual releases for all 4 libraries (for Swift, go on the [bdk-swift](https://github.com/bitcoindevkit/bdk-swift) trigger the release on `master` and simply add the version number and tag name in the text fields when running the workflow manually. Note that the version number must not contain the `v`, i.e. `0.26.0`, but the tag will have it, i.e. `v0.26.0`).
+27.  - [ ] Make sure the released libraries work and contain the artifacts you would expect 
+28.  - [ ] Aggregate all the changelog notices from the PRs and add them to the changelog file
+29.  - [ ] Bump the versions on master from `0.9.0-SNAPSHOT` to `0.10.0-SNAPSHOT`, `0.6.0.dev0` to `0.7.0.dev0`
+30.  - [ ] Apply changes to the minor_release and patch_release issue templates if they need any
+31.  - [ ] Open a PR on master with the changes in steps 29, 30, and 31. See [example PR here](https://github.com/bitcoindevkit/bdk-ffi/pull/317). Get a review and merge the PR.
+32.  - [ ] Make release on GitHub (set as pre-release and generate auto release notes between the previous tag and the new one)
+33.  - [ ] Post in the announcement channel
+34.  - [ ] Tweet about the library

--- a/bdk-android/justfile
+++ b/bdk-android/justfile
@@ -9,3 +9,9 @@ build:
 
 publishlocal:
   ./gradlew publishToMavenLocal -P localBuild
+
+clean:
+  rm -rf ../bdk-ffi/target/
+  rm -rf ./build/
+  rm -rf ./lib/build/
+  rm -rf ./plugins/build/

--- a/bdk-android/lib/build.gradle.kts
+++ b/bdk-android/lib/build.gradle.kts
@@ -19,6 +19,7 @@ android {
 
     defaultConfig {
         minSdk = 21
+        targetSdk = 34
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")
     }

--- a/bdk-jvm/justfile
+++ b/bdk-jvm/justfile
@@ -12,3 +12,9 @@ build:
 
 publishlocal:
   ./gradlew publishToMavenLocal -P localBuild
+
+clean:
+  rm -rf ../bdk-ffi/target/
+  rm -rf ./build/
+  rm -rf ./lib/build/
+  rm -rf ./plugins/build/

--- a/bdk-python/justfile
+++ b/bdk-python/justfile
@@ -3,3 +3,9 @@ test:
 
 maclocalbuild:
   bash ./scripts/generate-macos-arm64.sh && python3 setup.py bdist_wheel --verbose
+
+clean:
+  rm -rf ../bdk-ffi/target/
+  rm -rf ./bdkpython.egg-info/
+  rm -rf ./build/
+  rm -rf ./dist/

--- a/bdk-swift/justfile
+++ b/bdk-swift/justfile
@@ -6,3 +6,6 @@ test:
 
 offlinetests:
   swift test --skip LiveWalletTests --skip LiveTxBuilderTests
+
+clean:
+  rm -rf ../bdk-ffi/target/


### PR DESCRIPTION
This PR brings in a small fix required for the alpha 9 release on Android (plus a new `clean` task as part of the justfiles), and an update to the release workflow.