### PR TITLE
Add from to CannotConnectError

### DIFF
--- a/bdk-ffi/src/error.rs
+++ b/bdk-ffi/src/error.rs
@@ -20,6 +20,8 @@ use bdk::miniscript::descriptor::DescriptorKeyParseError as BdkDescriptorKeyPars
 
 use bdk::bitcoin::bip32;
 
+use bdk::chain;
+
 use bdk::wallet::error::CreateTxError as BdkCreateTxError;
 use std::convert::TryInto;
 
@@ -543,6 +545,14 @@ impl From<BdkCalculateFeeError> for CalculateFeeError {
                 out_points: out_points.iter().map(|op| op.into()).collect(),
             },
             BdkCalculateFeeError::NegativeFee(fee) => CalculateFeeError::NegativeFee { fee },
+        }
+    }
+}
+
+impl From<chain::local_chain::CannotConnectError> for CannotConnectError {
+    fn from(error: chain::local_chain::CannotConnectError) -> Self {
+        CannotConnectError::Include {
+            height: error.try_include_height,
         }
     }
 }

--- a/bdk-ffi/src/wallet.rs
+++ b/bdk-ffi/src/wallet.rs
@@ -59,9 +59,7 @@ impl Wallet {
     pub fn apply_update(&self, update: Arc<Update>) -> Result<(), CannotConnectError> {
         self.get_wallet()
             .apply_update(update.0.clone())
-            .map_err(|e| CannotConnectError::Include {
-                height: e.try_include_height,
-            })
+            .map_err(CannotConnectError::from)
     }
 
     // TODO: This is the fallible version of get_internal_address; should I rename it to get_internal_address?


### PR DESCRIPTION
<!-- Erase any parts of this template not applicable to your Pull Request. -->

### Description

Merge #524 first.

This adds a `From` for `CannotConnectError`, which is in line with how we want to format.

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Changelog notice

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Improved error handling for wallet connectivity issues.

- **Refactor**
	- Simplified error management in wallet operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->