### PR TITLE
Use Rust compiler 1.77.1 on python ci runs

### DIFF
--- a/.github/workflows/live-tests.yaml
+++ b/.github/workflows/live-tests.yaml
@@ -74,9 +74,11 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: actions-rs/toolchain@v1
+
+      - name: "Install Rust 1.77.1"
+        uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 1.77.1
 
       - name: "Generate bdk.py and binaries"
         run: bash ./scripts/generate-linux.sh

--- a/.github/workflows/publish-python.yaml
+++ b/.github/workflows/publish-python.yaml
@@ -31,11 +31,12 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: true
-      # TODO 2: Other CI workflows use explicit Rust compiler versions, I think we should do the same here
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
 
+      - name: "Install Rust 1.77.1"
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 1.77.1
+          
       - name: "Generate bdk.py and binaries"
         run: bash ./scripts/generate-linux.sh
 

--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -40,10 +40,12 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
 
+      - name: "Install Rust 1.77.1"
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 1.77.1
+          
       - name: "Generate bdk.py and binaries"
         run: bash ./scripts/generate-linux.sh
 


### PR DESCRIPTION
This PR initially tried to remove the "unused" action toolchain@v1. This turned out not to be true, because while the exact Rust compiler version is now defined in the [scripts](https://github.com/bitcoindevkit/bdk-ffi/tree/master/bdk-python/scripts), Rust must be installed already for those steps to have access to rustup in the first place.

The one improvement done here is that the correct version of Rust is downloaded in the first place on the CI, so we don't download the sable version only to then download a second version when the shell script starts. We save one round of downloads. Note that the rustup command to use 1.77.1 must stay in the shell scripts for people building locally.

Fixes #404