### PR TITLE
Add bumpfee finish related error

### DIFF
--- a/bdk-ffi/src/bdk.udl
+++ b/bdk-ffi/src/bdk.udl
@@ -337,8 +337,6 @@ interface TxBuilder {
 interface BumpFeeTxBuilder {
   constructor(string txid, FeeRate fee_rate);
 
-  BumpFeeTxBuilder allow_shrinking(Script script_pubkey);
-
   BumpFeeTxBuilder enable_rbf();
 
   BumpFeeTxBuilder enable_rbf_with_sequence(u32 nsequence);

--- a/bdk-ffi/src/bdk.udl
+++ b/bdk-ffi/src/bdk.udl
@@ -5,11 +5,6 @@ namespace bdk {};
 // ------------------------------------------------------------------------
 
 [Error]
-enum Alpha3Error {
-  "Generic"
-};
-
-[Error]
 interface Bip39Error {
   BadWordCount(u64 word_count);
   UnknownWord(u64 index);
@@ -348,7 +343,7 @@ interface BumpFeeTxBuilder {
 
   BumpFeeTxBuilder enable_rbf_with_sequence(u32 nsequence);
 
-  [Throws=Alpha3Error]
+  [Throws=CreateTxError]
   Psbt finish([ByRef] Wallet wallet);
 };
 

--- a/bdk-ffi/src/error.rs
+++ b/bdk-ffi/src/error.rs
@@ -6,7 +6,7 @@ use bdk::chain::tx_graph::CalculateFeeError as BdkCalculateFeeError;
 use bdk::descriptor::DescriptorError as BdkDescriptorError;
 use bdk::wallet::error::BuildFeeBumpError;
 use bdk::wallet::signer::SignerError as BdkSignerError;
-use bdk::wallet::tx_builder::{AddUtxoError, AllowShrinkingError};
+use bdk::wallet::tx_builder::AddUtxoError;
 use bdk::wallet::NewOrLoadError;
 use bdk_esplora::esplora_client::{Error as BdkEsploraError, Error};
 use bdk_file_store::FileError as BdkFileError;
@@ -500,16 +500,6 @@ impl From<AddUtxoError> for CreateTxError {
             AddUtxoError::UnknownUtxo(outpoint) => CreateTxError::UnknownUtxo {
                 outpoint: outpoint.to_string(),
             },
-        }
-    }
-}
-
-impl From<AllowShrinkingError> for CreateTxError {
-    fn from(error: AllowShrinkingError) -> Self {
-        match error {
-            AllowShrinkingError::MissingScriptPubKey(_script) => {
-                CreateTxError::ChangePolicyDescriptor
-            }
         }
     }
 }

--- a/bdk-ffi/src/lib.rs
+++ b/bdk-ffi/src/lib.rs
@@ -15,7 +15,6 @@ use crate::bitcoin::Transaction;
 use crate::bitcoin::TxOut;
 use crate::descriptor::Descriptor;
 use crate::error::AddressError;
-use crate::error::Alpha3Error;
 use crate::error::Bip32Error;
 use crate::error::Bip39Error;
 use crate::error::CalculateFeeError;

--- a/bdk-ffi/src/wallet.rs
+++ b/bdk-ffi/src/wallet.rs
@@ -355,7 +355,6 @@ impl TxBuilder {
 pub(crate) struct BumpFeeTxBuilder {
     pub(crate) txid: String,
     pub(crate) fee_rate: Arc<FeeRate>,
-    pub(crate) allow_shrinking: Option<Arc<Script>>,
     pub(crate) rbf: Option<RbfValue>,
 }
 
@@ -364,16 +363,8 @@ impl BumpFeeTxBuilder {
         Self {
             txid,
             fee_rate,
-            allow_shrinking: None,
             rbf: None,
         }
-    }
-
-    pub(crate) fn allow_shrinking(&self, script_pubkey: Arc<Script>) -> Arc<Self> {
-        Arc::new(Self {
-            allow_shrinking: Some(script_pubkey),
-            ..self.clone()
-        })
     }
 
     pub(crate) fn enable_rbf(&self) -> Arc<Self> {
@@ -397,11 +388,6 @@ impl BumpFeeTxBuilder {
         let mut wallet = wallet.get_wallet();
         let mut tx_builder = wallet.build_fee_bump(txid).map_err(CreateTxError::from)?;
         tx_builder.fee_rate(self.fee_rate.0);
-        if let Some(allow_shrinking) = &self.allow_shrinking {
-            tx_builder
-                .allow_shrinking(allow_shrinking.0.clone())
-                .map_err(CreateTxError::from)?;
-        }
         if let Some(rbf) = &self.rbf {
             match *rbf {
                 RbfValue::Default => {


### PR DESCRIPTION
<!-- Erase any parts of this template not applicable to your Pull Request. -->

### Description

This removes `Alpha3Error` completely by updating this last method that used it. ✅

`BumpFeeTxBuilder` has a `finish` method with a few things it hits under the hood like:
- getting a `TxId` from a string
- `allow_shrinking`
- getting a `Psbt`

I added a few `From`s, but did not add one for this line:
```
        let txid = Txid::from_str(self.txid.as_str()).map_err(|_| CreateTxError::UnknownUtxo {
            outpoint: self.txid.clone(),
        })?;
```
... because if `Txid::from_str` fails it seems likely it's because the string provided does not correctly represent a transaction identifier, and which is why I chose `UnknownUtxo` (and didn't create a `From`) to indicate that. But let me know if you think there is a better way to handle this (How to handle failing on `from_str` and/or if a `From` makes sense on that line of code)? Totally open to something better.

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Changelog notice

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Improved error handling in transaction creation by replacing `Alpha3Error` with `CreateTxError` to provide more specific error feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->