### PR TITLE
Bump Rust compiler to 1.77.1

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - version: 1.73.0
+          - version: 1.77.1
             clippy: true
     steps:
       - name: "Checkout"

--- a/.github/workflows/live-tests.yaml
+++ b/.github/workflows/live-tests.yaml
@@ -27,8 +27,8 @@ jobs:
           distribution: temurin
           java-version: 11
 
-      - name: "Set default Rust version to 1.73.0"
-        run: rustup default 1.73.0
+      - name: "Set default Rust version to 1.77.1"
+        run: rustup default 1.77.1
 
       - name: "Build bdk-jvm library"
         run: |

--- a/.github/workflows/publish-android.yaml
+++ b/.github/workflows/publish-android.yaml
@@ -25,8 +25,8 @@ jobs:
           distribution: temurin
           java-version: 17
 
-      - name: "Set default Rust version to 1.73.0"
-        run: rustup default 1.73.0
+      - name: "Set default Rust version to 1.77.1"
+        run: rustup default 1.77.1
 
       - name: "Install Rust Android targets"
         run: rustup target add x86_64-linux-android aarch64-linux-android armv7-linux-androideabi

--- a/.github/workflows/publish-jvm.yaml
+++ b/.github/workflows/publish-jvm.yaml
@@ -24,8 +24,8 @@ jobs:
           distribution: temurin
           java-version: 17
 
-      - name: "Set default Rust version to 1.73.0"
-        run: rustup default 1.73.0
+      - name: "Set default Rust version to 1.77.1"
+        run: rustup default 1.77.1
 
       - name: "Install aarch64 Rust target"
         run: rustup target add aarch64-apple-darwin
@@ -54,8 +54,8 @@ jobs:
           distribution: temurin
           java-version: 17
 
-      - name: "Set default Rust version to 1.73.0"
-        run: rustup default 1.73.0
+      - name: "Set default Rust version to 1.77.1"
+        run: rustup default 1.77.1
 
       - name: "Install x86_64-pc-windows-msvc Rust target"
         run: rustup target add x86_64-pc-windows-msvc
@@ -94,8 +94,8 @@ jobs:
           distribution: temurin
           java-version: 17
 
-      - name: "Set default Rust version to 1.73.0"
-        run: rustup default 1.73.0
+      - name: "Set default Rust version to 1.77.1"
+        run: rustup default 1.77.1
 
       - name: "Build bdk-jvm library"
         run: |

--- a/.github/workflows/test-android.yaml
+++ b/.github/workflows/test-android.yaml
@@ -37,8 +37,8 @@ jobs:
           distribution: temurin
           java-version: 17
 
-      - name: "Set default Rust version to 1.73.0"
-        run: rustup default 1.73.0
+      - name: "Set default Rust version to 1.77.1"
+        run: rustup default 1.77.1
 
       - name: "Install Rust Android targets"
         run: rustup target add x86_64-linux-android aarch64-linux-android armv7-linux-androideabi

--- a/.github/workflows/test-jvm.yaml
+++ b/.github/workflows/test-jvm.yaml
@@ -32,8 +32,8 @@ jobs:
           distribution: temurin
           java-version: 17
 
-      - name: "Set default Rust version to 1.73.0"
-        run: rustup default 1.73.0
+      - name: "Set default Rust version to 1.77.1"
+        run: rustup default 1.77.1
 
       - name: "Run JVM tests"
         run: |

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ just publishlocal
 ```
 
 ## Minimum Supported Rust Version (MSRV)
-This library should compile with any combination of features with Rust 1.73.0.
+This library should compile with any combination of features with Rust 1.77.1.
 
 ## Contributing
 To add new structs and functions, see the [UniFFI User Guide](https://mozilla.github.io/uniffi-rs/) and the [uniffi-examples](https://thunderbiscuit.github.io/uniffi-examples/) repository.

--- a/bdk-android/README.md
+++ b/bdk-android/README.md
@@ -38,10 +38,10 @@ _Note that Kotlin version `1.9.23` or later is required to build the library._
 git clone https://github.com/bitcoindevkit/bdk-ffi
 ```
 2. Follow the "General" bdk-ffi ["Getting Started (Developer)"] instructions. 
