### PR TITLE
Add descriptor key related error

### DIFF
--- a/bdk-ffi/src/bdk.udl
+++ b/bdk-ffi/src/bdk.udl
@@ -34,6 +34,13 @@ interface Bip32Error {
 };
 
 [Error]
+interface DescriptorKeyError {
+  Parse(string e);
+  InvalidKeyType();
+  Bip32(string e);
+};
+
+[Error]
 interface CalculateFeeError {
   MissingTxOut(sequence<OutPoint> out_points);
   NegativeFee(i64 fee);
@@ -369,13 +376,13 @@ interface DerivationPath {
 interface DescriptorSecretKey {
   constructor(Network network, [ByRef] Mnemonic mnemonic, string? password);
 
-  [Name=from_string, Throws=Alpha3Error]
+  [Name=from_string, Throws=DescriptorKeyError]
   constructor(string secret_key);
 
-  [Throws=Alpha3Error]
+  [Throws=DescriptorKeyError]
   DescriptorSecretKey derive([ByRef] DerivationPath path);
 
-  [Throws=Alpha3Error]
+  [Throws=DescriptorKeyError]
   DescriptorSecretKey extend([ByRef] DerivationPath path);
 
   DescriptorPublicKey as_public();
@@ -386,13 +393,13 @@ interface DescriptorSecretKey {
 };
 
 interface DescriptorPublicKey {
-  [Name=from_string, Throws=Alpha3Error]
+  [Name=from_string, Throws=DescriptorKeyError]
   constructor(string public_key);
 
-  [Throws=Alpha3Error]
+  [Throws=DescriptorKeyError]
   DescriptorPublicKey derive([ByRef] DerivationPath path);
 
-  [Throws=Alpha3Error]
+  [Throws=DescriptorKeyError]
   DescriptorPublicKey extend([ByRef] DerivationPath path);
 
   string as_string();

--- a/bdk-ffi/src/error.rs
+++ b/bdk-ffi/src/error.rs
@@ -16,6 +16,7 @@ use bitcoin_internals::hex::display::DisplayHex;
 use crate::error::bip32::Error as BdkBip32Error;
 use bdk::bitcoin::address::ParseError;
 use bdk::keys::bip39::Error as BdkBip39Error;
+use bdk::miniscript::descriptor::DescriptorKeyParseError as BdkDescriptorKeyParseError;
 
 use bdk::bitcoin::bip32;
 
@@ -131,6 +132,18 @@ pub enum CreateTxError {
 
     #[error("Miniscript PSBT error: {e}")]
     MiniscriptPsbt { e: String },
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum DescriptorKeyError {
+    #[error("error parsing descriptor key: {e}")]
+    Parse { e: String },
+
+    #[error("error invalid key type")]
+    InvalidKeyType,
+
+    #[error("error bip 32 related: {e}")]
+    Bip32 { e: String },
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -541,6 +554,22 @@ impl From<BdkSignerError> for SignerError {
                 e: format!("{:?}", e),
             },
             BdkSignerError::External(e) => SignerError::External { e },
+        }
+    }
+}
+
+impl From<BdkDescriptorKeyParseError> for DescriptorKeyError {
+    fn from(err: BdkDescriptorKeyParseError) -> DescriptorKeyError {
+        DescriptorKeyError::Parse {
+            e: format!("DescriptorKeyError error: {:?}", err),
+        }
+    }
+}
+
+impl From<bdk::bitcoin::bip32::Error> for DescriptorKeyError {
+    fn from(err: bdk::bitcoin::bip32::Error) -> DescriptorKeyError {
+        DescriptorKeyError::Bip32 {
+            e: format!("BIP32 derivation error: {:?}", err),
         }
     }
 }

--- a/bdk-ffi/src/lib.rs
+++ b/bdk-ffi/src/lib.rs
@@ -22,6 +22,7 @@ use crate::error::CalculateFeeError;
 use crate::error::CannotConnectError;
 use crate::error::CreateTxError;
 use crate::error::DescriptorError;
+use crate::error::DescriptorKeyError;
 use crate::error::EsploraError;
 use crate::error::ExtractTxError;
 use crate::error::FeeRateError;


### PR DESCRIPTION
<!-- Erase any parts of this template not applicable to your Pull Request. -->

### Description

[DescriptorSecretKey](https://docs.rs/bdk/1.0.0-alpha.9/bdk/keys/enum.DescriptorSecretKey.html)+[DescriptorPublicKey](https://docs.rs/bdk/1.0.0-alpha.9/bdk/descriptor/enum.DescriptorPublicKey.html) [Error](https://docs.rs/miniscript/11.0.0/miniscript/descriptor/struct.DescriptorKeyParseError.html)

### Notes to the reviewers

[FromStr](https://docs.rs/bdk/1.0.0-alpha.9/bdk/keys/enum.DescriptorSecretKey.html#impl-FromStr-for-DescriptorSecretKey) throws [DescriptorKeyParseError](https://docs.rs/miniscript/11.0.0/miniscript/descriptor/struct.DescriptorKeyParseError.html)

[derive_priv](https://docs.rs/bitcoin/0.31.2/bitcoin/bip32/struct.Xpriv.html#method.derive_priv) for `DescriptorSecretKey::XPrv` throws a [Bip32 Error](https://docs.rs/bitcoin/0.31.2/bitcoin/bip32/enum.Error.html)

`extend` for `DescriptorSecretKey::XPrv` constructs [DescriptorXKey](https://docs.rs/miniscript/11.0.0/miniscript/descriptor/struct.DescriptorXKey.html) 

**Note on `InvalidKeyType`:**
- for `Single` and `MultiXPrv` they are unreachable under the hood, etc, and thus throw `InvalidKeyType`
- didn't create a  `From` for `InvalidKeyType` because it suggests that some outside error could turn into an `InvalidKeyType` error, which isn’t really the case, so it seemed better to just use `InvalidKeyType` directly in the body of the functions, to keep things clear.

### Changelog notice

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [x] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
