### PR TITLE
Update bdk_wallet to alpha 12

### DIFF
--- a/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/LiveTxBuilderTest.kt
+++ b/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/LiveTxBuilderTest.kt
@@ -14,7 +14,7 @@ private const val TESTNET_ESPLORA_URL = "https://esplora.testnet.kuutamo.cloud"
 @RunWith(AndroidJUnit4::class)
 class LiveTxBuilderTest {
     private val persistenceFilePath = InstrumentationRegistry
-        .getInstrumentation().targetContext.filesDir.path + "/bdk_persistence3.db"
+        .getInstrumentation().targetContext.filesDir.path + "/bdk_persistence3.sqlite"
 
     @AfterTest
     fun cleanup() {

--- a/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/LiveWalletTest.kt
+++ b/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/LiveWalletTest.kt
@@ -14,7 +14,7 @@ private const val TESTNET_ESPLORA_URL = "https://esplora.testnet.kuutamo.cloud"
 @RunWith(AndroidJUnit4::class)
 class LiveWalletTest {
     private val persistenceFilePath = InstrumentationRegistry
-        .getInstrumentation().targetContext.filesDir.path + "/bdk_persistence2.db"
+        .getInstrumentation().targetContext.filesDir.path + "/bdk_persistence2.sqlite"
 
     @AfterTest
     fun cleanup() {

--- a/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/OfflineWalletTest.kt
+++ b/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/OfflineWalletTest.kt
@@ -13,7 +13,7 @@ import kotlin.test.AfterTest
 @RunWith(AndroidJUnit4::class)
 class OfflineWalletTest {
     private val persistenceFilePath = InstrumentationRegistry
-        .getInstrumentation().targetContext.filesDir.path + "/bdk_persistence1.db"
+        .getInstrumentation().targetContext.filesDir.path + "/bdk_persistence1.sqlite"
 
     @AfterTest
     fun cleanup() {

--- a/bdk-ffi/Cargo.lock
+++ b/bdk-ffi/Cargo.lock
@@ -3,6 +3,18 @@
 version = 3
 
 [[package]]
+name = "ahash"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -143,34 +155,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "bdk"
-version = "1.0.0-alpha.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65c23f2903ac5dbb7b35934ae319aadc946201e4fa51b652440bd1c8fa3080ee"
-dependencies = [
- "anyhow",
- "bdk_chain",
- "bdk_persist",
- "bip39",
- "bitcoin",
- "getrandom",
- "js-sys",
- "miniscript",
- "rand",
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "bdk-ffi"
 version = "1.0.0-alpha.11"
 dependencies = [
  "assert_matches",
- "bdk",
  "bdk_bitcoind_rpc",
  "bdk_electrum",
  "bdk_esplora",
- "bdk_file_store",
+ "bdk_sqlite",
+ "bdk_wallet",
  "bitcoin-internals",
  "thiserror",
  "uniffi",
@@ -182,7 +175,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54fe9410002d5c350b59145ed0b18af1bb81521e7d62515defe539a450e20551"
 dependencies = [
- "bdk_chain",
+ "bdk_chain 0.14.0",
  "bitcoin",
  "bitcoincore-rpc",
 ]
@@ -195,50 +188,80 @@ checksum = "440ec5b1c8911f126b540e05c98493b699b497a3cb90c5e9c5eee21cdd8d1e01"
 dependencies = [
  "bitcoin",
  "miniscript",
+]
+
+[[package]]
+name = "bdk_chain"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c601c4dc7e6c3efa538a0afbb43b964cefab9a9b5e8f352fa0ca38145448a5e7"
+dependencies = [
+ "bitcoin",
+ "miniscript",
  "serde",
 ]
 
 [[package]]
 name = "bdk_electrum"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44bbf3b0031651a37a48bdfab0c1d96a305b587f616593d34df9b1ff63efc4ff"
+checksum = "28906275aeb1f71dc32045670f06c8a26fb17cc62151a99f7425d258f4bda589"
 dependencies = [
- "bdk_chain",
+ "bdk_chain 0.15.0",
  "electrum-client",
 ]
 
 [[package]]
 name = "bdk_esplora"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb5b46f8c256bc083640342bd0d35ec1963971f18800c3fee1a9189eda60ecd"
+checksum = "28b2409ff6b35fc69e864bc6986731e024ccd70bd325183f8ffff1590d9895d1"
 dependencies = [
- "bdk_chain",
+ "bdk_chain 0.15.0",
  "esplora-client",
 ]
 
 [[package]]
-name = "bdk_file_store"
-version = "0.11.0"
+name = "bdk_persist"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfd7e9a5edb8d384ea1836b0bcd4febdd3211815acc058d64c7e284776d69ab"
+checksum = "41528569e8507f078143526c72bdee75f93f17d3b028cb7d88b4889278973e7d"
 dependencies = [
  "anyhow",
- "bdk_chain",
- "bdk_persist",
- "bincode",
- "serde",
+ "bdk_chain 0.15.0",
 ]
 
 [[package]]
-name = "bdk_persist"
-version = "0.2.0"
+name = "bdk_sqlite"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aba103c2108dd0f0b452650043d21c449ae07ce866dbaea29a9c59899a5964f0"
+checksum = "b665413b2c5d5151dbb9cb6a855ccbbc26fdb6143f22faf2deea4e8c61fc33e6"
 dependencies = [
  "anyhow",
- "bdk_chain",
+ "bdk_chain 0.15.0",
+ "bdk_persist",
+ "rusqlite",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "bdk_wallet"
+version = "1.0.0-alpha.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f830d1a9a090b5837d3813aff8b90888e04b72bf2704b29796e1bab439c86255"
+dependencies = [
+ "anyhow",
+ "bdk_chain 0.15.0",
+ "bdk_persist",
+ "bip39",
+ "bitcoin",
+ "getrandom",
+ "js-sys",
+ "miniscript",
+ "rand",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -332,6 +355,12 @@ dependencies = [
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "bitflags"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
 
 [[package]]
 name = "bumpalo"
@@ -465,11 +494,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a73e879128c5fcb38abaf0ec53e3310947c6e7b61ce0f1b4cd7a0b8ea1ab0389"
 dependencies = [
  "bitcoin",
- "hex-conservative 0.2.0",
+ "hex-conservative 0.2.1",
  "log",
  "minreq",
  "serde",
 ]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fs-err"
@@ -509,6 +550,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown",
+]
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -528,9 +587,9 @@ checksum = "30ed443af458ccb6d81c1e7e661545f94d3176752fb1df2f543b902a1e0f51e2"
 
 [[package]]
 name = "hex-conservative"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1aa273bf451e37ed35ced41c71a5e2a4e29064afb104158f2514bcd71c2c986"
+checksum = "5313b072ce3c597065a808dbf612c4c8e8590bdbf8b579508bf7a762c5eae6cd"
 dependencies = [
  "arrayvec",
 ]
@@ -572,6 +631,17 @@ name = "libc"
 version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c10584274047cb335c23d3e61bcef8e323adae7c5c8c760540f73610177fc3f"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "log"
@@ -621,9 +691,9 @@ dependencies = [
 
 [[package]]
 name = "minreq"
-version = "2.11.1"
+version = "2.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00a000cf8bbbfb123a9bdc66b61c2885a4bb038df4f2629884caafabeb76b0f9"
+checksum = "6fdef521c74c2884a4f3570bcdb6d2a77b3c533feb6b27ac2ae72673cc221c64"
 dependencies = [
  "base64 0.12.3",
  "log",
@@ -662,6 +732,12 @@ name = "paste"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
 name = "plain"
@@ -736,6 +812,20 @@ dependencies = [
  "spin",
  "untrusted",
  "windows-sys",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b838eba278d213a8beaf485bd313fd580ca4505a00d5871caeb1457c55322cae"
+dependencies = [
+ "bitflags",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
 ]
 
 [[package]]
@@ -862,6 +952,12 @@ name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
+
+[[package]]
+name = "smallvec"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "smawk"
@@ -1135,6 +1231,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1309,3 +1411,23 @@ name = "windows_x86_64_msvc"
 version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
+
+[[package]]
+name = "zerocopy"
+version = "0.7.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae87e3fcd617500e5d106f0380cf7b77f3c6092aae37191433159dda23cfb087"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]

--- a/bdk-ffi/Cargo.toml
+++ b/bdk-ffi/Cargo.toml
@@ -18,10 +18,10 @@ path = "uniffi-bindgen.rs"
 default = ["uniffi/cli"]
 
 [dependencies]
-bdk = { version = "1.0.0-alpha.11", features = ["all-keys", "keys-bip39"] }
-bdk_esplora = { version = "0.13.0", default-features = false, features = ["std", "blocking", "blocking-https-rustls"] }
-bdk_electrum = { version = "0.13.0" }
-bdk_file_store = { version = "0.11.0" }
+bdk_wallet = { version = "1.0.0-alpha.12", features = ["all-keys", "keys-bip39"] }
+bdk_esplora = { version = "0.14.0", default-features = false, features = ["std", "blocking", "blocking-https-rustls"] }
+bdk_electrum = { version = "0.14.0" }
+bdk_sqlite = { version = "0.1.0" }
 bdk_bitcoind_rpc = { version = "0.10.0" }
 
 uniffi = { version = "=0.27.1" }

--- a/bdk-ffi/src/bdk.udl
+++ b/bdk-ffi/src/bdk.udl
@@ -237,6 +237,12 @@ interface SignerError {
 };
 
 [Error]
+interface SqliteError {
+  InvalidNetwork(Network expected, Network given);
+  Sqlite(string rusqlite_error);
+};
+
+[Error]
 interface TransactionError {
   Io();
   OversizedVectorAllocation();

--- a/bdk-ffi/src/bdk.udl
+++ b/bdk-ffi/src/bdk.udl
@@ -262,6 +262,7 @@ interface WalletCreationError {
   LoadedGenesisDoesNotMatch(string expected, string got);
   LoadedNetworkDoesNotMatch(Network expected, Network? got);
   LoadedDescriptorDoesNotMatch(string got, KeychainKind keychain);
+  Sqlite(string error_message);
 };
 
 // ------------------------------------------------------------------------
@@ -416,7 +417,7 @@ interface TxBuilder {
 
   TxBuilder fee_rate([ByRef] FeeRate fee_rate);
 
-  TxBuilder fee_absolute(u64 fee);
+  TxBuilder fee_absolute(Amount fee);
 
   TxBuilder drain_wallet();
 

--- a/bdk-ffi/src/bitcoin.rs
+++ b/bdk-ffi/src/bitcoin.rs
@@ -1,22 +1,22 @@
 use crate::error::{AddressError, FeeRateError, PsbtError, PsbtParseError, TransactionError};
 
-use bdk::bitcoin::address::{NetworkChecked, NetworkUnchecked};
-use bdk::bitcoin::amount::ParseAmountError;
-use bdk::bitcoin::blockdata::script::ScriptBuf as BdkScriptBuf;
-use bdk::bitcoin::blockdata::transaction::TxOut as BdkTxOut;
-use bdk::bitcoin::consensus::encode::serialize;
-use bdk::bitcoin::consensus::Decodable;
-use bdk::bitcoin::psbt::ExtractTxError;
-use bdk::bitcoin::Address as BdkAddress;
-use bdk::bitcoin::Amount as BdkAmount;
-use bdk::bitcoin::FeeRate as BdkFeeRate;
-use bdk::bitcoin::Network;
-use bdk::bitcoin::OutPoint as BdkOutPoint;
-use bdk::bitcoin::Psbt as BdkPsbt;
-use bdk::bitcoin::Transaction as BdkTransaction;
-use bdk::bitcoin::TxIn as BdkTxIn;
-use bdk::bitcoin::Txid;
 use bdk_bitcoind_rpc::bitcoincore_rpc::jsonrpc::serde_json;
+use bdk_wallet::bitcoin::address::{NetworkChecked, NetworkUnchecked};
+use bdk_wallet::bitcoin::amount::ParseAmountError;
+use bdk_wallet::bitcoin::blockdata::script::ScriptBuf as BdkScriptBuf;
+use bdk_wallet::bitcoin::blockdata::transaction::TxOut as BdkTxOut;
+use bdk_wallet::bitcoin::consensus::encode::serialize;
+use bdk_wallet::bitcoin::consensus::Decodable;
+use bdk_wallet::bitcoin::psbt::ExtractTxError;
+use bdk_wallet::bitcoin::Address as BdkAddress;
+use bdk_wallet::bitcoin::Amount as BdkAmount;
+use bdk_wallet::bitcoin::FeeRate as BdkFeeRate;
+use bdk_wallet::bitcoin::Network;
+use bdk_wallet::bitcoin::OutPoint as BdkOutPoint;
+use bdk_wallet::bitcoin::Psbt as BdkPsbt;
+use bdk_wallet::bitcoin::Transaction as BdkTransaction;
+use bdk_wallet::bitcoin::TxIn as BdkTxIn;
+use bdk_wallet::bitcoin::Txid;
 
 use std::io::Cursor;
 use std::ops::Deref;
@@ -82,7 +82,7 @@ pub struct Address(BdkAddress<NetworkChecked>);
 
 impl Address {
     pub fn new(address: String, network: Network) -> Result<Self, AddressError> {
-        let parsed_address = address.parse::<bdk::bitcoin::Address<NetworkUnchecked>>()?;
+        let parsed_address = address.parse::<bdk_wallet::bitcoin::Address<NetworkUnchecked>>()?;
         let network_checked_address = parsed_address.require_network(network)?;
 
         Ok(Address(network_checked_address))

--- a/bdk-ffi/src/descriptor.rs
+++ b/bdk-ffi/src/descriptor.rs
@@ -2,17 +2,17 @@ use crate::error::DescriptorError;
 use crate::keys::DescriptorPublicKey;
 use crate::keys::DescriptorSecretKey;
 
-use bdk::bitcoin::bip32::Fingerprint;
-use bdk::bitcoin::key::Secp256k1;
-use bdk::bitcoin::Network;
-use bdk::descriptor::{ExtendedDescriptor, IntoWalletDescriptor};
-use bdk::keys::DescriptorPublicKey as BdkDescriptorPublicKey;
-use bdk::keys::{DescriptorSecretKey as BdkDescriptorSecretKey, KeyMap};
-use bdk::template::{
+use bdk_wallet::bitcoin::bip32::Fingerprint;
+use bdk_wallet::bitcoin::key::Secp256k1;
+use bdk_wallet::bitcoin::Network;
+use bdk_wallet::descriptor::{ExtendedDescriptor, IntoWalletDescriptor};
+use bdk_wallet::keys::DescriptorPublicKey as BdkDescriptorPublicKey;
+use bdk_wallet::keys::{DescriptorSecretKey as BdkDescriptorSecretKey, KeyMap};
+use bdk_wallet::template::{
     Bip44, Bip44Public, Bip49, Bip49Public, Bip84, Bip84Public, Bip86, Bip86Public,
     DescriptorTemplate,
 };
-use bdk::KeychainKind;
+use bdk_wallet::KeychainKind;
 
 use std::str::FromStr;
 
@@ -275,6 +275,8 @@ impl Descriptor {
 mod test {
     use crate::*;
     use assert_matches::assert_matches;
+    use bdk_wallet::bitcoin::Network;
+    use bdk_wallet::KeychainKind;
 
     fn get_descriptor_secret_key() -> DescriptorSecretKey {
         let mnemonic = Mnemonic::from_string("chaos fabric time speed sponsor all flat solution wisdom trophy crack object robot pave observe combine where aware bench orient secret primary cable detect".to_string()).unwrap();

--- a/bdk-ffi/src/electrum.rs
+++ b/bdk-ffi/src/electrum.rs
@@ -3,14 +3,15 @@ use crate::error::ElectrumError;
 use crate::types::{FullScanRequest, SyncRequest};
 use crate::wallet::Update;
 
-use bdk::bitcoin::Transaction as BdkTransaction;
-use bdk::chain::spk_client::FullScanRequest as BdkFullScanRequest;
-use bdk::chain::spk_client::FullScanResult as BdkFullScanResult;
-use bdk::chain::spk_client::SyncRequest as BdkSyncRequest;
-use bdk::chain::spk_client::SyncResult as BdkSyncResult;
-use bdk::KeychainKind;
 use bdk_electrum::electrum_client::{Client as BdkBlockingClient, ElectrumApi};
 use bdk_electrum::{ElectrumExt, ElectrumFullScanResult, ElectrumSyncResult};
+use bdk_wallet::bitcoin::Transaction as BdkTransaction;
+use bdk_wallet::chain::spk_client::FullScanRequest as BdkFullScanRequest;
+use bdk_wallet::chain::spk_client::FullScanResult as BdkFullScanResult;
+use bdk_wallet::chain::spk_client::SyncRequest as BdkSyncRequest;
+use bdk_wallet::chain::spk_client::SyncResult as BdkSyncResult;
+use bdk_wallet::wallet::Update as BdkUpdate;
+use bdk_wallet::KeychainKind;
 
 use std::collections::BTreeMap;
 use std::sync::Arc;
@@ -47,7 +48,7 @@ impl ElectrumClient {
         let full_scan_result: BdkFullScanResult<KeychainKind> =
             electrum_result.with_confirmation_time_height_anchor(&self.0)?;
 
-        let update = bdk::wallet::Update {
+        let update = BdkUpdate {
             last_active_indices: full_scan_result.last_active_indices,
             graph: full_scan_result.graph_update,
             chain: Some(full_scan_result.chain_update),
@@ -76,7 +77,7 @@ impl ElectrumClient {
         let sync_result: BdkSyncResult =
             electrum_result.with_confirmation_time_height_anchor(&self.0)?;
 
-        let update = bdk::wallet::Update {
+        let update = BdkUpdate {
             last_active_indices: BTreeMap::default(),
             graph: sync_result.graph_update,
             chain: Some(sync_result.chain_update),

--- a/bdk-ffi/src/esplora.rs
+++ b/bdk-ffi/src/esplora.rs
@@ -2,17 +2,18 @@ use crate::bitcoin::Transaction;
 use crate::error::EsploraError;
 use crate::types::{FullScanRequest, SyncRequest};
 use crate::wallet::Update;
-use std::collections::BTreeMap;
 
-use bdk::bitcoin::Transaction as BdkTransaction;
-use bdk::chain::spk_client::FullScanRequest as BdkFullScanRequest;
-use bdk::chain::spk_client::FullScanResult as BdkFullScanResult;
-use bdk::chain::spk_client::SyncRequest as BdkSyncRequest;
-use bdk::chain::spk_client::SyncResult as BdkSyncResult;
-use bdk::KeychainKind;
 use bdk_esplora::esplora_client::{BlockingClient, Builder};
 use bdk_esplora::EsploraExt;
+use bdk_wallet::bitcoin::Transaction as BdkTransaction;
+use bdk_wallet::chain::spk_client::FullScanRequest as BdkFullScanRequest;
+use bdk_wallet::chain::spk_client::FullScanResult as BdkFullScanResult;
+use bdk_wallet::chain::spk_client::SyncRequest as BdkSyncRequest;
+use bdk_wallet::chain::spk_client::SyncResult as BdkSyncResult;
+use bdk_wallet::wallet::Update as BdkUpdate;
+use bdk_wallet::KeychainKind;
 
+use std::collections::BTreeMap;
 use std::sync::Arc;
 
 pub struct EsploraClient(BlockingClient);
@@ -41,7 +42,7 @@ impl EsploraClient {
             self.0
                 .full_scan(request, stop_gap as usize, parallel_requests as usize)?;
 
-        let update = bdk::wallet::Update {
+        let update = BdkUpdate {
             last_active_indices: result.last_active_indices,
             graph: result.graph_update,
             chain: Some(result.chain_update),
@@ -65,7 +66,7 @@ impl EsploraClient {
 
         let result: BdkSyncResult = self.0.sync(request, parallel_requests as usize)?;
 
-        let update = bdk::wallet::Update {
+        let update = BdkUpdate {
             last_active_indices: BTreeMap::default(),
             graph: result.graph_update,
             chain: Some(result.chain_update),

--- a/bdk-ffi/src/keys.rs
+++ b/bdk-ffi/src/keys.rs
@@ -1,18 +1,18 @@
 use crate::error::{Bip32Error, Bip39Error, DescriptorKeyError};
 
-use bdk::bitcoin::bip32::DerivationPath as BdkDerivationPath;
-use bdk::bitcoin::key::Secp256k1;
-use bdk::bitcoin::secp256k1::rand;
-use bdk::bitcoin::secp256k1::rand::Rng;
-use bdk::bitcoin::Network;
-use bdk::keys::bip39::WordCount;
-use bdk::keys::bip39::{Language, Mnemonic as BdkMnemonic};
-use bdk::keys::{
+use bdk_wallet::bitcoin::bip32::DerivationPath as BdkDerivationPath;
+use bdk_wallet::bitcoin::key::Secp256k1;
+use bdk_wallet::bitcoin::secp256k1::rand;
+use bdk_wallet::bitcoin::secp256k1::rand::Rng;
+use bdk_wallet::bitcoin::Network;
+use bdk_wallet::keys::bip39::WordCount;
+use bdk_wallet::keys::bip39::{Language, Mnemonic as BdkMnemonic};
+use bdk_wallet::keys::{
     DerivableKey, DescriptorPublicKey as BdkDescriptorPublicKey,
     DescriptorSecretKey as BdkDescriptorSecretKey, ExtendedKey, GeneratableKey, GeneratedKey,
 };
-use bdk::miniscript::descriptor::{DescriptorXKey, Wildcard};
-use bdk::miniscript::BareCtx;
+use bdk_wallet::miniscript::descriptor::{DescriptorXKey, Wildcard};
+use bdk_wallet::miniscript::BareCtx;
 
 use std::ops::Deref;
 use std::str::FromStr;
@@ -224,10 +224,9 @@ impl DescriptorPublicKey {
 
 #[cfg(test)]
 mod test {
-    use crate::keys::{DerivationPath, DescriptorPublicKey, DescriptorSecretKey, Mnemonic};
-    // use bdk::bitcoin::hashes::hex::ToHex;
     use crate::error::DescriptorKeyError;
-    use bdk::bitcoin::Network;
+    use crate::keys::{DerivationPath, DescriptorPublicKey, DescriptorSecretKey, Mnemonic};
+    use bdk_wallet::bitcoin::Network;
     use std::sync::Arc;
 
     fn get_inner() -> DescriptorSecretKey {

--- a/bdk-ffi/src/lib.rs
+++ b/bdk-ffi/src/lib.rs
@@ -36,6 +36,7 @@ use crate::error::PersistenceError;
 use crate::error::PsbtError;
 use crate::error::PsbtParseError;
 use crate::error::SignerError;
+use crate::error::SqliteError;
 use crate::error::TransactionError;
 use crate::error::TxidParseError;
 use crate::error::WalletCreationError;

--- a/bdk-ffi/src/lib.rs
+++ b/bdk-ffi/src/lib.rs
@@ -60,9 +60,9 @@ use crate::wallet::TxBuilder;
 use crate::wallet::Update;
 use crate::wallet::Wallet;
 
-use bdk::bitcoin::Network;
-use bdk::keys::bip39::WordCount;
-use bdk::wallet::tx_builder::ChangeSpendPolicy;
-use bdk::KeychainKind;
+use bdk_wallet::bitcoin::Network;
+use bdk_wallet::keys::bip39::WordCount;
+use bdk_wallet::wallet::tx_builder::ChangeSpendPolicy;
+use bdk_wallet::KeychainKind;
 
 uniffi::include_scaffolding!("bdk");

--- a/bdk-ffi/src/types.rs
+++ b/bdk-ffi/src/types.rs
@@ -1,19 +1,19 @@
+use crate::bitcoin::Amount;
 use crate::bitcoin::{Address, OutPoint, Script, Transaction, TxOut};
+use crate::InspectError;
 
-use bdk::bitcoin::ScriptBuf as BdkScriptBuf;
-use bdk::chain::spk_client::FullScanRequest as BdkFullScanRequest;
-use bdk::chain::spk_client::SyncRequest as BdkSyncRequest;
-use bdk::chain::tx_graph::CanonicalTx as BdkCanonicalTx;
-use bdk::chain::{ChainPosition as BdkChainPosition, ConfirmationTimeHeightAnchor};
-use bdk::wallet::AddressInfo as BdkAddressInfo;
-use bdk::wallet::Balance as BdkBalance;
-use bdk::KeychainKind;
-use bdk::LocalOutput as BdkLocalOutput;
+use bdk_wallet::bitcoin::ScriptBuf as BdkScriptBuf;
+use bdk_wallet::bitcoin::Transaction as BdkTransaction;
+use bdk_wallet::chain::spk_client::FullScanRequest as BdkFullScanRequest;
+use bdk_wallet::chain::spk_client::SyncRequest as BdkSyncRequest;
+use bdk_wallet::chain::tx_graph::CanonicalTx as BdkCanonicalTx;
+use bdk_wallet::chain::{ChainPosition as BdkChainPosition, ConfirmationTimeHeightAnchor};
+use bdk_wallet::wallet::AddressInfo as BdkAddressInfo;
+use bdk_wallet::wallet::Balance as BdkBalance;
+use bdk_wallet::KeychainKind;
+use bdk_wallet::LocalOutput as BdkLocalOutput;
 
 use std::sync::{Arc, Mutex};
-
-use crate::bitcoin::Amount;
-use crate::error::InspectError;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ChainPosition {
@@ -26,12 +26,8 @@ pub struct CanonicalTx {
     pub chain_position: ChainPosition,
 }
 
-impl From<BdkCanonicalTx<'_, Arc<bdk::bitcoin::Transaction>, ConfirmationTimeHeightAnchor>>
-    for CanonicalTx
-{
-    fn from(
-        tx: BdkCanonicalTx<'_, Arc<bdk::bitcoin::Transaction>, ConfirmationTimeHeightAnchor>,
-    ) -> Self {
+impl From<BdkCanonicalTx<'_, Arc<BdkTransaction>, ConfirmationTimeHeightAnchor>> for CanonicalTx {
+    fn from(tx: BdkCanonicalTx<'_, Arc<BdkTransaction>, ConfirmationTimeHeightAnchor>) -> Self {
         let chain_position = match tx.chain_position {
             BdkChainPosition::Confirmed(anchor) => ChainPosition::Confirmed {
                 height: anchor.confirmation_height,

--- a/bdk-jvm/lib/src/test/kotlin/org/bitcoindevkit/LiveTxBuilderTest.kt
+++ b/bdk-jvm/lib/src/test/kotlin/org/bitcoindevkit/LiveTxBuilderTest.kt
@@ -11,7 +11,7 @@ private const val TESTNET_ESPLORA_URL = "https://esplora.testnet.kuutamo.cloud"
 class LiveTxBuilderTest {
     private val persistenceFilePath = run {
         val currentDirectory = System.getProperty("user.dir")
-        "$currentDirectory/bdk_persistence.db"
+        "$currentDirectory/bdk_persistence.sqlite"
     }
 
     @AfterTest

--- a/bdk-jvm/lib/src/test/kotlin/org/bitcoindevkit/LiveWalletTest.kt
+++ b/bdk-jvm/lib/src/test/kotlin/org/bitcoindevkit/LiveWalletTest.kt
@@ -11,7 +11,7 @@ private const val TESTNET_ESPLORA_URL = "https://esplora.testnet.kuutamo.cloud"
 class LiveWalletTest {
     private val persistenceFilePath = run {
         val currentDirectory = System.getProperty("user.dir")
-        "$currentDirectory/bdk_persistence.db"
+        "$currentDirectory/bdk_persistence.sqlite"
     }
 
     @AfterTest

--- a/bdk-jvm/lib/src/test/kotlin/org/bitcoindevkit/OfflineWalletTest.kt
+++ b/bdk-jvm/lib/src/test/kotlin/org/bitcoindevkit/OfflineWalletTest.kt
@@ -10,7 +10,7 @@ import kotlin.test.assertFalse
 class OfflineWalletTest {
     private val persistenceFilePath = run {
         val currentDirectory = System.getProperty("user.dir")
-        "$currentDirectory/bdk_persistence.db"
+        "$currentDirectory/bdk_persistence.sqlite"
     }
 
     @AfterTest

--- a/bdk-python/tests/test_live_tx_builder.py
+++ b/bdk-python/tests/test_live_tx_builder.py
@@ -8,8 +8,8 @@ TESTNET_ESPLORA_URL = "https://esplora.testnet.kuutamo.cloud"
 class LiveTxBuilderTest(unittest.TestCase):
 
     def tearDown(self) -> None:
-        if os.path.exists("./bdk_persistence.db"):
-            os.remove("./bdk_persistence.db")
+        if os.path.exists("./bdk_persistence.sqlite"):
+            os.remove("./bdk_persistence.sqlite")
 
     def test_tx_builder(self):
         descriptor: bdk.Descriptor = bdk.Descriptor(
@@ -19,7 +19,7 @@ class LiveTxBuilderTest(unittest.TestCase):
         wallet: bdk.Wallet = bdk.Wallet(
             descriptor,
             None,
-            "./bdk_persistence.db",
+            "./bdk_persistence.sqlite",
             bdk.Network.SIGNET
         )
         esplora_client: bdk.EsploraClient = bdk.EsploraClient(url = SIGNET_ESPLORA_URL)
@@ -55,7 +55,7 @@ class LiveTxBuilderTest(unittest.TestCase):
         wallet: bdk.Wallet = bdk.Wallet(
             descriptor,
             None,
-            "./bdk_persistence.db",
+            "./bdk_persistence.sqlite",
             bdk.Network.SIGNET
         )
         esplora_client: bdk.EsploraClient = bdk.EsploraClient(url = SIGNET_ESPLORA_URL)

--- a/bdk-python/tests/test_live_wallet.py
+++ b/bdk-python/tests/test_live_wallet.py
@@ -8,8 +8,8 @@ TESTNET_ESPLORA_URL = "https://esplora.testnet.kuutamo.cloud"
 class LiveWalletTest(unittest.TestCase):
 
     def tearDown(self) -> None:
-        if os.path.exists("./bdk_persistence.db"):
-            os.remove("./bdk_persistence.db")
+        if os.path.exists("./bdk_persistence.sqlite"):
+            os.remove("./bdk_persistence.sqlite")
 
     def test_synced_balance(self):
         descriptor: bdk.Descriptor = bdk.Descriptor(
@@ -19,7 +19,7 @@ class LiveWalletTest(unittest.TestCase):
         wallet: bdk.Wallet = bdk.Wallet(
             descriptor,
             None,
-            "./bdk_persistence.db",
+            "./bdk_persistence.sqlite",
             bdk.Network.SIGNET
         )
         esplora_client: bdk.EsploraClient = bdk.EsploraClient(url = SIGNET_ESPLORA_URL)
@@ -55,7 +55,7 @@ class LiveWalletTest(unittest.TestCase):
         wallet: bdk.Wallet = bdk.Wallet(
             descriptor,
             None,
-            "./bdk_persistence.db",
+            "./bdk_persistence.sqlite",
             bdk.Network.SIGNET
         )
         esplora_client: bdk.EsploraClient = bdk.EsploraClient(url = SIGNET_ESPLORA_URL)

--- a/bdk-python/tests/test_offline_wallet.py
+++ b/bdk-python/tests/test_offline_wallet.py
@@ -5,8 +5,8 @@ import os
 class OfflineWalletTest(unittest.TestCase):
 
     def tearDown(self) -> None:
-        if os.path.exists("./bdk_persistence.db"):
-            os.remove("./bdk_persistence.db")
+        if os.path.exists("./bdk_persistence.sqlite"):
+            os.remove("./bdk_persistence.sqlite")
     
     def test_new_address(self):
         descriptor: bdk.Descriptor = bdk.Descriptor(
@@ -16,7 +16,7 @@ class OfflineWalletTest(unittest.TestCase):
         wallet: Wallet = bdk.Wallet(
             descriptor,
             None,
-            "./bdk_persistence.db",
+            "./bdk_persistence.sqlite",
             bdk.Network.TESTNET
         )
         address_info: bdk.AddressInfo = wallet.reveal_next_address(bdk.KeychainKind.EXTERNAL)
@@ -36,7 +36,7 @@ class OfflineWalletTest(unittest.TestCase):
         wallet: bdk.Wallet = bdk.Wallet(
             descriptor,
             None,
-            "./bdk_persistence.db",
+            "./bdk_persistence.sqlite",
             bdk.Network.TESTNET
         )
     

--- a/bdk-swift/Tests/BitcoinDevKitTests/LiveTxBuilderTests.swift
+++ b/bdk-swift/Tests/BitcoinDevKitTests/LiveTxBuilderTests.swift
@@ -11,7 +11,7 @@ final class LiveTxBuilderTests: XCTestCase {
         super.setUp()
         let fileManager = FileManager.default
         let documentDirectory = fileManager.urls(for: .documentDirectory, in: .userDomainMask).first!
-        let uniqueDbFileName = "bdk_persistence_\(UUID().uuidString).db"
+        let uniqueDbFileName = "bdk_persistence_\(UUID().uuidString).sqlite"
         dbFilePath = documentDirectory.appendingPathComponent(uniqueDbFileName)
 
         if fileManager.fileExists(atPath: dbFilePath.path) {

--- a/bdk-swift/Tests/BitcoinDevKitTests/LiveWalletTests.swift
+++ b/bdk-swift/Tests/BitcoinDevKitTests/LiveWalletTests.swift
@@ -11,7 +11,7 @@ final class LiveWalletTests: XCTestCase {
         super.setUp()
         let fileManager = FileManager.default
         let documentDirectory = fileManager.urls(for: .documentDirectory, in: .userDomainMask).first!
-        let uniqueDbFileName = "bdk_persistence_\(UUID().uuidString).db"
+        let uniqueDbFileName = "bdk_persistence_\(UUID().uuidString).sqlite"
         dbFilePath = documentDirectory.appendingPathComponent(uniqueDbFileName)
 
         if fileManager.fileExists(atPath: dbFilePath.path) {

--- a/bdk-swift/Tests/BitcoinDevKitTests/OfflineWalletTests.swift
+++ b/bdk-swift/Tests/BitcoinDevKitTests/OfflineWalletTests.swift
@@ -8,7 +8,7 @@ final class OfflineWalletTests: XCTestCase {
         super.setUp()
         let fileManager = FileManager.default
         let documentDirectory = fileManager.urls(for: .documentDirectory, in: .userDomainMask).first!
-        let uniqueDbFileName = "bdk_persistence_\(UUID().uuidString).db"
+        let uniqueDbFileName = "bdk_persistence_\(UUID().uuidString).sqlite"
         dbFilePath = documentDirectory.appendingPathComponent(uniqueDbFileName)
 
         if fileManager.fileExists(atPath: dbFilePath.path) {


### PR DESCRIPTION
This PR upgrades the (newly named!) bdk_wallet library to the alpha 12 version. 

Also part of this are the upgrade to bdk_esplora (0.14.0), bdk_electrum (0.14.0), and the introduction of the new bdk_sqlite (0.1.0) persistence crate.

Note:
1. The diff is pretty big because all the imports using `bdk` are now switched to `bdk_wallet`.
2. I changed the names of the persistence files in the tests to `.sqlite`, as is common for those types of files (but is not required). This is also the naming used on the Rust bdk side, so I think it's a good fit anyway.
3. The core upgrade here for the sqlite persistence is surprisingly small: lines 41-42 in the wallet module.
4. I added the SqliteError type which is not used yet (should I remove it and wait to add it when we have a need?). The current places where the codebase can throw a sqlite error is on the wallet creation method, but this one can only throw one of the variants of the [BdkSqliteError](https://docs.rs/bdk_sqlite/0.1.0/bdk_sqlite/enum.Error.html), the one where it's a wrapper for the rusqlite error. So I added that as a variant on the WalletCreationError (that's required), but I also added just the normal bdk Sqlite error just so this PR has it and we can use it in the future.

### Changelog notice
```md
Upgrades
  - Update bdk_esplora client to 0.14.0 [#544]
  - Update bdk_electrum client to 0.14.0 [#544]

Added
  - bdk_sqlite persistence [#544]

Removed
  - flat file persistence [#544]

[#544]: https://github.com/bitcoindevkit/bdk-ffi/pull/544
```

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
