### PR TITLE
Remove Ruby config in uniffi.toml

### DIFF
--- a/bdk-ffi/uniffi.toml
+++ b/bdk-ffi/uniffi.toml
@@ -5,8 +5,5 @@ cdylib_name = "bdkffi"
 [bindings.python]
 cdylib_name = "bdkffi"
 
-[bindings.ruby]
-cdylib_name = "bdkffi"
-
 [bindings.swift]
 cdylib_name = "bdkffi"


### PR DESCRIPTION
Does what it says on the tin.

Fixes #548.