-3. Install Rust (note that we are currently building using Rust 1.73.0):
+3. Install Rust (note that we are currently building using Rust 1.77.1):
 ```shell
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
-rustup default 1.73.0
+rustup default 1.77.1
 ```
 4. Install required targets
 ```sh

--- a/bdk-ffi/src/bdk.udl
+++ b/bdk-ffi/src/bdk.udl
@@ -63,7 +63,7 @@ interface AddressError {
   ExcessiveScriptSize();
   UnrecognizedScript();
   NetworkValidation(Network required, Network found, string address);
-  OtherAddressError();
+  OtherAddressErr();
 };
 
 [Error]
@@ -74,7 +74,7 @@ interface TransactionError {
   NonMinimalVarInt();
   ParseFailed();
   UnsupportedSegwitFlag(u8 flag);
-  OtherTransactionError();
+  OtherTransactionErr();
 };
 
 [Error]
@@ -109,7 +109,7 @@ interface ExtractTxError {
   AbsurdFeeRate(u64 fee_rate);
   MissingInputValue();
   SendingTooMuch();
-  OtherExtractTransactionError();
+  OtherExtractTxErr();
 };
 
 // ------------------------------------------------------------------------

--- a/bdk-ffi/src/error.rs
+++ b/bdk-ffi/src/error.rs
@@ -156,7 +156,7 @@ pub enum AddressError {
 
     // This is required because the bdk::bitcoin::address::Error is non-exhaustive
     #[error("other address error")]
-    OtherAddressError,
+    OtherAddressErr,
 }
 
 // Mapping https://docs.rs/bitcoin/latest/src/bitcoin/consensus/encode.rs.html#40-63
@@ -182,7 +182,7 @@ pub enum TransactionError {
 
     // This is required because the bdk::bitcoin::consensus::encode::Error is non-exhaustive
     #[error("other transaction error")]
-    OtherTransactionError,
+    OtherTransactionErr,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -247,7 +247,7 @@ pub enum ExtractTxError {
     #[error(
         "this error is required because the bdk::bitcoin::psbt::ExtractTxError is non-exhaustive"
     )]
-    OtherExtractTransactionError,
+    OtherExtractTxErr,
 }
 
 impl From<BdkDescriptorError> for DescriptorError {
@@ -439,7 +439,7 @@ impl From<bdk::bitcoin::address::Error> for AddressError {
                 found,
                 address: format!("{:?}", address),
             },
-            _ => AddressError::OtherAddressError,
+            _ => AddressError::OtherAddressErr,
         }
     }
 }
@@ -455,7 +455,7 @@ impl From<ParseError> for AddressError {
             ParseError::WitnessProgram(e) => AddressError::WitnessProgram {
                 error_message: e.to_string(),
             },
-            _ => AddressError::OtherAddressError,
+            _ => AddressError::OtherAddressErr,
         }
     }
 }
@@ -480,7 +480,7 @@ impl From<bdk::bitcoin::consensus::encode::Error> for TransactionError {
             bdk::bitcoin::consensus::encode::Error::UnsupportedSegwitFlag(flag) => {
                 TransactionError::UnsupportedSegwitFlag { flag }
             }
-            _ => TransactionError::OtherTransactionError,
+            _ => TransactionError::OtherTransactionErr,
         }
     }
 }
@@ -500,7 +500,7 @@ impl From<bdk::bitcoin::psbt::ExtractTxError> for ExtractTxError {
             bdk::bitcoin::psbt::ExtractTxError::SendingTooMuch { .. } => {
                 ExtractTxError::SendingTooMuch
             }
-            _ => ExtractTxError::OtherExtractTransactionError,
+            _ => ExtractTxError::OtherExtractTxErr,
         }
     }
 }

--- a/bdk-jvm/README.md
+++ b/bdk-jvm/README.md
@@ -36,10 +36,10 @@ curl -s "https://get.sdkman.io" | bash
 source "$HOME/.sdkman/bin/sdkman-init.sh"
 sdk install java 17.0.2-tem
 ```
