### PR TITLE
Bring back TxIn and methods on Transaction

### DIFF
--- a/bdk-ffi/src/bdk.udl
+++ b/bdk-ffi/src/bdk.udl
@@ -582,6 +582,8 @@ interface Transaction {
   sequence<u8> serialize();
 
   u64 weight();
+
+  sequence<TxIn> input();
 };
 
 interface Psbt {
@@ -623,4 +625,11 @@ interface FeeRate {
   u64 to_sat_per_vb_floor();
 
   u64 to_sat_per_kwu();
+};
+
+dictionary TxIn {
+  OutPoint previous_output;
+  Script script_sig;
+  u32 sequence;
+  sequence<sequence<u8>> witness;
 };

--- a/bdk-ffi/src/bdk.udl
+++ b/bdk-ffi/src/bdk.udl
@@ -584,6 +584,8 @@ interface Transaction {
   u64 weight();
 
   sequence<TxIn> input();
+
+  sequence<TxOut> output();
 };
 
 interface Psbt {

--- a/bdk-ffi/src/bdk.udl
+++ b/bdk-ffi/src/bdk.udl
@@ -586,6 +586,8 @@ interface Transaction {
   sequence<TxIn> input();
 
   sequence<TxOut> output();
+
+  u32 lock_time();
 };
 
 interface Psbt {

--- a/bdk-ffi/src/bitcoin.rs
+++ b/bdk-ffi/src/bitcoin.rs
@@ -1,26 +1,25 @@
 use crate::error::{AddressError, FeeRateError, PsbtParseError, TransactionError};
 
 use bdk::bitcoin::address::{NetworkChecked, NetworkUnchecked};
+use bdk::bitcoin::amount::ParseAmountError;
 use bdk::bitcoin::blockdata::script::ScriptBuf as BdkScriptBuf;
 use bdk::bitcoin::blockdata::transaction::TxOut as BdkTxOut;
 use bdk::bitcoin::consensus::encode::serialize;
 use bdk::bitcoin::consensus::Decodable;
 use bdk::bitcoin::psbt::ExtractTxError;
 use bdk::bitcoin::Address as BdkAddress;
+use bdk::bitcoin::Amount as BdkAmount;
 use bdk::bitcoin::FeeRate as BdkFeeRate;
 use bdk::bitcoin::Network;
 use bdk::bitcoin::OutPoint as BdkOutPoint;
 use bdk::bitcoin::Psbt as BdkPsbt;
 use bdk::bitcoin::Transaction as BdkTransaction;
-use bdk::bitcoin::Txid;
 use bdk::bitcoin::TxIn as BdkTxIn;
-use bdk::bitcoin::amount::ParseAmountError;
-use bdk::bitcoin::Amount as BdkAmount;
+use bdk::bitcoin::Txid;
 
 use std::io::Cursor;
 use std::str::FromStr;
 use std::sync::{Arc, Mutex};
-
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Amount(pub(crate) BdkAmount);
@@ -173,6 +172,10 @@ impl Transaction {
 
     pub fn input(&self) -> Vec<TxIn> {
         self.0.input.iter().map(|tx_in| tx_in.into()).collect()
+    }
+
+    pub fn output(&self) -> Vec<TxOut> {
+        self.0.output.iter().map(|tx_out| tx_out.into()).collect()
     }
 }
 

--- a/bdk-ffi/src/bitcoin.rs
+++ b/bdk-ffi/src/bitcoin.rs
@@ -177,6 +177,10 @@ impl Transaction {
     pub fn output(&self) -> Vec<TxOut> {
         self.0.output.iter().map(|tx_out| tx_out.into()).collect()
     }
+
+    pub fn lock_time(&self) -> u32 {
+        self.0.lock_time.to_consensus_u32()
+    }
 }
 
 impl From<BdkTransaction> for Transaction {

--- a/bdk-ffi/src/lib.rs
+++ b/bdk-ffi/src/lib.rs
@@ -14,6 +14,7 @@ use crate::bitcoin::OutPoint;
 use crate::bitcoin::Psbt;
 use crate::bitcoin::Script;
 use crate::bitcoin::Transaction;
+use crate::bitcoin::TxIn;
 use crate::bitcoin::TxOut;
 use crate::descriptor::Descriptor;
 use crate::electrum::ElectrumClient;
@@ -53,7 +54,6 @@ use crate::wallet::BumpFeeTxBuilder;
 use crate::wallet::SentAndReceivedValues;
 use crate::wallet::TxBuilder;
 use crate::wallet::Update;
-use crate::bitcoin::TxIn;
 use crate::wallet::Wallet;
 
 use bdk::bitcoin::Network;

--- a/bdk-ffi/src/lib.rs
+++ b/bdk-ffi/src/lib.rs
@@ -53,6 +53,7 @@ use crate::wallet::BumpFeeTxBuilder;
 use crate::wallet::SentAndReceivedValues;
 use crate::wallet::TxBuilder;
 use crate::wallet::Update;
+use crate::bitcoin::TxIn;
 use crate::wallet::Wallet;
 
 use bdk::bitcoin::Network;

--- a/bdk-jvm/lib/src/test/kotlin/org/bitcoindevkit/LiveTransactionTests.kt
+++ b/bdk-jvm/lib/src/test/kotlin/org/bitcoindevkit/LiveTransactionTests.kt
@@ -1,0 +1,39 @@
+package org.bitcoindevkit
+
+import kotlin.test.Test
+
+private const val SIGNET_ESPLORA_URL = "http://signet.bitcoindevkit.net"
+private const val TESTNET_ESPLORA_URL = "https://esplora.testnet.kuutamo.cloud"
+
+class LiveTransactionTests {
+    @Test
+    fun testSyncedBalance() {
+        val descriptor: Descriptor = Descriptor(
+            "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/0/*)",
+            Network.SIGNET
+        )
+        val wallet: Wallet = Wallet.newNoPersist(descriptor, null, Network.SIGNET)
+        val esploraClient: EsploraClient = EsploraClient(SIGNET_ESPLORA_URL)
+        val fullScanRequest: FullScanRequest = wallet.startFullScan()
+        val update = esploraClient.fullScan(fullScanRequest, 10uL, 1uL)
+        wallet.applyUpdate(update)
+        wallet.commit()
+        println("Wallet balance: ${wallet.getBalance().total.toSat()}")
+
+        assert(wallet.getBalance().total.toSat() > 0uL) {
+            "Wallet balance must be greater than 0! Please send funds to ${wallet.revealNextAddress(KeychainKind.EXTERNAL).address.asString()} and try again."
+        }
+
+        val transaction: Transaction = wallet.transactions().first().transaction
+        println("First transaction:")
+        println("Txid: ${transaction.txid()}")
+        println("Version: ${transaction.version()}")
+        println("Total size: ${transaction.totalSize()}")
+        println("Vsize: ${transaction.vsize()}")
+        println("Weight: ${transaction.weight()}")
+        println("Coinbase transaction: ${transaction.isCoinbase()}")
+        println("Is explicitly RBF: ${transaction.isExplicitlyRbf()}")
+        println("Inputs: ${transaction.input()}")
+        println("Outputs: ${transaction.output()}")
+    }
+}

--- a/bdk-swift/Tests/BitcoinDevKitTests/LiveTransactionTests.swift
+++ b/bdk-swift/Tests/BitcoinDevKitTests/LiveTransactionTests.swift
@@ -1,0 +1,51 @@
+import XCTest
+@testable import BitcoinDevKit
+
+private let SIGNET_ESPLORA_URL = "http://signet.bitcoindevkit.net"
+private let TESTNET_ESPLORA_URL = "https://esplora.testnet.kuutamo.cloud"
+
+final class LiveTransactionTests: XCTestCase {
+    func testSyncedBalance() throws {
+        let descriptor = try Descriptor(
+            descriptor: "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/0/*)",
+            network: Network.signet
+        )
+        let wallet = try Wallet.newNoPersist(
+            descriptor: descriptor,
+            changeDescriptor: nil,
+            network: .signet
+        )
+        let esploraClient = EsploraClient(url: SIGNET_ESPLORA_URL)
+        let fullScanRequest: FullScanRequest = wallet.startFullScan()
+        let update = try esploraClient.fullScan(
+            fullScanRequest: fullScanRequest,
+            stopGap: 10,
+            parallelRequests: 1
+        )
+        try wallet.applyUpdate(update: update)
+        let _ = try wallet.commit()
+        let address = try wallet.revealNextAddress(keychain: KeychainKind.external).address.asString()
+
+        XCTAssertGreaterThan(
+            wallet.getBalance().total.toSat(),
+            UInt64(0),
+            "Wallet must have positive balance, please send funds to \(address)"
+        )
+            
+        guard let transaction = wallet.transactions().first?.transaction else {
+            print("No transactions found")
+            return
+        }
+        print("First transaction:")
+        print("Txid: \(transaction.txid())")
+        print("Version: \(transaction.version())")
+        print("Total size: \(transaction.totalSize())")
+        print("Vsize: \(transaction.vsize())")
+        print("Weight: \(transaction.weight())")
+        print("Coinbase transaction: \(transaction.isCoinbase())")
+        print("Is explicitly RBF: \(transaction.isExplicitlyRbf())")
+        print("Inputs: \(transaction.input())")
+        print("Outputs: \(transaction.output())")
+
+    }
+}


### PR DESCRIPTION
This PR add the `TxIn` type from rust bitcoin, and adds the `Transaction.input()`, `Transaction.output()`, and `Transaction.lock_time()` methods.

### Description
The `input()` and `output()` methods are actually just returning the actual field on the type, hence their name. I don't know why those fields are not called inputs and outputs, but I didn't want to clean up rust-bitcoin's naming convention.

### Notes to the reviewers
The LockTime field is a really good one to add in the future, and we should open an issue for it (returning a LockTime instead of a u32).

### Changelog notice
```md
Added
  - TxIn type [#536]
  - Transaction.input() method [#536]
  - Transaction.output() method [#536]
  - Transaction.lock_time method [#536]

[#536]: https://github.com/bitcoindevkit/bdk-ffi/pull/536
```

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [x] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
