### PR TITLE
Use signet for live tests

### DIFF
--- a/.github/workflows/live-tests.yaml
+++ b/.github/workflows/live-tests.yaml
@@ -48,7 +48,8 @@ jobs:
         uses: actions/checkout@v3
 
       - name: "Build Swift package"
-        run: bash ./bdk-swift/build-local-swift.sh
+        working-directory: bdk-swift
+        run: bash ./build-local-swift.sh
 
       - name: "Run live Swift tests"
         working-directory: bdk-swift

--- a/.github/workflows/live-tests.yaml
+++ b/.github/workflows/live-tests.yaml
@@ -74,9 +74,11 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: actions-rs/toolchain@v1
+
+      - name: "Install Rust 1.77.1"
+        uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 1.77.1
 
       - name: "Generate bdk.py and binaries"
         run: bash ./scripts/generate-linux.sh

--- a/.github/workflows/publish-python.yaml
+++ b/.github/workflows/publish-python.yaml
@@ -31,11 +31,12 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: true
-      # TODO 2: Other CI workflows use explicit Rust compiler versions, I think we should do the same here
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
 
+      - name: "Install Rust 1.77.1"
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 1.77.1
+          
       - name: "Generate bdk.py and binaries"
         run: bash ./scripts/generate-linux.sh
 

--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -40,10 +40,12 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
 
+      - name: "Install Rust 1.77.1"
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 1.77.1
+          
       - name: "Generate bdk.py and binaries"
         run: bash ./scripts/generate-linux.sh
 

--- a/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/LiveTxBuilderTest.kt
+++ b/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/LiveTxBuilderTest.kt
@@ -8,6 +8,9 @@ import java.io.File
 import kotlin.test.AfterTest
 import kotlin.test.assertTrue
 
