### PR TITLE
Stop build if ANDROID_NDK_ROOT is not defined for android lib

### DIFF
--- a/bdk-android/README.md
+++ b/bdk-android/README.md
@@ -48,12 +48,17 @@ rustup default 1.77.1
 rustup target add x86_64-linux-android aarch64-linux-android armv7-linux-androideabi
 ```
 5. Install Android SDK and Build-Tools for API level 30+
-6. Setup `$ANDROID_SDK_ROOT` and `$ANDROID_NDK_ROOT` path variables (which are required by the
-   build tool), for example (note that currently, NDK version 25.2.9519653 or above is required):
+6. Setup `ANDROID_SDK_ROOT` and `ANDROID_NDK_ROOT` path variables which are required by the build tool. Note that currently, NDK version 25.2.9519653 or above is required. For example:
 ```shell
-export ANDROID_SDK_ROOT=~/Android/Sdk
+# macOS
+export ANDROID_SDK_ROOT=~/Library/Android/sdk
+export ANDROID_NDK_ROOT=$ANDROID_SDK_ROOT/ndk/25.2.9519653
+
+# linux
+export ANDROID_SDK_ROOT=/usr/local/lib/android/sdk
 export ANDROID_NDK_ROOT=$ANDROID_SDK_ROOT/ndk/25.2.9519653
 ```
+
 7. Build kotlin bindings
  ```sh
  # build Android library

--- a/bdk-android/plugins/src/main/kotlin/org/bitcoindevkit/plugins/Enums.kt
+++ b/bdk-android/plugins/src/main/kotlin/org/bitcoindevkit/plugins/Enums.kt
@@ -1,6 +1,5 @@
 package org.bitcoindevkit.plugins
 
-
 val operatingSystem: OS = when {
     System.getProperty("os.name").contains("mac", ignoreCase = true) -> OS.MAC
     System.getProperty("os.name").contains("linux", ignoreCase = true) -> OS.LINUX

--- a/bdk-android/plugins/src/main/kotlin/org/bitcoindevkit/plugins/UniFfiAndroidPlugin.kt
+++ b/bdk-android/plugins/src/main/kotlin/org/bitcoindevkit/plugins/UniFfiAndroidPlugin.kt
@@ -17,6 +17,11 @@ internal class UniFfiAndroidPlugin : Plugin<Project> {
             OS.OTHER -> throw Error("Cannot build Android library from current architecture")
         }
 
+        // if ANDROID_NDK_ROOT is not set, stop build
+        if (System.getenv("ANDROID_NDK_ROOT") == null) {
+            throw IllegalStateException("ANDROID_NDK_ROOT environment variable is not set; cannot build library")
+        }
+
         // arm64-v8a is the most popular hardware architecture for Android
         val buildAndroidAarch64Binary by tasks.register<Exec>("buildAndroidAarch64Binary") {
 
@@ -25,13 +30,6 @@ internal class UniFfiAndroidPlugin : Plugin<Project> {
 
             executable("cargo")
             args(cargoArgs)
-
-            // if ANDROID_NDK_ROOT is not set then set it to github actions default
-            if (System.getenv("ANDROID_NDK_ROOT") == null) {
-                environment(
-                    Pair("ANDROID_NDK_ROOT", "${System.getenv("ANDROID_SDK_ROOT")}/ndk-bundle")
-                )
-            }
 
             environment(
                 // add build toolchain to PATH
@@ -56,13 +54,6 @@ internal class UniFfiAndroidPlugin : Plugin<Project> {
             executable("cargo")
             args(cargoArgs)
 
-            // if ANDROID_NDK_ROOT is not set then set it to github actions default
-            if (System.getenv("ANDROID_NDK_ROOT") == null) {
-                environment(
-                    Pair("ANDROID_NDK_ROOT", "${System.getenv("ANDROID_SDK_ROOT")}/ndk-bundle")
-                )
-            }
-
             environment(
                 // add build toolchain to PATH
                 Pair("PATH", "${System.getenv("PATH")}:${System.getenv("ANDROID_NDK_ROOT")}/toolchains/llvm/prebuilt/$llvmArchPath/bin"),
@@ -85,13 +76,6 @@ internal class UniFfiAndroidPlugin : Plugin<Project> {
 
             executable("cargo")
             args(cargoArgs)
-
-            // if ANDROID_NDK_ROOT is not set then set it to github actions default
-            if (System.getenv("ANDROID_NDK_ROOT") == null) {
-                environment(
-                    Pair("ANDROID_NDK_ROOT", "${System.getenv("ANDROID_SDK_ROOT")}/ndk-bundle")
-                )
-            }
 
             environment(
                 // add build toolchain to PATH


### PR DESCRIPTION
This PR simplifies the Android plugin and forces users to have the ANDROID_NDK_ROOT environment variable defined before attempting to build the Android library. We've had reports that build would fail but devs would not know why, and this was because their ANDROID_SDK_ROOT was not defined, and the plugin assumed it was. This change now makes the plugin throw. Info on how to build and solve the issue is in the readme.

Fixes #295.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Documentation**
  - Updated setup instructions for `ANDROID_SDK_ROOT` and `ANDROID_NDK_ROOT` on macOS and Linux in the README.
- **Bug Fixes**
  - Modified build process to halt if `ANDROID_NDK_ROOT` is not set, ensuring correct environment setup.
- **Refactor**
  - Removed an unnecessary empty line in `Enums.kt` to improve code cleanliness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->