### PR TITLE
Add memory wallet

### DIFF
--- a/bdk-ffi/src/bdk.udl
+++ b/bdk-ffi/src/bdk.udl
@@ -271,6 +271,9 @@ interface Wallet {
   [Throws=WalletCreationError]
   constructor(Descriptor descriptor, Descriptor? change_descriptor, string persistence_backend_path, Network network);
 
+  [Name=new_no_persist, Throws=DescriptorError]
+  constructor(Descriptor descriptor, Descriptor? change_descriptor, Network network);
+
   [Throws=PersistenceError]
   AddressInfo reveal_next_address(KeychainKind keychain);
 

--- a/bdk-ffi/src/wallet.rs
+++ b/bdk-ffi/src/wallet.rs
@@ -2,8 +2,8 @@ use crate::bitcoin::Amount;
 use crate::bitcoin::{FeeRate, OutPoint, Psbt, Script, Transaction};
 use crate::descriptor::Descriptor;
 use crate::error::{
-    CalculateFeeError, CannotConnectError, CreateTxError, PersistenceError, SignerError,
-    TxidParseError, WalletCreationError,
+    CalculateFeeError, CannotConnectError, CreateTxError, DescriptorError, PersistenceError,
+    SignerError, TxidParseError, WalletCreationError,
 };
 use crate::types::{
     AddressInfo, Balance, CanonicalTx, FullScanRequest, LocalOutput, ScriptAmount, SyncRequest,
@@ -43,6 +43,22 @@ impl Wallet {
 
         let wallet: BdkWallet =
             BdkWallet::new_or_load(&descriptor, change_descriptor.as_ref(), db, network)?;
+
+        Ok(Wallet {
+            inner_mutex: Mutex::new(wallet),
+        })
+    }
+
+    pub fn new_no_persist(
+        descriptor: Arc<Descriptor>,
+        change_descriptor: Option<Arc<Descriptor>>,
+        network: Network,
+    ) -> Result<Self, DescriptorError> {
+        let descriptor = descriptor.as_string_private();
+        let change_descriptor = change_descriptor.map(|d| d.as_string_private());
+
+        let wallet: BdkWallet =
+            BdkWallet::new_no_persist(&descriptor, change_descriptor.as_ref(), network)?;
 
         Ok(Wallet {
             inner_mutex: Mutex::new(wallet),

--- a/bdk-jvm/lib/src/test/kotlin/org/bitcoindevkit/LiveMemoryWalletTest.kt
+++ b/bdk-jvm/lib/src/test/kotlin/org/bitcoindevkit/LiveMemoryWalletTest.kt
@@ -1,0 +1,36 @@
+package org.bitcoindevkit
+
+import kotlin.test.Test
+
+private const val SIGNET_ESPLORA_URL = "http://signet.bitcoindevkit.net"
+private const val TESTNET_ESPLORA_URL = "https://esplora.testnet.kuutamo.cloud"
+
+class LiveMemoryWalletTest {
+    @Test
+    fun testSyncedBalance() {
+        val descriptor: Descriptor = Descriptor(
+            "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/0/*)",
+            Network.SIGNET
+        )
+        val wallet: Wallet = Wallet.newNoPersist(descriptor, null, Network.SIGNET)
+        val esploraClient: EsploraClient = EsploraClient(SIGNET_ESPLORA_URL)
+        val fullScanRequest: FullScanRequest = wallet.startFullScan()
+        val update = esploraClient.fullScan(fullScanRequest, 10uL, 1uL)
+        wallet.applyUpdate(update)
+        wallet.commit()
+        println("Balance: ${wallet.getBalance().total.toSat()}")
+
+        assert(wallet.getBalance().total.toSat() > 0uL) {
+            "Wallet balance must be greater than 0! Please send funds to ${wallet.revealNextAddress(KeychainKind.EXTERNAL).address.asString()} and try again."
+        }
+
+        println("Transactions count: ${wallet.transactions().count()}")
+        val transactions = wallet.transactions().take(3)
+        for (tx in transactions) {
+            val sentAndReceived = wallet.sentAndReceived(tx.transaction)
+            println("Transaction: ${tx.transaction.txid()}")
+            println("Sent ${sentAndReceived.sent.toSat()}")
+            println("Received ${sentAndReceived.received.toSat()}")
+        }
+    }
+}

--- a/bdk-swift/Tests/BitcoinDevKitTests/LiveMemoryWalletTests.swift
+++ b/bdk-swift/Tests/BitcoinDevKitTests/LiveMemoryWalletTests.swift
@@ -1,0 +1,44 @@
+import XCTest
+@testable import BitcoinDevKit
+
+private let SIGNET_ESPLORA_URL = "http://signet.bitcoindevkit.net"
+private let TESTNET_ESPLORA_URL = "https://esplora.testnet.kuutamo.cloud"
+
+final class LiveMemoryWalletTests: XCTestCase {
+    func testSyncedBalance() throws {
+        let descriptor = try Descriptor(
+            descriptor: "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/0/*)",
+            network: Network.signet
+        )
+        let wallet = try Wallet.newNoPersist(
+            descriptor: descriptor,
+            changeDescriptor: nil,
+            network: .signet
+        )
+        let esploraClient = EsploraClient(url: SIGNET_ESPLORA_URL)
+        let fullScanRequest: FullScanRequest = wallet.startFullScan()
+        let update = try esploraClient.fullScan(
+            fullScanRequest: fullScanRequest,
+            stopGap: 10,
+            parallelRequests: 1
+        )
+        try wallet.applyUpdate(update: update)
+        let _ = try wallet.commit()
+        let address = try wallet.revealNextAddress(keychain: KeychainKind.external).address.asString()
+
+        XCTAssertGreaterThan(
+            wallet.getBalance().total.toSat(),
+            UInt64(0),
+            "Wallet must have positive balance, please send funds to \(address)"
+        )
+
+        print("Transactions count: \(wallet.transactions().count)")
+        let transactions = wallet.transactions().prefix(3)
+        for tx in transactions {
+            let sentAndReceived = wallet.sentAndReceived(tx: tx.transaction)
+            print("Transaction: \(tx.transaction.txid())")
+            print("Sent \(sentAndReceived.sent)")
+            print("Received \(sentAndReceived.received)")
+        }
+    }
+}


### PR DESCRIPTION
I almost can't believe we get this for free now that the generic on the Wallet type has been removed. 

Don't merge, needs actual testing. My main concern would be that certain methods don't work on the memory wallet, but that should be captured at compile time, so... are we just getting away with it with such simple changes? It's too good to be true.

### Changelog notice

```md
Added
  - New memory wallet [#528]

[#528]: https://github.com/bitcoindevkit/bdk-ffi/pull/528
```

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