+private const val SIGNET_ESPLORA_URL = "http://signet.bitcoindevkit.net"
+private const val TESTNET_ESPLORA_URL = "https://esplora.testnet.kuutamo.cloud"
+
 @RunWith(AndroidJUnit4::class)
 class LiveTxBuilderTest {
     private val persistenceFilePath = InstrumentationRegistry
@@ -23,9 +26,9 @@ class LiveTxBuilderTest {
 
     @Test
     fun testTxBuilder() {
-        val descriptor = Descriptor("wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/0/*)", Network.TESTNET)
-        val wallet = Wallet(descriptor, null, persistenceFilePath, Network.TESTNET)
-        val esploraClient = EsploraClient("https://esplora.testnet.kuutamo.cloud/")
+        val descriptor = Descriptor("wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/0/*)", Network.SIGNET)
+        val wallet = Wallet(descriptor, null, persistenceFilePath, Network.SIGNET)
+        val esploraClient = EsploraClient(SIGNET_ESPLORA_URL)
         val fullScanRequest: FullScanRequest = wallet.startFullScan()
         val update = esploraClient.fullScan(fullScanRequest, 10uL, 1uL)
         wallet.applyUpdate(update)
@@ -34,7 +37,7 @@ class LiveTxBuilderTest {
 
         assert(wallet.getBalance().total > 0uL)
 
-        val recipient: Address = Address("tb1qrnfslnrve9uncz9pzpvf83k3ukz22ljgees989", Network.TESTNET)
+        val recipient: Address = Address("tb1qrnfslnrve9uncz9pzpvf83k3ukz22ljgees989", Network.SIGNET)
         val psbt: Psbt = TxBuilder()
             .addRecipient(recipient.scriptPubkey(), 4200uL)
             .feeRate(FeeRate.fromSatPerVb(2uL))
@@ -46,10 +49,10 @@ class LiveTxBuilderTest {
 
     @Test
     fun complexTxBuilder() {
-        val externalDescriptor = Descriptor("wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/0/*)", Network.TESTNET)
-        val changeDescriptor = Descriptor("wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/1/*)", Network.TESTNET)
+        val externalDescriptor = Descriptor("wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/0/*)", Network.SIGNET)
+        val changeDescriptor = Descriptor("wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/1/*)", Network.SIGNET)
         val wallet = Wallet(externalDescriptor, changeDescriptor, persistenceFilePath, Network.TESTNET)
-        val esploraClient = EsploraClient("https://esplora.testnet.kuutamo.cloud/")
+        val esploraClient = EsploraClient(SIGNET_ESPLORA_URL)
         val fullScanRequest: FullScanRequest = wallet.startFullScan()
         val update = esploraClient.fullScan(fullScanRequest, 10uL, 1uL)
         wallet.applyUpdate(update)
@@ -58,8 +61,8 @@ class LiveTxBuilderTest {
 
         assert(wallet.getBalance().total > 0uL)
 
-        val recipient1: Address = Address("tb1qrnfslnrve9uncz9pzpvf83k3ukz22ljgees989", Network.TESTNET)
-        val recipient2: Address = Address("tb1qw2c3lxufxqe2x9s4rdzh65tpf4d7fssjgh8nv6", Network.TESTNET)
+        val recipient1: Address = Address("tb1qrnfslnrve9uncz9pzpvf83k3ukz22ljgees989", Network.SIGNET)
+        val recipient2: Address = Address("tb1qw2c3lxufxqe2x9s4rdzh65tpf4d7fssjgh8nv6", Network.SIGNET)
         val allRecipients: List<ScriptAmount> = listOf(
             ScriptAmount(recipient1.scriptPubkey(), 4200uL),
             ScriptAmount(recipient2.scriptPubkey(), 4200uL),

--- a/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/LiveTxBuilderTest.kt
+++ b/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/LiveTxBuilderTest.kt
@@ -35,7 +35,9 @@ class LiveTxBuilderTest {
         wallet.commit()
         println("Balance: ${wallet.getBalance().total}")
 
-        assert(wallet.getBalance().total > 0uL)
+        assert(wallet.getBalance().total > 0uL) {
+            "Wallet balance must be greater than 0! Please send funds to ${wallet.revealNextAddress(KeychainKind.EXTERNAL).address.asString()} and try again."
+        }
 
         val recipient: Address = Address("tb1qrnfslnrve9uncz9pzpvf83k3ukz22ljgees989", Network.SIGNET)
         val psbt: Psbt = TxBuilder()
@@ -59,7 +61,9 @@ class LiveTxBuilderTest {
         wallet.commit()
         println("Balance: ${wallet.getBalance().total}")
 
-        assert(wallet.getBalance().total > 0uL)
+        assert(wallet.getBalance().total > 0uL) {
+            "Wallet balance must be greater than 0! Please send funds to ${wallet.revealNextAddress(KeychainKind.EXTERNAL).address.asString()} and try again."
+        }
 
         val recipient1: Address = Address("tb1qrnfslnrve9uncz9pzpvf83k3ukz22ljgees989", Network.SIGNET)
         val recipient2: Address = Address("tb1qw2c3lxufxqe2x9s4rdzh65tpf4d7fssjgh8nv6", Network.SIGNET)

--- a/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/LiveWalletTest.kt
+++ b/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/LiveWalletTest.kt
@@ -37,7 +37,9 @@ class LiveWalletTest {
         val balance: Balance = wallet.getBalance()
         println("Balance: $balance")
 
-        assert(wallet.getBalance().total > 0uL)
+        assert(wallet.getBalance().total > 0uL) {
+            "Wallet balance must be greater than 0! Please send funds to ${wallet.revealNextAddress(KeychainKind.EXTERNAL).address.asString()} and try again."
+        }
 
         println("Transactions count: ${wallet.transactions().count()}")
         val transactions = wallet.transactions().take(3)
@@ -59,7 +61,6 @@ class LiveWalletTest {
         wallet.applyUpdate(update)
         wallet.commit()
         println("Balance: ${wallet.getBalance().total}")
-        println("New address: ${wallet.revealNextAddress(KeychainKind.EXTERNAL).address}")
 
         assert(wallet.getBalance().total > 0uL) {
             "Wallet balance must be greater than 0! Please send funds to ${wallet.revealNextAddress(KeychainKind.EXTERNAL).address} and try again."
@@ -82,7 +83,7 @@ class LiveWalletTest {
         println("Txid is: ${tx.txid()}")
 
         val txFee: ULong = wallet.calculateFee(tx)
-        println("Tx fee is: ${txFee}")
+        println("Tx fee is: $txFee")
 
         val feeRate: FeeRate = wallet.calculateFeeRate(tx)
         println("Tx fee rate is: ${feeRate.toSatPerVbCeil()} sat/vB")

--- a/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/LiveWalletTest.kt
+++ b/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/LiveWalletTest.kt
@@ -8,6 +8,9 @@ import java.io.File
 import kotlin.test.AfterTest
 import kotlin.test.assertTrue
 
+private const val SIGNET_ESPLORA_URL = "http://signet.bitcoindevkit.net"
+private const val TESTNET_ESPLORA_URL = "https://esplora.testnet.kuutamo.cloud"
+
 @RunWith(AndroidJUnit4::class)
 class LiveWalletTest {
     private val persistenceFilePath = InstrumentationRegistry
@@ -23,9 +26,9 @@ class LiveWalletTest {
 
     @Test
     fun testSyncedBalance() {
-        val descriptor: Descriptor = Descriptor("wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/0/*)", Network.TESTNET)
-        val wallet: Wallet = Wallet(descriptor, null, persistenceFilePath, Network.TESTNET)
-        val esploraClient: EsploraClient = EsploraClient("https://esplora.testnet.kuutamo.cloud/")
+        val descriptor: Descriptor = Descriptor("wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/0/*)", Network.SIGNET)
+        val wallet: Wallet = Wallet(descriptor, null, persistenceFilePath, Network.SIGNET)
+        val esploraClient: EsploraClient = EsploraClient(SIGNET_ESPLORA_URL)
         val fullScanRequest: FullScanRequest = wallet.startFullScan()
         val update = esploraClient.fullScan(fullScanRequest, 10uL, 1uL)
         wallet.applyUpdate(update)
@@ -48,9 +51,9 @@ class LiveWalletTest {
 
     @Test
     fun testBroadcastTransaction() {
-        val descriptor = Descriptor("wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/0/*)", Network.TESTNET)
-        val wallet = Wallet(descriptor, null, persistenceFilePath, Network.TESTNET)
-        val esploraClient = EsploraClient("https://esplora.testnet.kuutamo.cloud/")
+        val descriptor = Descriptor("wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/0/*)", Network.SIGNET)
+        val wallet = Wallet(descriptor, null, persistenceFilePath, Network.SIGNET)
+        val esploraClient = EsploraClient(SIGNET_ESPLORA_URL)
         val fullScanRequest: FullScanRequest = wallet.startFullScan()
         val update = esploraClient.fullScan(fullScanRequest, 10uL, 1uL)
         wallet.applyUpdate(update)
@@ -62,7 +65,7 @@ class LiveWalletTest {
             "Wallet balance must be greater than 0! Please send funds to ${wallet.revealNextAddress(KeychainKind.EXTERNAL).address} and try again."
         }
 
-        val recipient: Address = Address("tb1qrnfslnrve9uncz9pzpvf83k3ukz22ljgees989", Network.TESTNET)
+        val recipient: Address = Address("tb1qrnfslnrve9uncz9pzpvf83k3ukz22ljgees989", Network.SIGNET)
 
         val psbt: Psbt = TxBuilder()
             .addRecipient(recipient.scriptPubkey(), 4200uL)

--- a/bdk-jvm/lib/src/test/kotlin/org/bitcoindevkit/LiveTxBuilderTest.kt
+++ b/bdk-jvm/lib/src/test/kotlin/org/bitcoindevkit/LiveTxBuilderTest.kt
@@ -5,6 +5,9 @@ import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertTrue
 
+private const val SIGNET_ESPLORA_URL = "http://signet.bitcoindevkit.net"
+private const val TESTNET_ESPLORA_URL = "https://esplora.testnet.kuutamo.cloud"
+
 class LiveTxBuilderTest {
     private val persistenceFilePath = run {
         val currentDirectory = System.getProperty("user.dir")
@@ -23,8 +26,7 @@ class LiveTxBuilderTest {
     fun testTxBuilder() {
         val descriptor = Descriptor("wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/0/*)", Network.TESTNET)
         val wallet = Wallet(descriptor, null, persistenceFilePath, Network.SIGNET)
-        // val esploraClient = EsploraClient("https://esplora.testnet.kuutamo.cloud/")
-        val esploraClient = EsploraClient("http://signet.bitcoindevkit.net")
+        val esploraClient = EsploraClient(SIGNET_ESPLORA_URL)
         val fullScanRequest: FullScanRequest = wallet.startFullScan()
         val update = esploraClient.fullScan(fullScanRequest, 10uL, 1uL)
         wallet.applyUpdate(update)
@@ -49,8 +51,7 @@ class LiveTxBuilderTest {
         val externalDescriptor = Descriptor("wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/0/*)", Network.TESTNET)
         val changeDescriptor = Descriptor("wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/1/*)", Network.TESTNET)
         val wallet = Wallet(externalDescriptor, changeDescriptor, persistenceFilePath, Network.SIGNET)
-        // val esploraClient = EsploraClient("https://esplora.testnet.kuutamo.cloud/")
-        val esploraClient = EsploraClient("http://signet.bitcoindevkit.net")
+        val esploraClient = EsploraClient(SIGNET_ESPLORA_URL)
         val fullScanRequest: FullScanRequest = wallet.startFullScan()
         val update = esploraClient.fullScan(fullScanRequest, 10uL, 1uL)
         wallet.applyUpdate(update)

--- a/bdk-jvm/lib/src/test/kotlin/org/bitcoindevkit/LiveTxBuilderTest.kt
+++ b/bdk-jvm/lib/src/test/kotlin/org/bitcoindevkit/LiveTxBuilderTest.kt
@@ -33,7 +33,9 @@ class LiveTxBuilderTest {
         wallet.commit()
         println("Balance: ${wallet.getBalance().total}")
 
-        assert(wallet.getBalance().total > 0uL)
+        assert(wallet.getBalance().total > 0uL) {
+            "Wallet balance must be greater than 0! Please send funds to ${wallet.revealNextAddress(KeychainKind.EXTERNAL).address.asString()} and try again."
+        }
 
         val recipient: Address = Address("tb1qrnfslnrve9uncz9pzpvf83k3ukz22ljgees989", Network.SIGNET)
         val psbt: Psbt = TxBuilder()
@@ -58,7 +60,9 @@ class LiveTxBuilderTest {
         wallet.commit()
         println("Balance: ${wallet.getBalance().total}")
 
-        assert(wallet.getBalance().total > 0uL)
+        assert(wallet.getBalance().total > 0uL) {
+            "Wallet balance must be greater than 0! Please send funds to ${wallet.revealNextAddress(KeychainKind.EXTERNAL).address.asString()} and try again."
+        }
 
         val recipient1: Address = Address("tb1qrnfslnrve9uncz9pzpvf83k3ukz22ljgees989", Network.SIGNET)
         val recipient2: Address = Address("tb1qw2c3lxufxqe2x9s4rdzh65tpf4d7fssjgh8nv6", Network.SIGNET)

--- a/bdk-jvm/lib/src/test/kotlin/org/bitcoindevkit/LiveWalletTest.kt
+++ b/bdk-jvm/lib/src/test/kotlin/org/bitcoindevkit/LiveWalletTest.kt
@@ -33,7 +33,9 @@ class LiveWalletTest {
         wallet.commit()
         println("Balance: ${wallet.getBalance().total}")
 
-        assert(wallet.getBalance().total > 0uL)
+        assert(wallet.getBalance().total > 0uL) {
+            "Wallet balance must be greater than 0! Please send funds to ${wallet.revealNextAddress(KeychainKind.EXTERNAL).address.asString()} and try again."
+        }
 
         println("Transactions count: ${wallet.transactions().count()}")
         val transactions = wallet.transactions().take(3)
@@ -55,7 +57,6 @@ class LiveWalletTest {
         wallet.applyUpdate(update)
         wallet.commit()
         println("Balance: ${wallet.getBalance().total}")
-        println("New address: ${wallet.revealNextAddress(KeychainKind.EXTERNAL).address.asString()}")
 
         assert(wallet.getBalance().total > 0uL) {
             "Wallet balance must be greater than 0! Please send funds to ${wallet.revealNextAddress(KeychainKind.EXTERNAL).address.asString()} and try again."

--- a/bdk-jvm/lib/src/test/kotlin/org/bitcoindevkit/LiveWalletTest.kt
+++ b/bdk-jvm/lib/src/test/kotlin/org/bitcoindevkit/LiveWalletTest.kt
@@ -5,6 +5,9 @@ import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertTrue
 
+private const val SIGNET_ESPLORA_URL = "http://signet.bitcoindevkit.net"
+private const val TESTNET_ESPLORA_URL = "https://esplora.testnet.kuutamo.cloud"
+
 class LiveWalletTest {
     private val persistenceFilePath = run {
         val currentDirectory = System.getProperty("user.dir")
@@ -21,11 +24,9 @@ class LiveWalletTest {
 
     @Test
     fun testSyncedBalance() {
-        val descriptor: Descriptor = Descriptor("wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/0/*)", Network.TESTNET)
-        val wallet: Wallet = Wallet(descriptor, null, persistenceFilePath, Network.TESTNET)
-        val esploraClient: EsploraClient = EsploraClient("https://esplora.testnet.kuutamo.cloud/")
-        // val esploraClient: EsploraClient = EsploraClient("https://mempool.space/testnet/api")
-        // val esploraClient = EsploraClient("https://blockstream.info/testnet/api")
+        val descriptor: Descriptor = Descriptor("wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/0/*)", Network.SIGNET)
+        val wallet: Wallet = Wallet(descriptor, null, persistenceFilePath, Network.SIGNET)
+        val esploraClient: EsploraClient = EsploraClient(SIGNET_ESPLORA_URL)
         val fullScanRequest: FullScanRequest = wallet.startFullScan()
         val update = esploraClient.fullScan(fullScanRequest, 10uL, 1uL)
         wallet.applyUpdate(update)
@@ -46,9 +47,9 @@ class LiveWalletTest {
 
     @Test
     fun testBroadcastTransaction() {
-        val descriptor = Descriptor("wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/0/*)", Network.TESTNET)
-        val wallet: Wallet = Wallet(descriptor, null, persistenceFilePath, Network.TESTNET)
-        val esploraClient = EsploraClient("https://esplora.testnet.kuutamo.cloud/")
+        val descriptor = Descriptor("wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/0/*)", Network.SIGNET)
+        val wallet: Wallet = Wallet(descriptor, null, persistenceFilePath, Network.SIGNET)
+        val esploraClient = EsploraClient(SIGNET_ESPLORA_URL)
         val fullScanRequest: FullScanRequest = wallet.startFullScan()
         val update = esploraClient.fullScan(fullScanRequest, 10uL, 1uL)
         wallet.applyUpdate(update)
@@ -60,7 +61,7 @@ class LiveWalletTest {
             "Wallet balance must be greater than 0! Please send funds to ${wallet.revealNextAddress(KeychainKind.EXTERNAL).address.asString()} and try again."
         }
 
-        val recipient: Address = Address("tb1qrnfslnrve9uncz9pzpvf83k3ukz22ljgees989", Network.TESTNET)
+        val recipient: Address = Address("tb1qrnfslnrve9uncz9pzpvf83k3ukz22ljgees989", Network.SIGNET)
 
         val psbt: Psbt = TxBuilder()
             .addRecipient(recipient.scriptPubkey(), 4200uL)

--- a/bdk-python/tests/test_live_tx_builder.py
+++ b/bdk-python/tests/test_live_tx_builder.py
@@ -32,7 +32,11 @@ class LiveTxBuilderTest(unittest.TestCase):
         wallet.apply_update(update)
         wallet.commit()
         
-        self.assertGreater(wallet.get_balance().total, 0)
+        self.assertGreater(
+            wallet.get_balance().total,
+            0,
+            f"Wallet balance must be greater than 0! Please send funds to {wallet.reveal_next_address(bdk.KeychainKind.EXTERNAL).address.as_string()} and try again."
+        )
         
         recipient = bdk.Address(
             address="tb1qrnfslnrve9uncz9pzpvf83k3ukz22ljgees989",
@@ -68,7 +72,11 @@ class LiveTxBuilderTest(unittest.TestCase):
         wallet.apply_update(update)
         wallet.commit()
         
-        self.assertGreater(wallet.get_balance().total, 0)
+        self.assertGreater(
+            wallet.get_balance().total, 
+            0,
+            f"Wallet balance must be greater than 0! Please send funds to {wallet.reveal_next_address(bdk.KeychainKind.EXTERNAL).address.as_string()} and try again."
+        )
         
         recipient1 = bdk.Address(
             address="tb1qrnfslnrve9uncz9pzpvf83k3ukz22ljgees989",

--- a/bdk-python/tests/test_live_tx_builder.py
+++ b/bdk-python/tests/test_live_tx_builder.py
@@ -2,6 +2,9 @@ import bdkpython as bdk
 import unittest
 import os
 
+SIGNET_ESPLORA_URL = "http://signet.bitcoindevkit.net"
+TESTNET_ESPLORA_URL = "https://esplora.testnet.kuutamo.cloud"
+
 class LiveTxBuilderTest(unittest.TestCase):
 
     def tearDown(self) -> None:
@@ -11,15 +14,15 @@ class LiveTxBuilderTest(unittest.TestCase):
     def test_tx_builder(self):
         descriptor: bdk.Descriptor = bdk.Descriptor(
             "wpkh([c258d2e4/84h/1h/0h]tpubDDYkZojQFQjht8Tm4jsS3iuEmKjTiEGjG6KnuFNKKJb5A6ZUCUZKdvLdSDWofKi4ToRCwb9poe1XdqfUnP4jaJjCB2Zwv11ZLgSbnZSNecE/0/*)",
-            bdk.Network.TESTNET
+            bdk.Network.SIGNET
         )
         wallet: bdk.Wallet = bdk.Wallet(
             descriptor,
             None,
             "./bdk_persistence.db",
-            bdk.Network.TESTNET
+            bdk.Network.SIGNET
         )
-        esplora_client: bdk.EsploraClient = bdk.EsploraClient(url = "https://esplora.testnet.kuutamo.cloud/")
+        esplora_client: bdk.EsploraClient = bdk.EsploraClient(url = SIGNET_ESPLORA_URL)
         full_scan_request: bdk.FullScanRequest = wallet.start_full_scan()
         update = esplora_client.full_scan(
             full_scan_request=full_scan_request,
@@ -33,7 +36,7 @@ class LiveTxBuilderTest(unittest.TestCase):
         
         recipient = bdk.Address(
             address="tb1qrnfslnrve9uncz9pzpvf83k3ukz22ljgees989",
-            network=bdk.Network.TESTNET
+            network=bdk.Network.SIGNET
         )
         
         psbt = bdk.TxBuilder().add_recipient(script=recipient.script_pubkey(), amount=4200).fee_rate(fee_rate=bdk.FeeRate.from_sat_per_vb(2)).finish(wallet)
@@ -43,19 +46,19 @@ class LiveTxBuilderTest(unittest.TestCase):
     def complex_tx_builder(self):
         descriptor: bdk.Descriptor = bdk.Descriptor(
             "wpkh([c258d2e4/84h/1h/0h]tpubDDYkZojQFQjht8Tm4jsS3iuEmKjTiEGjG6KnuFNKKJb5A6ZUCUZKdvLdSDWofKi4ToRCwb9poe1XdqfUnP4jaJjCB2Zwv11ZLgSbnZSNecE/0/*)",
-            bdk.Network.TESTNET
+            bdk.Network.SIGNET
         )
         change_descriptor: bdk.Descriptor = bdk.Descriptor(
             "wpkh([c258d2e4/84h/1h/0h]tpubDDYkZojQFQjht8Tm4jsS3iuEmKjTiEGjG6KnuFNKKJb5A6ZUCUZKdvLdSDWofKi4ToRCwb9poe1XdqfUnP4jaJjCB2Zwv11ZLgSbnZSNecE/1/*)",
-            bdk.Network.TESTNET
+            bdk.Network.SIGNET
         )
         wallet: bdk.Wallet = bdk.Wallet(
             descriptor,
             change_descriptor,
             "./bdk_persistence.db",
-            bdk.Network.TESTNET
+            bdk.Network.SIGNET
         )
-        esplora_client: bdk.EsploraClient = bdk.EsploraClient(url = "https://esplora.testnet.kuutamo.cloud/")
+        esplora_client: bdk.EsploraClient = bdk.EsploraClient(url = SIGNET_ESPLORA_URL)
         full_scan_request: bdk.FullScanRequest = wallet.start_full_scan()
         update = esplora_client.full_scan(
             full_scan_request=full_scan_request,
@@ -69,11 +72,11 @@ class LiveTxBuilderTest(unittest.TestCase):
         
         recipient1 = bdk.Address(
             address="tb1qrnfslnrve9uncz9pzpvf83k3ukz22ljgees989",
-            network=bdk.Network.TESTNET
+            network=bdk.Network.SIGNET
         )
         recipient2 = bdk.Address(
             address="tb1qw2c3lxufxqe2x9s4rdzh65tpf4d7fssjgh8nv6",
-            network=bdk.Network.TESTNET
+            network=bdk.Network.SIGNET
         )
         all_recipients = list(
             bdk.ScriptAmount(recipient1.script_pubkey, 4200),

--- a/bdk-python/tests/test_live_wallet.py
+++ b/bdk-python/tests/test_live_wallet.py
@@ -32,7 +32,11 @@ class LiveWalletTest(unittest.TestCase):
         wallet.apply_update(update)
         wallet.commit()
         
-        self.assertGreater(wallet.get_balance().total, 0)
+        self.assertGreater(
+            wallet.get_balance().total,    
+            0,
+            f"Wallet balance must be greater than 0! Please send funds to {wallet.reveal_next_address(bdk.KeychainKind.EXTERNAL).address.as_string()} and try again."
+        )
         
         print(f"Transactions count: {len(wallet.transactions())}")
         transactions = wallet.transactions()[:3]
@@ -64,7 +68,11 @@ class LiveWalletTest(unittest.TestCase):
         wallet.apply_update(update)
         wallet.commit()
         
-        self.assertGreater(wallet.get_balance().total, 0)
+        self.assertGreater(
+            wallet.get_balance().total, 
+            0,
+            f"Wallet balance must be greater than 0! Please send funds to {wallet.reveal_next_address(bdk.KeychainKind.EXTERNAL).address.as_string()} and try again."
+        )
         
         recipient = bdk.Address(
             address="tb1qrnfslnrve9uncz9pzpvf83k3ukz22ljgees989",

--- a/bdk-python/tests/test_live_wallet.py
+++ b/bdk-python/tests/test_live_wallet.py
@@ -2,6 +2,9 @@ import bdkpython as bdk
 import unittest
 import os
 
+SIGNET_ESPLORA_URL = "http://signet.bitcoindevkit.net"
+TESTNET_ESPLORA_URL = "https://esplora.testnet.kuutamo.cloud"
+
 class LiveWalletTest(unittest.TestCase):
 
     def tearDown(self) -> None:
@@ -11,15 +14,15 @@ class LiveWalletTest(unittest.TestCase):
     def test_synced_balance(self):
         descriptor: bdk.Descriptor = bdk.Descriptor(
             "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/0/*)",
-            bdk.Network.TESTNET
+            bdk.Network.SIGNET
         )
         wallet: bdk.Wallet = bdk.Wallet(
             descriptor,
             None,
             "./bdk_persistence.db",
-            bdk.Network.TESTNET
+            bdk.Network.SIGNET
         )
-        esplora_client: bdk.EsploraClient = bdk.EsploraClient(url = "https://esplora.testnet.kuutamo.cloud/")
+        esplora_client: bdk.EsploraClient = bdk.EsploraClient(url = SIGNET_ESPLORA_URL)
         full_scan_request: bdk.FullScanRequest = wallet.start_full_scan()
         update = esplora_client.full_scan(
             full_scan_request=full_scan_request,
@@ -43,15 +46,15 @@ class LiveWalletTest(unittest.TestCase):
     def test_broadcast_transaction(self):
         descriptor: bdk.Descriptor = bdk.Descriptor(
             "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/0/*)",
-            bdk.Network.TESTNET
+            bdk.Network.SIGNET
         )
         wallet: bdk.Wallet = bdk.Wallet(
             descriptor,
             None,
             "./bdk_persistence.db",
-            bdk.Network.TESTNET
+            bdk.Network.SIGNET
         )
-        esplora_client: bdk.EsploraClient = bdk.EsploraClient(url = "https://esplora.testnet.kuutamo.cloud/")
+        esplora_client: bdk.EsploraClient = bdk.EsploraClient(url = SIGNET_ESPLORA_URL)
         full_scan_request: bdk.FullScanRequest = wallet.start_full_scan()
         update = esplora_client.full_scan(
             full_scan_request=full_scan_request,
@@ -65,7 +68,7 @@ class LiveWalletTest(unittest.TestCase):
         
         recipient = bdk.Address(
             address="tb1qrnfslnrve9uncz9pzpvf83k3ukz22ljgees989",
-            network=bdk.Network.TESTNET
+            network=bdk.Network.SIGNET
         )
         
         psbt: bdk.Psbt = bdk.TxBuilder().add_recipient(script=recipient.script_pubkey(), amount=4200).fee_rate(fee_rate=bdk.FeeRate.from_sat_per_vb(2)).finish(wallet)

--- a/bdk-swift/Tests/BitcoinDevKitTests/LiveTxBuilderTests.swift
+++ b/bdk-swift/Tests/BitcoinDevKitTests/LiveTxBuilderTests.swift
@@ -1,6 +1,9 @@
 import XCTest
 @testable import BitcoinDevKit
 
+let SIGNET_ESPLORA_URL = "http://signet.bitcoindevkit.net"
+let TESTNET_ESPLORA_URL = "https://esplora.testnet.kuutamo.cloud"
+
 final class LiveTxBuilderTests: XCTestCase {
     var dbFilePath: URL!
 
@@ -26,15 +29,15 @@ final class LiveTxBuilderTests: XCTestCase {
     func testTxBuilder() throws {
         let descriptor = try Descriptor(
             descriptor: "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/0/*)",
-            network: Network.testnet
+            network: Network.signet
         )
         let wallet = try Wallet(
             descriptor: descriptor,
             changeDescriptor: nil,
             persistenceBackendPath: dbFilePath.path,
-            network: .testnet
+            network: .signet
         )
-        let esploraClient = EsploraClient(url: "https://esplora.testnet.kuutamo.cloud/")
+        let esploraClient = EsploraClient(url: SIGNET_ESPLORA_URL)
         let fullScanRequest: FullScanRequest = wallet.startFullScan()
         let update = try esploraClient.fullScan(
             fullScanRequest: fullScanRequest,
@@ -46,7 +49,7 @@ final class LiveTxBuilderTests: XCTestCase {
 
         XCTAssertGreaterThan(wallet.getBalance().total, UInt64(0), "Wallet must have positive balance, please add funds")
 
-        let recipient: Address = try Address(address: "tb1qrnfslnrve9uncz9pzpvf83k3ukz22ljgees989", network: .testnet)
+        let recipient: Address = try Address(address: "tb1qrnfslnrve9uncz9pzpvf83k3ukz22ljgees989", network: .signet)
         let psbt: Psbt = try TxBuilder()
             .addRecipient(script: recipient.scriptPubkey(), amount: 4200)
             .feeRate(feeRate: FeeRate.fromSatPerVb(satPerVb: 2))
@@ -59,19 +62,19 @@ final class LiveTxBuilderTests: XCTestCase {
     func testComplexTxBuilder() throws {
         let descriptor = try Descriptor(
             descriptor: "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/0/*)",
-            network: Network.testnet
+            network: Network.signet
         )
         let changeDescriptor = try Descriptor(
             descriptor: "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/1/*)",
-            network: Network.testnet
+            network: Network.signet
         )
         let wallet = try Wallet(
             descriptor: descriptor,
             changeDescriptor: changeDescriptor,
             persistenceBackendPath: dbFilePath.path,
-            network: .testnet
+            network: .signet
         )
-        let esploraClient = EsploraClient(url: "https://esplora.testnet.kuutamo.cloud/")
+        let esploraClient = EsploraClient(url: SIGNET_ESPLORA_URL)
         let fullScanRequest: FullScanRequest = wallet.startFullScan()
         let update = try esploraClient.fullScan(
             fullScanRequest: fullScanRequest,
@@ -83,8 +86,8 @@ final class LiveTxBuilderTests: XCTestCase {
         
         XCTAssertGreaterThan(wallet.getBalance().total, UInt64(0), "Wallet must have positive balance, please add funds")
 
-        let recipient1: Address = try Address(address: "tb1qrnfslnrve9uncz9pzpvf83k3ukz22ljgees989", network: .testnet)
-        let recipient2: Address = try Address(address: "tb1qw2c3lxufxqe2x9s4rdzh65tpf4d7fssjgh8nv6", network: .testnet)
+        let recipient1: Address = try Address(address: "tb1qrnfslnrve9uncz9pzpvf83k3ukz22ljgees989", network: .signet)
+        let recipient2: Address = try Address(address: "tb1qw2c3lxufxqe2x9s4rdzh65tpf4d7fssjgh8nv6", network: .signet)
         let allRecipients: [ScriptAmount] = [
             ScriptAmount(script: recipient1.scriptPubkey(), amount: 4200),
             ScriptAmount(script: recipient2.scriptPubkey(), amount: 4200)

--- a/bdk-swift/Tests/BitcoinDevKitTests/LiveTxBuilderTests.swift
+++ b/bdk-swift/Tests/BitcoinDevKitTests/LiveTxBuilderTests.swift
@@ -1,8 +1,8 @@
 import XCTest
 @testable import BitcoinDevKit
 
-let SIGNET_ESPLORA_URL = "http://signet.bitcoindevkit.net"
-let TESTNET_ESPLORA_URL = "https://esplora.testnet.kuutamo.cloud"
+private let SIGNET_ESPLORA_URL = "http://signet.bitcoindevkit.net"
+private let TESTNET_ESPLORA_URL = "https://esplora.testnet.kuutamo.cloud"
 
 final class LiveTxBuilderTests: XCTestCase {
     var dbFilePath: URL!
@@ -45,9 +45,14 @@ final class LiveTxBuilderTests: XCTestCase {
             parallelRequests: 1
         )
         try wallet.applyUpdate(update: update)
-        try wallet.commit()
+        let _ = try wallet.commit()
+        let address = try wallet.revealNextAddress(keychain: KeychainKind.external).address.asString()
 
-        XCTAssertGreaterThan(wallet.getBalance().total, UInt64(0), "Wallet must have positive balance, please add funds")
+        XCTAssertGreaterThan(
+            wallet.getBalance().total,
+            UInt64(0),
+            "Wallet must have positive balance, please send funds to \(address)"
+        )
 
         let recipient: Address = try Address(address: "tb1qrnfslnrve9uncz9pzpvf83k3ukz22ljgees989", network: .signet)
         let psbt: Psbt = try TxBuilder()
@@ -82,9 +87,14 @@ final class LiveTxBuilderTests: XCTestCase {
             parallelRequests: 1
         )
         try wallet.applyUpdate(update: update)
-        try wallet.commit()
-        
-        XCTAssertGreaterThan(wallet.getBalance().total, UInt64(0), "Wallet must have positive balance, please add funds")
+        let _ = try wallet.commit()
+        let address = try wallet.revealNextAddress(keychain: KeychainKind.external).address.asString()
+
+        XCTAssertGreaterThan(
+            wallet.getBalance().total,
+            UInt64(0),
+            "Wallet must have positive balance, please send funds to \(address)"
+        )
 
         let recipient1: Address = try Address(address: "tb1qrnfslnrve9uncz9pzpvf83k3ukz22ljgees989", network: .signet)
         let recipient2: Address = try Address(address: "tb1qw2c3lxufxqe2x9s4rdzh65tpf4d7fssjgh8nv6", network: .signet)
@@ -100,7 +110,7 @@ final class LiveTxBuilderTests: XCTestCase {
             .enableRbf()
             .finish(wallet: wallet)
 
-        try! wallet.sign(psbt: psbt)
+        let _ = try! wallet.sign(psbt: psbt)
 
         XCTAssertTrue(psbt.serialize().hasPrefix("cHNi"), "PSBT should start with cHNI")
     }

--- a/bdk-swift/Tests/BitcoinDevKitTests/LiveWalletTests.swift
+++ b/bdk-swift/Tests/BitcoinDevKitTests/LiveWalletTests.swift
@@ -1,6 +1,9 @@
 import XCTest
 @testable import BitcoinDevKit
 
+let SIGNET_ESPLORA_URL = "http://signet.bitcoindevkit.net"
+let TESTNET_ESPLORA_URL = "https://esplora.testnet.kuutamo.cloud"
+
 final class LiveWalletTests: XCTestCase {
     var dbFilePath: URL!
 
@@ -26,15 +29,15 @@ final class LiveWalletTests: XCTestCase {
     func testSyncedBalance() throws {
         let descriptor = try Descriptor(
             descriptor: "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/0/*)",
-            network: Network.testnet
+            network: Network.signet
         )
         let wallet = try Wallet(
             descriptor: descriptor,
             changeDescriptor: nil,
             persistenceBackendPath: dbFilePath.path,
-            network: .testnet
+            network: .signet
         )
-        let esploraClient = EsploraClient(url: "https://esplora.testnet.kuutamo.cloud/")
+        let esploraClient = EsploraClient(url: SIGNET_ESPLORA_URL)
         let fullScanRequest: FullScanRequest = wallet.startFullScan()
         let update = try esploraClient.fullScan(
             fullScanRequest: fullScanRequest,
@@ -59,15 +62,15 @@ final class LiveWalletTests: XCTestCase {
     func testBroadcastTransaction() throws {
         let descriptor = try Descriptor(
             descriptor: "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/0/*)",
-            network: Network.testnet
+            network: Network.signet
         )
         let wallet = try Wallet(
             descriptor: descriptor,
             changeDescriptor: nil,
             persistenceBackendPath: dbFilePath.path,
-            network: .testnet
+            network: .signet
         )
-        let esploraClient = EsploraClient(url: "https://esplora.testnet.kuutamo.cloud/")
+        let esploraClient = EsploraClient(url: SIGNET_ESPLORA_URL)
         let fullScanRequest: FullScanRequest = wallet.startFullScan()
         let update = try esploraClient.fullScan(
             fullScanRequest: fullScanRequest,
@@ -81,7 +84,7 @@ final class LiveWalletTests: XCTestCase {
 
         print("Balance: \(wallet.getBalance().total)")
 
-        let recipient: Address = try Address(address: "tb1qrnfslnrve9uncz9pzpvf83k3ukz22ljgees989", network: .testnet)
+        let recipient: Address = try Address(address: "tb1qrnfslnrve9uncz9pzpvf83k3ukz22ljgees989", network: .signet)
         let psbt: Psbt = try
             TxBuilder()
                 .addRecipient(script: recipient.scriptPubkey(), amount: 4200)

--- a/bdk-swift/Tests/BitcoinDevKitTests/LiveWalletTests.swift
+++ b/bdk-swift/Tests/BitcoinDevKitTests/LiveWalletTests.swift
@@ -1,8 +1,8 @@
 import XCTest
 @testable import BitcoinDevKit
 
-let SIGNET_ESPLORA_URL = "http://signet.bitcoindevkit.net"
-let TESTNET_ESPLORA_URL = "https://esplora.testnet.kuutamo.cloud"
+private let SIGNET_ESPLORA_URL = "http://signet.bitcoindevkit.net"
+private let TESTNET_ESPLORA_URL = "https://esplora.testnet.kuutamo.cloud"
 
 final class LiveWalletTests: XCTestCase {
     var dbFilePath: URL!
@@ -45,9 +45,14 @@ final class LiveWalletTests: XCTestCase {
             parallelRequests: 1
         )
         try wallet.applyUpdate(update: update)
-        try wallet.commit()
+        let _ = try wallet.commit()
+        let address = try wallet.revealNextAddress(keychain: KeychainKind.external).address.asString()
 
-        XCTAssertGreaterThan(wallet.getBalance().total, UInt64(0))
+        XCTAssertGreaterThan(
+            wallet.getBalance().total,
+            UInt64(0),
+            "Wallet must have positive balance, please send funds to \(address)"
+        )
 
         print("Transactions count: \(wallet.transactions().count)")
         let transactions = wallet.transactions().prefix(3)
@@ -78,9 +83,15 @@ final class LiveWalletTests: XCTestCase {
             parallelRequests: 1
         )
         try wallet.applyUpdate(update: update)
-        try wallet.commit()
-
-        XCTAssertGreaterThan(wallet.getBalance().total, UInt64(0), "Wallet must have positive balance, please add funds")
+        let _ = try wallet.commit()
+        let address = try wallet.revealNextAddress(keychain: KeychainKind.external).address.asString()
+        
+        XCTAssertGreaterThan(
+            wallet.getBalance().total,
+            UInt64(0),
+            "Wallet must have positive balance, please send funds to \(address)"
+        )
+        
 
         print("Balance: \(wallet.getBalance().total)")
 


### PR DESCRIPTION
This PR moves the live tests from testnet to signet. Merge after #518.

Note that the tests below do not actually run the live tests. The runs for the live tests triggered manually is [here](https://github.com/bitcoindevkit/bdk-ffi/actions/runs/9034091785). Note: the balance on the wallet was 0. The new run is [here](https://github.com/bitcoindevkit/bdk-ffi/actions/runs/9036407306).