### PR TITLE
Refactor: move structs with one inner field containing a BDK type to tuple structs

### DIFF
--- a/bdk-ffi/justfile
+++ b/bdk-ffi/justfile
@@ -3,3 +3,7 @@ build:
 
 test:
   cargo test --lib
+
+check:
+  cargo fmt
+  cargo clippy

--- a/bdk-ffi/src/bitcoin.rs
+++ b/bdk-ffi/src/bitcoin.rs
@@ -124,7 +124,7 @@ impl Transaction {
     }
 
     pub fn weight(&self) -> u64 {
-        self.inner.weight().to_wu()
+        self.0.weight().to_wu()
     }
 
     pub fn total_size(&self) -> u64 {

--- a/bdk-ffi/src/bitcoin.rs
+++ b/bdk-ffi/src/bitcoin.rs
@@ -39,18 +39,14 @@ impl From<BdkScriptBuf> for Script {
 }
 
 #[derive(Debug, PartialEq, Eq)]
-pub struct Address {
-    inner: BdkAddress<NetworkChecked>,
-}
+pub struct Address(BdkAddress<NetworkChecked>);
 
 impl Address {
     pub fn new(address: String, network: Network) -> Result<Self, AddressError> {
         let parsed_address = address.parse::<bdk::bitcoin::Address<NetworkUnchecked>>()?;
         let network_checked_address = parsed_address.require_network(network)?;
 
-        Ok(Address {
-            inner: network_checked_address,
-        })
+        Ok(Address(network_checked_address))
     }
 
     /// alternative constructor
@@ -76,23 +72,23 @@ impl Address {
     // }
 
     pub fn network(&self) -> Network {
-        *self.inner.network()
+        *self.0.network()
     }
 
     pub fn script_pubkey(&self) -> Arc<Script> {
-        Arc::new(Script(self.inner.script_pubkey()))
+        Arc::new(Script(self.0.script_pubkey()))
     }
 
     pub fn to_qr_uri(&self) -> String {
-        self.inner.to_qr_uri()
+        self.0.to_qr_uri()
     }
 
     pub fn as_string(&self) -> String {
-        self.inner.to_string()
+        self.0.to_string()
     }
 
     pub fn is_valid_for_network(&self, network: Network) -> bool {
-        let address_str = self.inner.to_string();
+        let address_str = self.0.to_string();
         if let Ok(unchecked_address) = address_str.parse::<BdkAddress<NetworkUnchecked>>() {
             unchecked_address.is_valid_for_network(network)
         } else {
@@ -103,13 +99,13 @@ impl Address {
 
 impl From<Address> for BdkAddress {
     fn from(address: Address) -> Self {
-        address.inner
+        address.0
     }
 }
 
 impl From<BdkAddress> for Address {
     fn from(address: BdkAddress) -> Self {
-        Address { inner: address }
+        Address(address)
     }
 }
 

--- a/bdk-ffi/src/bitcoin.rs
+++ b/bdk-ffi/src/bitcoin.rs
@@ -110,19 +110,17 @@ impl From<BdkAddress> for Address {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Transaction {
-    inner: BdkTransaction,
-}
+pub struct Transaction(BdkTransaction);
 
 impl Transaction {
     pub fn new(transaction_bytes: Vec<u8>) -> Result<Self, TransactionError> {
         let mut decoder = Cursor::new(transaction_bytes);
         let tx: BdkTransaction = BdkTransaction::consensus_decode(&mut decoder)?;
-        Ok(Transaction { inner: tx })
+        Ok(Transaction(tx))
     }
 
     pub fn txid(&self) -> String {
-        self.inner.txid().to_string()
+        self.0.txid().to_string()
     }
 
     pub fn weight(&self) -> u64 {
@@ -130,31 +128,31 @@ impl Transaction {
     }
 
     pub fn total_size(&self) -> u64 {
-        self.inner.total_size() as u64
+        self.0.total_size() as u64
     }
 
     pub fn vsize(&self) -> u64 {
-        self.inner.vsize() as u64
+        self.0.vsize() as u64
     }
 
     pub fn is_coinbase(&self) -> bool {
-        self.inner.is_coinbase()
+        self.0.is_coinbase()
     }
 
     pub fn is_explicitly_rbf(&self) -> bool {
-        self.inner.is_explicitly_rbf()
+        self.0.is_explicitly_rbf()
     }
 
     pub fn is_lock_time_enabled(&self) -> bool {
-        self.inner.is_lock_time_enabled()
+        self.0.is_lock_time_enabled()
     }
 
     pub fn version(&self) -> i32 {
-        self.inner.version.0
+        self.0.version.0
     }
 
     pub fn serialize(&self) -> Vec<u8> {
-        serialize(&self.inner)
+        serialize(&self.0)
     }
 
     // fn lock_time(&self) -> u32 {
@@ -172,19 +170,19 @@ impl Transaction {
 
 impl From<BdkTransaction> for Transaction {
     fn from(tx: BdkTransaction) -> Self {
-        Transaction { inner: tx }
+        Transaction(tx)
     }
 }
 
 impl From<&BdkTransaction> for Transaction {
     fn from(tx: &BdkTransaction) -> Self {
-        Transaction { inner: tx.clone() }
+        Transaction(tx.clone())
     }
 }
 
 impl From<&Transaction> for BdkTransaction {
     fn from(tx: &Transaction) -> Self {
-        tx.inner.clone()
+        tx.0.clone()
     }
 }
 

--- a/bdk-ffi/src/bitcoin.rs
+++ b/bdk-ffi/src/bitcoin.rs
@@ -186,20 +186,16 @@ impl From<&Transaction> for BdkTransaction {
     }
 }
 
-pub struct Psbt {
-    pub(crate) inner: Mutex<BdkPsbt>,
-}
+pub struct Psbt(pub(crate) Mutex<BdkPsbt>);
 
 impl Psbt {
     pub(crate) fn new(psbt_base64: String) -> Result<Self, PsbtParseError> {
         let psbt: BdkPsbt = BdkPsbt::from_str(&psbt_base64)?;
-        Ok(Psbt {
-            inner: Mutex::new(psbt),
-        })
+        Ok(Psbt(Mutex::new(psbt)))
     }
 
     pub(crate) fn serialize(&self) -> String {
-        let psbt = self.inner.lock().unwrap().clone();
+        let psbt = self.0.lock().unwrap().clone();
         psbt.to_string()
     }
 
@@ -210,7 +206,7 @@ impl Psbt {
     // }
 
     pub(crate) fn extract_tx(&self) -> Result<Arc<Transaction>, ExtractTxError> {
-        let tx: BdkTransaction = self.inner.lock().unwrap().clone().extract_tx()?;
+        let tx: BdkTransaction = self.0.lock().unwrap().clone().extract_tx()?;
         let transaction: Transaction = tx.into();
         Ok(Arc::new(transaction))
     }
@@ -254,9 +250,7 @@ impl Psbt {
 
 impl From<BdkPsbt> for Psbt {
     fn from(psbt: BdkPsbt) -> Self {
-        Psbt {
-            inner: Mutex::new(psbt),
-        }
+        Psbt(Mutex::new(psbt))
     }
 }
 

--- a/bdk-ffi/src/descriptor.rs
+++ b/bdk-ffi/src/descriptor.rs
@@ -37,7 +37,7 @@ impl Descriptor {
         keychain_kind: KeychainKind,
         network: Network,
     ) -> Self {
-        let derivable_key = &secret_key.inner;
+        let derivable_key = &secret_key.0;
 
         match derivable_key {
             BdkDescriptorSecretKey::Single(_) => {
@@ -65,7 +65,7 @@ impl Descriptor {
         network: Network,
     ) -> Self {
         let fingerprint = Fingerprint::from_str(fingerprint.as_str()).unwrap();
-        let derivable_key = &public_key.inner;
+        let derivable_key = &public_key.0;
 
         match derivable_key {
             BdkDescriptorPublicKey::Single(_) => {
@@ -94,7 +94,7 @@ impl Descriptor {
         keychain_kind: KeychainKind,
         network: Network,
     ) -> Self {
-        let derivable_key = &secret_key.inner;
+        let derivable_key = &secret_key.0;
 
         match derivable_key {
             BdkDescriptorSecretKey::Single(_) => {
@@ -122,7 +122,7 @@ impl Descriptor {
         network: Network,
     ) -> Self {
         let fingerprint = Fingerprint::from_str(fingerprint.as_str()).unwrap();
-        let derivable_key = &public_key.inner;
+        let derivable_key = &public_key.0;
 
         match derivable_key {
             BdkDescriptorPublicKey::Single(_) => {
@@ -151,7 +151,7 @@ impl Descriptor {
         keychain_kind: KeychainKind,
         network: Network,
     ) -> Self {
-        let derivable_key = &secret_key.inner;
+        let derivable_key = &secret_key.0;
 
         match derivable_key {
             BdkDescriptorSecretKey::Single(_) => {
@@ -179,7 +179,7 @@ impl Descriptor {
         network: Network,
     ) -> Self {
         let fingerprint = Fingerprint::from_str(fingerprint.as_str()).unwrap();
-        let derivable_key = &public_key.inner;
+        let derivable_key = &public_key.0;
 
         match derivable_key {
             BdkDescriptorPublicKey::Single(_) => {
@@ -208,7 +208,7 @@ impl Descriptor {
         keychain_kind: KeychainKind,
         network: Network,
     ) -> Self {
-        let derivable_key = &secret_key.inner;
+        let derivable_key = &secret_key.0;
 
         match derivable_key {
             BdkDescriptorSecretKey::Single(_) => {
@@ -236,7 +236,7 @@ impl Descriptor {
         network: Network,
     ) -> Self {
         let fingerprint = Fingerprint::from_str(fingerprint.as_str()).unwrap();
-        let derivable_key = &public_key.inner;
+        let derivable_key = &public_key.0;
 
         match derivable_key {
             BdkDescriptorPublicKey::Single(_) => {

--- a/bdk-ffi/src/keys.rs
+++ b/bdk-ffi/src/keys.rs
@@ -18,9 +18,7 @@ use std::ops::Deref;
 use std::str::FromStr;
 use std::sync::{Arc, Mutex};
 
-pub(crate) struct Mnemonic {
-    inner: BdkMnemonic,
-}
+pub(crate) struct Mnemonic(pub(crate) BdkMnemonic);
 
 impl Mnemonic {
     pub(crate) fn new(word_count: WordCount) -> Self {
@@ -32,23 +30,23 @@ impl Mnemonic {
         let generated_key: GeneratedKey<_, BareCtx> =
             BdkMnemonic::generate_with_entropy((word_count, Language::English), entropy).unwrap();
         let mnemonic = BdkMnemonic::parse_in(Language::English, generated_key.to_string()).unwrap();
-        Mnemonic { inner: mnemonic }
+        Mnemonic(mnemonic)
     }
 
     pub(crate) fn from_string(mnemonic: String) -> Result<Self, Bip39Error> {
         BdkMnemonic::from_str(&mnemonic)
-            .map(|m| Mnemonic { inner: m })
+            .map(Mnemonic)
             .map_err(Bip39Error::from)
     }
 
     pub(crate) fn from_entropy(entropy: Vec<u8>) -> Result<Self, Bip39Error> {
         BdkMnemonic::from_entropy(entropy.as_slice())
-            .map(|m| Mnemonic { inner: m })
+            .map(Mnemonic)
             .map_err(Bip39Error::from)
     }
 
     pub(crate) fn as_string(&self) -> String {
-        self.inner.to_string()
+        self.0.to_string()
     }
 }
 
@@ -73,7 +71,7 @@ pub struct DescriptorSecretKey {
 
 impl DescriptorSecretKey {
     pub(crate) fn new(network: Network, mnemonic: &Mnemonic, password: Option<String>) -> Self {
-        let mnemonic = mnemonic.inner.clone();
+        let mnemonic = mnemonic.0.clone();
         let xkey: ExtendedKey = (mnemonic, password).into_extended_key().unwrap();
         let descriptor_secret_key = BdkDescriptorSecretKey::XPrv(DescriptorXKey {
             origin: None,

--- a/bdk-ffi/src/keys.rs
+++ b/bdk-ffi/src/keys.rs
@@ -65,9 +65,7 @@ impl DerivationPath {
 }
 
 #[derive(Debug)]
-pub struct DescriptorSecretKey {
-    pub(crate) inner: BdkDescriptorSecretKey,
-}
+pub struct DescriptorSecretKey(pub(crate) BdkDescriptorSecretKey);
 
 impl DescriptorSecretKey {
     pub(crate) fn new(network: Network, mnemonic: &Mnemonic, password: Option<String>) -> Self {
@@ -79,22 +77,18 @@ impl DescriptorSecretKey {
             derivation_path: BdkDerivationPath::master(),
             wildcard: Wildcard::Unhardened,
         });
-        Self {
-            inner: descriptor_secret_key,
-        }
+        Self(descriptor_secret_key)
     }
 
     pub(crate) fn from_string(private_key: String) -> Result<Self, DescriptorKeyError> {
         let descriptor_secret_key = BdkDescriptorSecretKey::from_str(private_key.as_str())
             .map_err(DescriptorKeyError::from)?;
-        Ok(Self {
-            inner: descriptor_secret_key,
-        })
+        Ok(Self(descriptor_secret_key))
     }
 
     pub(crate) fn derive(&self, path: &DerivationPath) -> Result<Arc<Self>, DescriptorKeyError> {
         let secp = Secp256k1::new();
-        let descriptor_secret_key = &self.inner;
+        let descriptor_secret_key = &self.0;
         let path = path.inner_mutex.lock().unwrap().deref().clone();
         match descriptor_secret_key {
             BdkDescriptorSecretKey::Single(_) => Err(DescriptorKeyError::InvalidKeyType),
@@ -113,16 +107,14 @@ impl DescriptorSecretKey {
                     derivation_path: BdkDerivationPath::default(),
                     wildcard: descriptor_x_key.wildcard,
                 });
-                Ok(Arc::new(Self {
-                    inner: derived_descriptor_secret_key,
-                }))
+                Ok(Arc::new(Self(derived_descriptor_secret_key)))
             }
             BdkDescriptorSecretKey::MultiXPrv(_) => Err(DescriptorKeyError::InvalidKeyType),
         }
     }
 
-    pub(crate) fn extend(&self, path: &DerivationPath) -> Result<Arc<Self>, DescriptorKeyError> {
-        let descriptor_secret_key = &self.inner;
+    pub(crate) fn extend(&self, path: &DerivationPath) -> Result<Arc<Self>, Alpha3Error> {
+        let descriptor_secret_key = &self.0;
         let path = path.inner_mutex.lock().unwrap().deref().clone();
         match descriptor_secret_key {
             BdkDescriptorSecretKey::Single(_) => Err(DescriptorKeyError::InvalidKeyType),
@@ -134,9 +126,7 @@ impl DescriptorSecretKey {
                     derivation_path: extended_path,
                     wildcard: descriptor_x_key.wildcard,
                 });
-                Ok(Arc::new(Self {
-                    inner: extended_descriptor_secret_key,
-                }))
+                Ok(Arc::new(Self(extended_descriptor_secret_key)))
             }
             BdkDescriptorSecretKey::MultiXPrv(_) => Err(DescriptorKeyError::InvalidKeyType),
         }
@@ -144,14 +134,14 @@ impl DescriptorSecretKey {
 
     pub(crate) fn as_public(&self) -> Arc<DescriptorPublicKey> {
         let secp = Secp256k1::new();
-        let descriptor_public_key = self.inner.to_public(&secp).unwrap();
+        let descriptor_public_key = self.0.to_public(&secp).unwrap();
         Arc::new(DescriptorPublicKey {
             inner: descriptor_public_key,
         })
     }
 
     pub(crate) fn secret_bytes(&self) -> Vec<u8> {
-        let inner = &self.inner;
+        let inner = &self.0;
         let secret_bytes: Vec<u8> = match inner {
             BdkDescriptorSecretKey::Single(_) => {
                 unreachable!()
@@ -168,7 +158,7 @@ impl DescriptorSecretKey {
     }
 
     pub(crate) fn as_string(&self) -> String {
-        self.inner.to_string()
+        self.0.to_string()
     }
 }
 

--- a/bdk-ffi/src/keys.rs
+++ b/bdk-ffi/src/keys.rs
@@ -113,7 +113,7 @@ impl DescriptorSecretKey {
         }
     }
 
-    pub(crate) fn extend(&self, path: &DerivationPath) -> Result<Arc<Self>, Alpha3Error> {
+    pub(crate) fn extend(&self, path: &DerivationPath) -> Result<Arc<Self>, DescriptorKeyError> {
         let descriptor_secret_key = &self.0;
         let path = path.inner_mutex.lock().unwrap().deref().clone();
         match descriptor_secret_key {
@@ -198,7 +198,7 @@ impl DescriptorPublicKey {
         }
     }
 
-    pub(crate) fn extend(&self, path: &DerivationPath) -> Result<Arc<Self>, Alpha3Error> {
+    pub(crate) fn extend(&self, path: &DerivationPath) -> Result<Arc<Self>, DescriptorKeyError> {
         let descriptor_public_key = &self.0;
         let path = path.inner_mutex.lock().unwrap().deref().clone();
         match descriptor_public_key {

--- a/bdk-ffi/src/wallet.rs
+++ b/bdk-ffi/src/wallet.rs
@@ -95,7 +95,7 @@ impl Wallet {
         psbt: Arc<Psbt>,
         // sign_options: Option<SignOptions>,
     ) -> Result<bool, SignerError> {
-        let mut psbt = psbt.inner.lock().unwrap();
+        let mut psbt = psbt.0.lock().unwrap();
         self.get_wallet()
             .sign(&mut psbt, SignOptions::default())
             .map_err(SignerError::from)


### PR DESCRIPTION
This is something we had decided to start doing a while back, and never really enforced (and back ported the old code). This PR simply streamline our use of tuple structs when we need a type that wraps a single BDK type. Note that I did 6 of those types in this PR, so it's easier to review by doing commit-by-commit review than looking at the whole thing.

Fixes #511 

### Description
Something that used to be
```rust
pub Address {
    inner: BdkAddress
}
```
is now
```rust
pub Address(pub BdkAddress);
```

Note that this doesn't change the public API in any way, it simply affects how we use the inner type in our Rust code.
Other note: I snuck in a new justfile command in there, #sorrynotsorry

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
