### PR TITLE
Set rust compiler version before running cargo commands in python

### DIFF
--- a/bdk-python/scripts/generate-linux.sh
+++ b/bdk-python/scripts/generate-linux.sh
@@ -6,10 +6,10 @@ ${PYBIN}/pip install -r requirements.txt
 
 echo "Generating bdk.py..."
 cd ../bdk-ffi/
+rustup default 1.77.1
 cargo run --bin uniffi-bindgen generate src/bdk.udl --language python --out-dir ../bdk-python/src/bdkpython/ --no-format
 
 echo "Generating native binaries..."
-rustup default 1.77.1
 cargo build --profile release-smaller
 
 echo "Copying linux libbdkffi.so..."

--- a/bdk-python/scripts/generate-macos-arm64.sh
+++ b/bdk-python/scripts/generate-macos-arm64.sh
@@ -6,10 +6,10 @@ pip install -r requirements.txt
 
 echo "Generating bdk.py..."
 cd ../bdk-ffi/
+rustup default 1.77.1
 cargo run --bin uniffi-bindgen generate src/bdk.udl --language python --out-dir ../bdk-python/src/bdkpython/ --no-format
 
 echo "Generating native binaries..."
-rustup default 1.77.1
 rustup target add aarch64-apple-darwin
 cargo build --profile release-smaller --target aarch64-apple-darwin
 

--- a/bdk-python/scripts/generate-macos-x86_64.sh
+++ b/bdk-python/scripts/generate-macos-x86_64.sh
@@ -6,10 +6,10 @@ pip install -r requirements.txt
 
 echo "Generating bdk.py..."
 cd ../bdk-ffi/
+rustup default 1.77.1
 cargo run --bin uniffi-bindgen generate src/bdk.udl --language python --out-dir ../bdk-python/src/bdkpython/ --no-format
 
 echo "Generating native binaries..."
-rustup default 1.77.1
 rustup target add x86_64-apple-darwin
 cargo build --profile release-smaller --target x86_64-apple-darwin
 

--- a/bdk-python/scripts/generate-windows.sh
+++ b/bdk-python/scripts/generate-windows.sh
@@ -6,10 +6,10 @@ pip install -r requirements.txt
 
 echo "Generating bdk.py..."
 cd ../bdk-ffi/
+rustup default 1.77.1
 cargo run --bin uniffi-bindgen generate src/bdk.udl --language python --out-dir ../bdk-python/src/bdkpython/ --no-format
 
 echo "Generating native binaries..."
-rustup default 1.77.1
 rustup target add x86_64-pc-windows-msvc
 cargo build --profile release-smaller --target x86_64-pc-windows-msvc
 


### PR DESCRIPTION
Small issue I discovered while attempting to fix #404.

The Rust compiler version was defined after running the first cargo command, whereas it should of course be set before, to ensure all cargo commands are run with the same compiler version.
