### PR TITLE
Prepare language bindings libraries for alpha 11 release

### DIFF
--- a/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/LiveTxBuilderTest.kt
+++ b/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/LiveTxBuilderTest.kt
@@ -14,7 +14,7 @@ private const val TESTNET_ESPLORA_URL = "https://esplora.testnet.kuutamo.cloud"
 @RunWith(AndroidJUnit4::class)
 class LiveTxBuilderTest {
     private val persistenceFilePath = InstrumentationRegistry
-        .getInstrumentation().targetContext.filesDir.path + "/bdk_persistence.db"
+        .getInstrumentation().targetContext.filesDir.path + "/bdk_persistence3.db"
 
     @AfterTest
     fun cleanup() {
@@ -28,7 +28,7 @@ class LiveTxBuilderTest {
     fun testTxBuilder() {
         val descriptor = Descriptor("wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/0/*)", Network.SIGNET)
         val wallet = Wallet(descriptor, null, persistenceFilePath, Network.SIGNET)
-        val esploraClient = EsploraClient(SIGNET_ESPLORA_URL)
+        val esploraClient: EsploraClient = EsploraClient(SIGNET_ESPLORA_URL)
         val fullScanRequest: FullScanRequest = wallet.startFullScan()
         val update = esploraClient.fullScan(fullScanRequest, 10uL, 1uL)
         wallet.applyUpdate(update)
@@ -41,7 +41,7 @@ class LiveTxBuilderTest {
 
         val recipient: Address = Address("tb1qrnfslnrve9uncz9pzpvf83k3ukz22ljgees989", Network.SIGNET)
         val psbt: Psbt = TxBuilder()
-            .addRecipient(recipient.scriptPubkey(), 4200uL)
+            .addRecipient(recipient.scriptPubkey(), Amount.fromSat(4200uL))
             .feeRate(FeeRate.fromSatPerVb(2uL))
             .finish(wallet)
 
@@ -53,8 +53,8 @@ class LiveTxBuilderTest {
     fun complexTxBuilder() {
         val externalDescriptor = Descriptor("wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/0/*)", Network.SIGNET)
         val changeDescriptor = Descriptor("wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/1/*)", Network.SIGNET)
-        val wallet = Wallet(externalDescriptor, changeDescriptor, persistenceFilePath, Network.TESTNET)
-        val esploraClient = EsploraClient(SIGNET_ESPLORA_URL)
+        val wallet = Wallet(externalDescriptor, changeDescriptor, persistenceFilePath, Network.SIGNET)
+        val esploraClient: EsploraClient = EsploraClient(SIGNET_ESPLORA_URL)
         val fullScanRequest: FullScanRequest = wallet.startFullScan()
         val update = esploraClient.fullScan(fullScanRequest, 10uL, 1uL)
         wallet.applyUpdate(update)
@@ -68,8 +68,8 @@ class LiveTxBuilderTest {
         val recipient1: Address = Address("tb1qrnfslnrve9uncz9pzpvf83k3ukz22ljgees989", Network.SIGNET)
         val recipient2: Address = Address("tb1qw2c3lxufxqe2x9s4rdzh65tpf4d7fssjgh8nv6", Network.SIGNET)
         val allRecipients: List<ScriptAmount> = listOf(
-            ScriptAmount(recipient1.scriptPubkey(), 4200uL),
-            ScriptAmount(recipient2.scriptPubkey(), 4200uL),
+            ScriptAmount(recipient1.scriptPubkey(), Amount.fromSat(4200uL)),
+            ScriptAmount(recipient2.scriptPubkey(), Amount.fromSat(4200uL)),
         )
 
         val psbt: Psbt = TxBuilder()

--- a/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/LiveWalletTest.kt
+++ b/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/LiveWalletTest.kt
@@ -14,7 +14,7 @@ private const val TESTNET_ESPLORA_URL = "https://esplora.testnet.kuutamo.cloud"
 @RunWith(AndroidJUnit4::class)
 class LiveWalletTest {
     private val persistenceFilePath = InstrumentationRegistry
-        .getInstrumentation().targetContext.filesDir.path + "/bdk_persistence.db"
+        .getInstrumentation().targetContext.filesDir.path + "/bdk_persistence2.db"
 
     @AfterTest
     fun cleanup() {
@@ -69,7 +69,7 @@ class LiveWalletTest {
         val recipient: Address = Address("tb1qrnfslnrve9uncz9pzpvf83k3ukz22ljgees989", Network.SIGNET)
 
         val psbt: Psbt = TxBuilder()
-            .addRecipient(recipient.scriptPubkey(), 4200uL)
+            .addRecipient(recipient.scriptPubkey(), Amount.fromSat(4200uL))
             .feeRate(FeeRate.fromSatPerVb(4uL))
             .finish(wallet)
 

--- a/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/OfflineWalletTest.kt
+++ b/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/OfflineWalletTest.kt
@@ -13,7 +13,7 @@ import kotlin.test.AfterTest
 @RunWith(AndroidJUnit4::class)
 class OfflineWalletTest {
     private val persistenceFilePath = InstrumentationRegistry
-        .getInstrumentation().targetContext.filesDir.path + "/bdk_persistence.db"
+        .getInstrumentation().targetContext.filesDir.path + "/bdk_persistence1.db"
 
     @AfterTest
     fun cleanup() {

--- a/bdk-ffi/Cargo.lock
+++ b/bdk-ffi/Cargo.lock
@@ -157,7 +157,7 @@ dependencies = [
 
 [[package]]
 name = "bdk-ffi"
-version = "1.0.0-alpha.10"
+version = "1.0.0-alpha.11"
 dependencies = [
  "assert_matches",
  "bdk",

--- a/bdk-ffi/Cargo.toml
+++ b/bdk-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk-ffi"
-version = "1.0.0-alpha.10"
+version = "1.0.0-alpha.11"
 homepage = "https://bitcoindevkit.org"
 repository = "https://github.com/bitcoindevkit/bdk"
 edition = "2018"

--- a/bdk-swift/Tests/BitcoinDevKitTests/LiveElectrumClientTests.swift
+++ b/bdk-swift/Tests/BitcoinDevKitTests/LiveElectrumClientTests.swift
@@ -37,8 +37,8 @@ final class LiveElectrumClientTests: XCTestCase {
         for tx in transactions {
             let sentAndReceived = wallet.sentAndReceived(tx: tx.transaction)
             print("Transaction: \(tx.transaction.txid())")
-            print("Sent \(sentAndReceived.sent)")
-            print("Received \(sentAndReceived.received)")
+            print("Sent \(sentAndReceived.sent.toSat())")
+            print("Received \(sentAndReceived.received.toSat())")
         }
     }
 }

--- a/bdk-swift/Tests/BitcoinDevKitTests/LiveMemoryWalletTests.swift
+++ b/bdk-swift/Tests/BitcoinDevKitTests/LiveMemoryWalletTests.swift
@@ -37,8 +37,8 @@ final class LiveMemoryWalletTests: XCTestCase {
         for tx in transactions {
             let sentAndReceived = wallet.sentAndReceived(tx: tx.transaction)
             print("Transaction: \(tx.transaction.txid())")
-            print("Sent \(sentAndReceived.sent)")
-            print("Received \(sentAndReceived.received)")
+            print("Sent \(sentAndReceived.sent.toSat())")
+            print("Received \(sentAndReceived.received.toSat())")
         }
     }
 }

--- a/bdk-swift/Tests/BitcoinDevKitTests/LiveWalletTests.swift
+++ b/bdk-swift/Tests/BitcoinDevKitTests/LiveWalletTests.swift
@@ -59,8 +59,8 @@ final class LiveWalletTests: XCTestCase {
         for tx in transactions {
             let sentAndReceived = wallet.sentAndReceived(tx: tx.transaction)
             print("Transaction: \(tx.transaction.txid())")
-            print("Sent \(sentAndReceived.sent)")
-            print("Received \(sentAndReceived.received)")
+            print("Sent \(sentAndReceived.sent.toSat())")
+            print("Received \(sentAndReceived.received.toSat())")
         }
     }
     


### PR DESCRIPTION
This PR:
1. Fixes the Android tests in 2 ways:
  - The tests execute in parallel, so even if we have a teardown method on the persistence file, two tests can use it at the same time and if (as if they currently stand) one is on testnet and one is on signet, the wallet errors out on initialization
  - The live tests didn't update for the new `Amount` type
2. Bumps the (unused) version of the library in the `Cargo.toml` file to alpha 11.
3. Fixes the Swift tests to also print amounts in sat