### PR TITLE
Generate bindings files using library mode

### DIFF
--- a/bdk-android/plugins/src/main/kotlin/org/bitcoindevkit/plugins/UniFfiAndroidPlugin.kt
+++ b/bdk-android/plugins/src/main/kotlin/org/bitcoindevkit/plugins/UniFfiAndroidPlugin.kt
@@ -123,14 +123,14 @@ internal class UniFfiAndroidPlugin : Plugin<Project> {
         val generateAndroidBindings by tasks.register<Exec>("generateAndroidBindings") {
             dependsOn(moveNativeAndroidLibs)
 
-            // val libraryPath = "${project.projectDir}/../../bdk-ffi/target/aarch64-linux-android/release-smaller/libbdkffi.so"
-            // workingDir("${project.projectDir}/../../bdk-ffi")
-            // val cargoArgs: List<String> = listOf("run", "--bin", "uniffi-bindgen", "generate", "--library", libraryPath, "--language", "kotlin", "--out-dir", "../bdk-android/lib/src/main/kotlin", "--no-format")
+            val libraryPath = "${project.projectDir}/../../bdk-ffi/target/aarch64-linux-android/release-smaller/libbdkffi.so"
+            workingDir("${project.projectDir}/../../bdk-ffi")
+            val cargoArgs: List<String> = listOf("run", "--bin", "uniffi-bindgen", "generate", "--library", libraryPath, "--language", "kotlin", "--out-dir", "../bdk-android/lib/src/main/kotlin", "--no-format")
 
             // The code above worked for uniffi 0.24.3 using the --library flag
             // The code below works for uniffi 0.23.0
-            workingDir("${project.projectDir}/../../bdk-ffi")
-            val cargoArgs: List<String> = listOf("run", "--bin", "uniffi-bindgen", "generate", "src/bdk.udl", "--language", "kotlin", "--config", "uniffi-android.toml", "--out-dir", "../bdk-android/lib/src/main/kotlin", "--no-format")
+            // workingDir("${project.projectDir}/../../bdk-ffi")
+            // val cargoArgs: List<String> = listOf("run", "--bin", "uniffi-bindgen", "generate", "src/bdk.udl", "--language", "kotlin", "--config", "uniffi-android.toml", "--out-dir", "../bdk-android/lib/src/main/kotlin", "--no-format")
 
             executable("cargo")
             args(cargoArgs)

--- a/bdk-jvm/plugins/src/main/kotlin/org/bitcoindevkit/plugins/UniFfiJvmPlugin.kt
+++ b/bdk-jvm/plugins/src/main/kotlin/org/bitcoindevkit/plugins/UniFfiJvmPlugin.kt
@@ -112,20 +112,20 @@ internal class UniFfiJvmPlugin : Plugin<Project> {
 
             // TODO 2: Is the Windows name the correct one?
             // TODO 3: This will not work on mac Intel (x86_64 architecture)
-            // val libraryPath = when (operatingSystem) {
-            //     OS.LINUX   -> "./target/x86_64-unknown-linux-gnu/release-smaller/libbdkffi.so"
-            //     OS.MAC     -> "./target/aarch64-apple-darwin/release-smaller/libbdkffi.dylib"
-            //     OS.WINDOWS -> "./target/x86_64-pc-windows-msvc/release-smaller/bdkffi.dll"
-            //     else       -> throw Exception("Unsupported OS")
-            // }
+            val libraryPath = when (operatingSystem) {
+                OS.LINUX   -> "./target/x86_64-unknown-linux-gnu/release-smaller/libbdkffi.so"
+                OS.MAC     -> "./target/aarch64-apple-darwin/release-smaller/libbdkffi.dylib"
+                OS.WINDOWS -> "./target/x86_64-pc-windows-msvc/release-smaller/bdkffi.dll"
+                else       -> throw Exception("Unsupported OS")
+            }
 
-            // workingDir("${project.projectDir}/../../bdk-ffi/")
-            // val cargoArgs: List<String> = listOf("run", "--bin", "uniffi-bindgen", "generate", "--library", libraryPath, "--language", "kotlin", "--out-dir", "../bdk-jvm/lib/src/main/kotlin/", "--no-format")
+            workingDir("${project.projectDir}/../../bdk-ffi/")
+            val cargoArgs: List<String> = listOf("run", "--bin", "uniffi-bindgen", "generate", "--library", libraryPath, "--language", "kotlin", "--out-dir", "../bdk-jvm/lib/src/main/kotlin/", "--no-format")
 
             // The code above was for the migration to uniffi 0.24.3 using the --library flag
             // The code below works with uniffi 0.23.0
-            workingDir("${project.projectDir}/../../bdk-ffi/")
-            val cargoArgs: List<String> = listOf("run", "--bin", "uniffi-bindgen", "generate", "src/bdk.udl", "--language", "kotlin", "--out-dir", "../bdk-jvm/lib/src/main/kotlin", "--no-format")
+            // workingDir("${project.projectDir}/../../bdk-ffi/")
+            // val cargoArgs: List<String> = listOf("run", "--bin", "uniffi-bindgen", "generate", "src/bdk.udl", "--language", "kotlin", "--out-dir", "../bdk-jvm/lib/src/main/kotlin", "--no-format")
             executable("cargo")
             args(cargoArgs)
 

--- a/bdk-python/justfile
+++ b/bdk-python/justfile
@@ -1,5 +1,5 @@
 test:
-  python -m unittest --verbose
+  python3 -m unittest --verbose
 
 maclocalbuild:
   bash ./scripts/generate-macos-arm64.sh && python3 setup.py bdist_wheel --verbose

--- a/bdk-python/scripts/generate-linux.sh
+++ b/bdk-python/scripts/generate-linux.sh
@@ -4,13 +4,14 @@ set -euo pipefail
 ${PYBIN}/python --version
 ${PYBIN}/pip install -r requirements.txt
 
-echo "Generating bdk.py..."
 cd ../bdk-ffi/
 rustup default 1.77.1
-cargo run --bin uniffi-bindgen generate src/bdk.udl --language python --out-dir ../bdk-python/src/bdkpython/ --no-format
 
 echo "Generating native binaries..."
 cargo build --profile release-smaller
+
+echo "Generating bdk.py..."
+cargo run --bin uniffi-bindgen generate --library ./target/release-smaller/libbdkffi.so --language python --out-dir ../bdk-python/src/bdkpython/ --no-format
 
 echo "Copying linux libbdkffi.so..."
 cp ./target/release-smaller/libbdkffi.so ../bdk-python/src/bdkpython/libbdkffi.so

--- a/bdk-python/scripts/generate-macos-arm64.sh
+++ b/bdk-python/scripts/generate-macos-arm64.sh
@@ -4,14 +4,15 @@ set -euo pipefail
 python3 --version
 pip install -r requirements.txt
 
-echo "Generating bdk.py..."
 cd ../bdk-ffi/
 rustup default 1.77.1
-cargo run --bin uniffi-bindgen generate src/bdk.udl --language python --out-dir ../bdk-python/src/bdkpython/ --no-format
+rustup target add aarch64-apple-darwin
 
 echo "Generating native binaries..."
-rustup target add aarch64-apple-darwin
 cargo build --profile release-smaller --target aarch64-apple-darwin
+
+echo "Generating bdk.py..."
+cargo run --bin uniffi-bindgen generate --library ./target/aarch64-apple-darwin/release-smaller/libbdkffi.dylib --language python --out-dir ../bdk-python/src/bdkpython/ --no-format
 
 echo "Copying libraries libbdkffi.dylib..."
 cp ./target/aarch64-apple-darwin/release-smaller/libbdkffi.dylib ../bdk-python/src/bdkpython/libbdkffi.dylib

--- a/bdk-python/scripts/generate-macos-x86_64.sh
+++ b/bdk-python/scripts/generate-macos-x86_64.sh
@@ -4,14 +4,15 @@ set -euo pipefail
 python3 --version
 pip install -r requirements.txt
 
-echo "Generating bdk.py..."
 cd ../bdk-ffi/
 rustup default 1.77.1
-cargo run --bin uniffi-bindgen generate src/bdk.udl --language python --out-dir ../bdk-python/src/bdkpython/ --no-format
+rustup target add x86_64-apple-darwin
 
 echo "Generating native binaries..."
-rustup target add x86_64-apple-darwin
 cargo build --profile release-smaller --target x86_64-apple-darwin
+
+echo "Generating bdk.py..."
+cargo run --bin uniffi-bindgen generate --library ./target/x86_64-apple-darwin/release-smaller/libbdkffi.dylib --language python --out-dir ../bdk-python/src/bdkpython/ --no-format
 
 echo "Copying libraries libbdkffi.dylib..."
 cp ./target/x86_64-apple-darwin/release-smaller/libbdkffi.dylib ../bdk-python/src/bdkpython/libbdkffi.dylib

--- a/bdk-python/scripts/generate-windows.sh
+++ b/bdk-python/scripts/generate-windows.sh
@@ -4,14 +4,15 @@ set -euo pipefail
 python3 --version
 pip install -r requirements.txt
 
-echo "Generating bdk.py..."
 cd ../bdk-ffi/
 rustup default 1.77.1
-cargo run --bin uniffi-bindgen generate src/bdk.udl --language python --out-dir ../bdk-python/src/bdkpython/ --no-format
+rustup target add x86_64-pc-windows-msvc
 
 echo "Generating native binaries..."
-rustup target add x86_64-pc-windows-msvc
 cargo build --profile release-smaller --target x86_64-pc-windows-msvc
+
+echo "Generating bdk.py..."
+cargo run --bin uniffi-bindgen generate --library ./target/x86_64-pc-windows-msvc/release-smaller/bdkffi.dll --language python --out-dir ../bdk-python/src/bdkpython/ --no-format
 
 echo "Copying libraries bdkffi.dll..."
 cp ./target/x86_64-pc-windows-msvc/release-smaller/bdkffi.dll ../bdk-python/src/bdkpython/bdkffi.dll

--- a/bdk-swift/build-local-swift.sh
+++ b/bdk-swift/build-local-swift.sh
@@ -12,13 +12,14 @@ rustup target add aarch64-apple-darwin   # mac M1
 rustup target add x86_64-apple-darwin    # mac x86_64
 
 cd ../bdk-ffi/ || exit
-cargo run --bin uniffi-bindgen generate src/bdk.udl --language swift --out-dir ../bdk-swift/Sources/BitcoinDevKit --no-format
 
 cargo build --package bdk-ffi --profile release-smaller --target x86_64-apple-darwin
 cargo build --package bdk-ffi --profile release-smaller --target aarch64-apple-darwin
 cargo build --package bdk-ffi --profile release-smaller --target x86_64-apple-ios
 cargo build --package bdk-ffi --profile release-smaller --target aarch64-apple-ios
 cargo build --package bdk-ffi --profile release-smaller --target aarch64-apple-ios-sim
+
+cargo run --bin uniffi-bindgen generate --library ./target/aarch64-apple-ios/release-smaller/libbdkffi.dylib --language swift --out-dir ../bdk-swift/Sources/BitcoinDevKit --no-format
 
 mkdir -p target/lipo-ios-sim/release-smaller
 lipo target/aarch64-apple-ios-sim/release-smaller/libbdkffi.a target/x86_64-apple-ios/release-smaller/libbdkffi.a -create -output target/lipo-ios-sim/release-smaller/libbdkffi.a


### PR DESCRIPTION
This PR migrates the build workflows for all four libraries to use the [library mode](https://mozilla.github.io/uniffi-rs/tutorial/foreign_language_bindings.html#running-uniffi-bindgen-using-a-library-file-recommended) from uniffi. This is the recommended approach, and is a prerequisite for moving forward and experimenting with proc macros.

I have tried to do as much local testing as I can, but one thing I can't test are the Windows builds. Would love to make sure my paths are correctly set, as the changes here are fairly custom and hard-coded instead of being programatically derived.

Related to #300.

### Changelog notice
No changelog.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the generation process for Android and JVM bindings, improving compatibility and configuration flexibility.
	- Updated the Python and Swift bindings generation scripts to support new library paths and target architectures, enhancing cross-platform support.

- **Bug Fixes**
	- Fixed inconsistencies in the test execution commands to ensure compatibility with different Python versions.

- **Refactor**
	- Streamlined the generation of bindings across various platforms by updating scripts and removing outdated configurations.

- **Chore**
	- Adjusted working directory settings across various plugins to align with updated project structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->