-2. Install Rust (note that we are currently building using Rust 1.73.0):
+2. Install Rust (note that we are currently building using Rust 1.77.1):
 ```shell
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
-rustup default 1.73.0
+rustup default 1.77.1
 ```
 3. Clone this repository.
 ```shell

--- a/bdk-python/scripts/generate-linux.sh
+++ b/bdk-python/scripts/generate-linux.sh
@@ -9,7 +9,7 @@ cd ../bdk-ffi/
 cargo run --bin uniffi-bindgen generate src/bdk.udl --language python --out-dir ../bdk-python/src/bdkpython/ --no-format
 
 echo "Generating native binaries..."
-rustup default 1.73.0
+rustup default 1.77.1
 cargo build --profile release-smaller
 
 echo "Copying linux libbdkffi.so..."

--- a/bdk-python/scripts/generate-macos-arm64.sh
+++ b/bdk-python/scripts/generate-macos-arm64.sh
@@ -9,7 +9,7 @@ cd ../bdk-ffi/
 cargo run --bin uniffi-bindgen generate src/bdk.udl --language python --out-dir ../bdk-python/src/bdkpython/ --no-format
 
 echo "Generating native binaries..."
-rustup default 1.73.0
+rustup default 1.77.1
 rustup target add aarch64-apple-darwin
 cargo build --profile release-smaller --target aarch64-apple-darwin
 

--- a/bdk-python/scripts/generate-macos-x86_64.sh
+++ b/bdk-python/scripts/generate-macos-x86_64.sh
@@ -9,7 +9,7 @@ cd ../bdk-ffi/
 cargo run --bin uniffi-bindgen generate src/bdk.udl --language python --out-dir ../bdk-python/src/bdkpython/ --no-format
 
 echo "Generating native binaries..."
-rustup default 1.73.0
+rustup default 1.77.1
 rustup target add x86_64-apple-darwin
 cargo build --profile release-smaller --target x86_64-apple-darwin
 

--- a/bdk-python/scripts/generate-windows.sh
+++ b/bdk-python/scripts/generate-windows.sh
@@ -9,7 +9,7 @@ cd ../bdk-ffi/
 cargo run --bin uniffi-bindgen generate src/bdk.udl --language python --out-dir ../bdk-python/src/bdkpython/ --no-format
 
 echo "Generating native binaries..."
-rustup default 1.73.0
+rustup default 1.77.1
 rustup target add x86_64-pc-windows-msvc
 cargo build --profile release-smaller --target x86_64-pc-windows-msvc
 

--- a/bdk-swift/build-local-swift.sh
+++ b/bdk-swift/build-local-swift.sh
@@ -3,7 +3,7 @@
 # The results of this script can be used for locally testing your SPM package adding a local package
 # to your application pointing at the bdk-swift directory.
 
-rustup install 1.73.0
+rustup install 1.77.1
 rustup component add rust-src
 rustup target add aarch64-apple-ios      # iOS arm64
 rustup target add x86_64-apple-ios       # iOS x86_64

--- a/bdk-swift/build-local-swift.sh
+++ b/bdk-swift/build-local-swift.sh
@@ -3,7 +3,7 @@
 # The results of this script can be used for locally testing your SPM package adding a local package
 # to your application pointing at the bdk-swift directory.
 
-rustup install 1.77.1
+rustup default 1.77.1
 rustup component add rust-src
 rustup target add aarch64-apple-ios      # iOS arm64
 rustup target add x86_64-apple-ios       # iOS x86_64


### PR DESCRIPTION
Trying to run this through the CI.

The [security audit](https://github.com/bitcoindevkit/bdk-ffi/actions/runs/8757105604) sent me down this rabbit hole. Note that even uniffi has updated their minimum Rust version to 1.74, so our builds were about to run into problems anyway. I'm using the 1.77.1 version of the Rust compiler here because the actual latest Rust stable (1.77.2) breaks, and Mozilla uses 1.77.1.