### PR TITLE
Post Alpha 11 Changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ Changelog information can also be found in each release's git tag (which can be 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.0.0-alpha.11]
+## [v1.0.0-alpha.11]
 This release brings the latest alpha 11 release of the Rust bdk_wallet library, as well as the new Electrum client, the new memory wallet, and a whole lot of new types and APIs across the library. Also of note are the much simpler-to-use full_scan and sync workflows for syncing wallets.
 
 Added:
@@ -20,10 +20,10 @@ Added:
 [#535]: https://github.com/bitcoindevkit/bdk-ffi/pull/535
 [#536]: https://github.com/bitcoindevkit/bdk-ffi/pull/536
 
-## [1.0.0-alpha.7]
+## [v1.0.0-alpha.7]
 This release brings back into the 1.0 API a number of APIs from the 0.31 release, and adds the new flat file persistence feature, as well as more fine-grain errors.
 
-## [1.0.0-alpha.2a]
+## [v1.0.0-alpha.2a]
 This release is the first alpha release of the 1.0 API for the bindings libraries. Here is what is now available:
 - Create and recover wallets using descriptors, including the four descriptor templates
 - Sync a wallet using a blocking Esplora client
@@ -31,7 +31,7 @@ This release is the first alpha release of the 1.0 API for the bindings librarie
 - Create and sign transactions using the transaction builder
 - Broadcast transactions
 
-## [0.31.0]
+## [v0.31.0]
 This release updates the bindings libraries to bdk version 0.29.0, updating rust-bitcoin to version 0.30.2.
 
 - APIs Changed:
@@ -43,7 +43,7 @@ This release updates the bindings libraries to bdk version 0.29.0, updating rust
 
 [#443]: https://github.com/bitcoindevkit/bdk-ffi/pull/443
 
-## [0.30.0]
+## [v0.30.0]
 This release has a new API and a few internal optimizations and refactorings.
 
 - APIs Added
@@ -51,7 +51,7 @@ This release has a new API and a few internal optimizations and refactorings.
 
 [#388]: https://github.com/bitcoindevkit/bdk-ffi/pull/388
 
-## [0.29.0]
+## [v0.29.0]
 This release has a number of new APIs, and adds support for Windows in bdk-jvm.
 
 Changelog
@@ -262,9 +262,9 @@ Changelog
 
 [BIP 0174]:https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki#encoding
 
-[1.0.0-alpha.11]: https://github.com/bitcoindevkit/bdk-ffi/compare/v1.0.0-alpha.7...v1.0.0-alpha.11
-[1.0.0-alpha.7]: https://github.com/bitcoindevkit/bdk-ffi/compare/v1.0.0-alpha.2a...v1.0.0-alpha.7
-[1.0.0-alpha.2a]: https://github.com/bitcoindevkit/bdk-ffi/compare/v0.31.0...v1.0.0-alpha.2a
+[v1.0.0-alpha.11]: https://github.com/bitcoindevkit/bdk-ffi/compare/v1.0.0-alpha.7...v1.0.0-alpha.11
+[v1.0.0-alpha.7]: https://github.com/bitcoindevkit/bdk-ffi/compare/v1.0.0-alpha.2a...v1.0.0-alpha.7
+[v1.0.0-alpha.2a]: https://github.com/bitcoindevkit/bdk-ffi/compare/v0.31.0...v1.0.0-alpha.2a
 [v0.31.0]: https://github.com/bitcoindevkit/bdk-ffi/compare/v0.30.0...v0.31.0
 [v0.30.0]: https://github.com/bitcoindevkit/bdk-ffi/compare/v0.29.0...v0.30.0
 [v0.29.0]: https://github.com/bitcoindevkit/bdk-ffi/compare/v0.28.0...v0.29.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,21 @@ Changelog information can also be found in each release's git tag (which can be 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [1.0.0-alpha.11]
-This release adds the new `Amount` type, as well as more fine-grain errors.
+This release brings the latest alpha 11 release of the Rust bdk_wallet library, as well as the new Electrum client, the new memory wallet, and a whole lot of new types and APIs across the library. Also of note are the much simpler-to-use full_scan and sync workflows for syncing wallets.
+
+Added:
+  - `Amount` type [#533]
+  - `TxIn` type [#536]
+  - `Transaction.input()` method [#536]
+  - `Transaction.output()` method [#536]
+  - `Transaction.lock_time()` method [#536]
+  - `Electrum` client [#535]
+  - Memory wallet [#528]
+
+[#528]: https://github.com/bitcoindevkit/bdk-ffi/pull/528
+[#533]: https://github.com/bitcoindevkit/bdk-ffi/pull/533
+[#535]: https://github.com/bitcoindevkit/bdk-ffi/pull/535
+[#536]: https://github.com/bitcoindevkit/bdk-ffi/pull/536
 
 ## [1.0.0-alpha.7]
 This release brings back into the 1.0 API a number of APIs from the 0.31 release, and adds the new flat file persistence feature, as well as more fine-grain errors.
@@ -248,6 +262,7 @@ Changelog
 
 [BIP 0174]:https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki#encoding
 
+[1.0.0-alpha.11]: https://github.com/bitcoindevkit/bdk-ffi/compare/v1.0.0-alpha.7...v1.0.0-alpha.11
 [1.0.0-alpha.7]: https://github.com/bitcoindevkit/bdk-ffi/compare/v1.0.0-alpha.2a...v1.0.0-alpha.7
 [1.0.0-alpha.2a]: https://github.com/bitcoindevkit/bdk-ffi/compare/v0.31.0...v1.0.0-alpha.2a
 [v0.31.0]: https://github.com/bitcoindevkit/bdk-ffi/compare/v0.30.0...v0.31.0

--- a/bdk-android/gradle.properties
+++ b/bdk-android/gradle.properties
@@ -2,4 +2,4 @@ org.gradle.jvmargs=-Xmx1536m
 android.useAndroidX=true
 android.enableJetifier=true
 kotlin.code.style=official
-libraryVersion=1.0.0-alpha.10-SNAPSHOT
+libraryVersion=1.0.0-alpha.12-SNAPSHOT

--- a/bdk-jvm/gradle.properties
+++ b/bdk-jvm/gradle.properties
@@ -1,4 +1,4 @@
 org.gradle.jvmargs=-Xmx1536m
 android.enableJetifier=true
 kotlin.code.style=official
-libraryVersion=1.0.0-alpha.10-SNAPSHOT
+libraryVersion=1.0.0-alpha.12-SNAPSHOT

--- a/bdk-python/setup.py
+++ b/bdk-python/setup.py
@@ -18,7 +18,7 @@ import bdkpython as bdk
 
 setup(
     name="bdkpython",
-    version="1.0.0a10.dev",
+    version="1.0.0a12.dev",
     description="The Python language bindings for the Bitcoin Development Kit",
     long_description=LONG_DESCRIPTION,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
This PR does two things:
- Bump the development versions of bdk-android, bdk-jvm, and bdk-python
- Update the changelog

There were not changes to the release workflow isssue template this time around.
