### PR TITLE
Use `Display` trait to auto-populate the toString method and `description` fields

### DIFF
--- a/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/LiveTxBuilderTest.kt
+++ b/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/LiveTxBuilderTest.kt
@@ -36,7 +36,7 @@ class LiveTxBuilderTest {
         println("Balance: ${wallet.getBalance().total.toSat()}")
 
         assert(wallet.getBalance().total.toSat() > 0uL) {
-            "Wallet balance must be greater than 0! Please send funds to ${wallet.revealNextAddress(KeychainKind.EXTERNAL).address.asString()} and try again."
+            "Wallet balance must be greater than 0! Please send funds to ${wallet.revealNextAddress(KeychainKind.EXTERNAL).address} and try again."
         }
 
         val recipient: Address = Address("tb1qrnfslnrve9uncz9pzpvf83k3ukz22ljgees989", Network.SIGNET)

--- a/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/OfflineWalletTest.kt
+++ b/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/OfflineWalletTest.kt
@@ -53,7 +53,7 @@ class OfflineWalletTest {
 
         assertEquals(
             expected = "tb1qzg4mckdh50nwdm9hkzq06528rsu73hjxxzem3e",
-            actual = addressInfo.address.asString()
+            actual = addressInfo.address.toString()
         )
     }
 

--- a/bdk-ffi/src/bdk.udl
+++ b/bdk-ffi/src/bdk.udl
@@ -611,6 +611,7 @@ enum WordCount {
   "Words24",
 };
 
+[Traits=(Display)]
 interface Address {
   [Throws=AddressError]
   constructor(string address, Network network);
@@ -620,8 +621,6 @@ interface Address {
   Script script_pubkey();
 
   string to_qr_uri();
-
-  string as_string();
 
   boolean is_valid_for_network(Network network);
 };

--- a/bdk-ffi/src/bitcoin.rs
+++ b/bdk-ffi/src/bitcoin.rs
@@ -1,4 +1,5 @@
 use crate::error::{AddressError, FeeRateError, PsbtError, PsbtParseError, TransactionError};
+use std::fmt::Display;
 
 use bdk_bitcoind_rpc::bitcoincore_rpc::jsonrpc::serde_json;
 use bdk_wallet::bitcoin::address::{NetworkChecked, NetworkUnchecked};
@@ -100,10 +101,6 @@ impl Address {
         self.0.to_qr_uri()
     }
 
-    pub fn as_string(&self) -> String {
-        self.0.to_string()
-    }
-
     pub fn is_valid_for_network(&self, network: Network) -> bool {
         let address_str = self.0.to_string();
         if let Ok(unchecked_address) = address_str.parse::<BdkAddress<NetworkUnchecked>>() {
@@ -111,6 +108,12 @@ impl Address {
         } else {
             false
         }
+    }
+}
+
+impl Display for Address {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
     }
 }
 

--- a/bdk-jvm/lib/src/test/kotlin/org/bitcoindevkit/LiveElectrumClientTest.kt
+++ b/bdk-jvm/lib/src/test/kotlin/org/bitcoindevkit/LiveElectrumClientTest.kt
@@ -20,7 +20,7 @@ class LiveElectrumClientTest {
         println("Balance: ${wallet.getBalance().total.toSat()}")
 
         assert(wallet.getBalance().total.toSat() > 0uL) {
-            "Wallet balance must be greater than 0! Please send funds to ${wallet.revealNextAddress(KeychainKind.EXTERNAL).address.asString()} and try again."
+            "Wallet balance must be greater than 0! Please send funds to ${wallet.revealNextAddress(KeychainKind.EXTERNAL).address} and try again."
         }
 
         println("Transactions count: ${wallet.transactions().count()}")

--- a/bdk-jvm/lib/src/test/kotlin/org/bitcoindevkit/LiveMemoryWalletTest.kt
+++ b/bdk-jvm/lib/src/test/kotlin/org/bitcoindevkit/LiveMemoryWalletTest.kt
@@ -22,7 +22,7 @@ class LiveMemoryWalletTest {
         println("Balance: ${wallet.getBalance().total.toSat()}")
 
         assert(wallet.getBalance().total.toSat() > 0uL) {
-            "Wallet balance must be greater than 0! Please send funds to ${wallet.revealNextAddress(KeychainKind.EXTERNAL).address.asString()} and try again."
+            "Wallet balance must be greater than 0! Please send funds to ${wallet.revealNextAddress(KeychainKind.EXTERNAL).address} and try again."
         }
 
         println("Transactions count: ${wallet.transactions().count()}")
@@ -57,7 +57,7 @@ class LiveMemoryWalletTest {
         println("Balance: ${wallet.getBalance().total.toSat()}")
 
         assert(wallet.getBalance().total.toSat() > 0uL) {
-            "Wallet balance must be greater than 0! Please send funds to ${wallet.revealNextAddress(KeychainKind.EXTERNAL).address.asString()} and try again."
+            "Wallet balance must be greater than 0! Please send funds to ${wallet.revealNextAddress(KeychainKind.EXTERNAL).address} and try again."
         }
 
     }

--- a/bdk-jvm/lib/src/test/kotlin/org/bitcoindevkit/LiveTransactionTests.kt
+++ b/bdk-jvm/lib/src/test/kotlin/org/bitcoindevkit/LiveTransactionTests.kt
@@ -21,7 +21,7 @@ class LiveTransactionTests {
         println("Wallet balance: ${wallet.getBalance().total.toSat()}")
 
         assert(wallet.getBalance().total.toSat() > 0uL) {
-            "Wallet balance must be greater than 0! Please send funds to ${wallet.revealNextAddress(KeychainKind.EXTERNAL).address.asString()} and try again."
+            "Wallet balance must be greater than 0! Please send funds to ${wallet.revealNextAddress(KeychainKind.EXTERNAL).address} and try again."
         }
 
         val transaction: Transaction = wallet.transactions().first().transaction

--- a/bdk-jvm/lib/src/test/kotlin/org/bitcoindevkit/LiveTxBuilderTest.kt
+++ b/bdk-jvm/lib/src/test/kotlin/org/bitcoindevkit/LiveTxBuilderTest.kt
@@ -34,7 +34,7 @@ class LiveTxBuilderTest {
         println("Balance: ${wallet.getBalance().total.toSat()}")
 
         assert(wallet.getBalance().total.toSat() > 0uL) {
-            "Wallet balance must be greater than 0! Please send funds to ${wallet.revealNextAddress(KeychainKind.EXTERNAL).address.asString()} and try again."
+            "Wallet balance must be greater than 0! Please send funds to ${wallet.revealNextAddress(KeychainKind.EXTERNAL).address} and try again."
         }
 
         val recipient: Address = Address("tb1qrnfslnrve9uncz9pzpvf83k3ukz22ljgees989", Network.SIGNET)
@@ -61,7 +61,7 @@ class LiveTxBuilderTest {
         println("Balance: ${wallet.getBalance().total.toSat()}")
 
         assert(wallet.getBalance().total.toSat() > 0uL) {
-            "Wallet balance must be greater than 0! Please send funds to ${wallet.revealNextAddress(KeychainKind.EXTERNAL).address.asString()} and try again."
+            "Wallet balance must be greater than 0! Please send funds to ${wallet.revealNextAddress(KeychainKind.EXTERNAL).address} and try again."
         }
 
         val recipient1: Address = Address("tb1qrnfslnrve9uncz9pzpvf83k3ukz22ljgees989", Network.SIGNET)

--- a/bdk-jvm/lib/src/test/kotlin/org/bitcoindevkit/LiveWalletTest.kt
+++ b/bdk-jvm/lib/src/test/kotlin/org/bitcoindevkit/LiveWalletTest.kt
@@ -34,7 +34,7 @@ class LiveWalletTest {
         println("Balance: ${wallet.getBalance().total.toSat()}")
 
         assert(wallet.getBalance().total.toSat() > 0uL) {
-            "Wallet balance must be greater than 0! Please send funds to ${wallet.revealNextAddress(KeychainKind.EXTERNAL).address.asString()} and try again."
+            "Wallet balance must be greater than 0! Please send funds to ${wallet.revealNextAddress(KeychainKind.EXTERNAL).address} and try again."
         }
 
         println("Transactions count: ${wallet.transactions().count()}")
@@ -59,7 +59,7 @@ class LiveWalletTest {
         println("Balance: ${wallet.getBalance().total.toSat()}")
 
         assert(wallet.getBalance().total.toSat() > 0uL) {
-            "Wallet balance must be greater than 0! Please send funds to ${wallet.revealNextAddress(KeychainKind.EXTERNAL).address.asString()} and try again."
+            "Wallet balance must be greater than 0! Please send funds to ${wallet.revealNextAddress(KeychainKind.EXTERNAL).address} and try again."
         }
 
         val recipient: Address = Address("tb1qrnfslnrve9uncz9pzpvf83k3ukz22ljgees989", Network.SIGNET)

--- a/bdk-jvm/lib/src/test/kotlin/org/bitcoindevkit/OfflineWalletTest.kt
+++ b/bdk-jvm/lib/src/test/kotlin/org/bitcoindevkit/OfflineWalletTest.kt
@@ -51,7 +51,7 @@ class OfflineWalletTest {
 
         assertEquals(
             expected = "tb1qzg4mckdh50nwdm9hkzq06528rsu73hjxxzem3e",
-            actual = addressInfo.address.asString()
+            actual = addressInfo.address.toString()
         )
     }
 

--- a/bdk-python/tests/test_live_tx_builder.py
+++ b/bdk-python/tests/test_live_tx_builder.py
@@ -35,7 +35,7 @@ class LiveTxBuilderTest(unittest.TestCase):
         self.assertGreater(
             wallet.get_balance().total.to_sat(),
             0,
-            f"Wallet balance must be greater than 0! Please send funds to {wallet.reveal_next_address(bdk.KeychainKind.EXTERNAL).address.as_string()} and try again."
+            f"Wallet balance must be greater than 0! Please send funds to {wallet.reveal_next_address(bdk.KeychainKind.EXTERNAL).address} and try again."
         )
         
         recipient = bdk.Address(
@@ -71,7 +71,7 @@ class LiveTxBuilderTest(unittest.TestCase):
         self.assertGreater(
             wallet.get_balance().total.to_sat(),
             0,
-            f"Wallet balance must be greater than 0! Please send funds to {wallet.reveal_next_address(bdk.KeychainKind.EXTERNAL).address.as_string()} and try again."
+            f"Wallet balance must be greater than 0! Please send funds to {wallet.reveal_next_address(bdk.KeychainKind.EXTERNAL).address} and try again."
         )
         
         recipient1 = bdk.Address(

--- a/bdk-python/tests/test_live_wallet.py
+++ b/bdk-python/tests/test_live_wallet.py
@@ -35,7 +35,7 @@ class LiveWalletTest(unittest.TestCase):
         self.assertGreater(
             wallet.get_balance().total.to_sat(),
             0,
-            f"Wallet balance must be greater than 0! Please send funds to {wallet.reveal_next_address(bdk.KeychainKind.EXTERNAL).address.as_string()} and try again."
+            f"Wallet balance must be greater than 0! Please send funds to {wallet.reveal_next_address(bdk.KeychainKind.EXTERNAL).address} and try again."
         )
         
         print(f"Transactions count: {len(wallet.transactions())}")
@@ -71,7 +71,7 @@ class LiveWalletTest(unittest.TestCase):
         self.assertGreater(
             wallet.get_balance().total.to_sat(),
             0,
-            f"Wallet balance must be greater than 0! Please send funds to {wallet.reveal_next_address(bdk.KeychainKind.EXTERNAL).address.as_string()} and try again."
+            f"Wallet balance must be greater than 0! Please send funds to {wallet.reveal_next_address(bdk.KeychainKind.EXTERNAL).address} and try again."
         )
         
         recipient = bdk.Address(

--- a/bdk-python/tests/test_offline_wallet.py
+++ b/bdk-python/tests/test_offline_wallet.py
@@ -26,7 +26,7 @@ class OfflineWalletTest(unittest.TestCase):
         self.assertFalse(address_info.address.is_valid_for_network(bdk.Network.REGTEST), "Address is valid for regtest network, but it shouldn't be")
         self.assertFalse(address_info.address.is_valid_for_network(bdk.Network.BITCOIN), "Address is valid for bitcoin network, but it shouldn't be")
     
-        self.assertEqual("tb1qzg4mckdh50nwdm9hkzq06528rsu73hjxxzem3e", address_info.address.as_string())
+        self.assertEqual("tb1qzg4mckdh50nwdm9hkzq06528rsu73hjxxzem3e", address_info.address.__str__())
     
     def test_balance(self):
         descriptor: bdk.Descriptor = bdk.Descriptor(

--- a/bdk-swift/Tests/BitcoinDevKitTests/LiveElectrumClientTests.swift
+++ b/bdk-swift/Tests/BitcoinDevKitTests/LiveElectrumClientTests.swift
@@ -24,7 +24,7 @@ final class LiveElectrumClientTests: XCTestCase {
         )
         try wallet.applyUpdate(update: update)
         let _ = try wallet.commit()
-        let address = try wallet.revealNextAddress(keychain: KeychainKind.external).address.asString()
+        let address = try wallet.revealNextAddress(keychain: KeychainKind.external).address
 
         XCTAssertGreaterThan(
             wallet.getBalance().total.toSat(),

--- a/bdk-swift/Tests/BitcoinDevKitTests/LiveMemoryWalletTests.swift
+++ b/bdk-swift/Tests/BitcoinDevKitTests/LiveMemoryWalletTests.swift
@@ -25,7 +25,7 @@ final class LiveMemoryWalletTests: XCTestCase {
         )
         try wallet.applyUpdate(update: update)
         let _ = try wallet.commit()
-        let address = try wallet.revealNextAddress(keychain: KeychainKind.external).address.asString()
+        let address = try wallet.revealNextAddress(keychain: KeychainKind.external).address.description
 
         XCTAssertGreaterThan(
             wallet.getBalance().total.toSat(),
@@ -68,7 +68,7 @@ final class LiveMemoryWalletTests: XCTestCase {
         )
         try wallet.applyUpdate(update: update)
         let _ = try wallet.commit()
-        let address = try wallet.revealNextAddress(keychain: KeychainKind.external).address.asString()
+        let address = try wallet.revealNextAddress(keychain: KeychainKind.external).address.description
 
         XCTAssertGreaterThan(
             wallet.getBalance().total.toSat(),

--- a/bdk-swift/Tests/BitcoinDevKitTests/LiveTransactionTests.swift
+++ b/bdk-swift/Tests/BitcoinDevKitTests/LiveTransactionTests.swift
@@ -24,7 +24,7 @@ final class LiveTransactionTests: XCTestCase {
         )
         try wallet.applyUpdate(update: update)
         let _ = try wallet.commit()
-        let address = try wallet.revealNextAddress(keychain: KeychainKind.external).address.asString()
+        let address = try wallet.revealNextAddress(keychain: KeychainKind.external).address.description
 
         XCTAssertGreaterThan(
             wallet.getBalance().total.toSat(),

--- a/bdk-swift/Tests/BitcoinDevKitTests/LiveTxBuilderTests.swift
+++ b/bdk-swift/Tests/BitcoinDevKitTests/LiveTxBuilderTests.swift
@@ -46,7 +46,7 @@ final class LiveTxBuilderTests: XCTestCase {
         )
         try wallet.applyUpdate(update: update)
         let _ = try wallet.commit()
-        let address = try wallet.revealNextAddress(keychain: KeychainKind.external).address.asString()
+        let address = try wallet.revealNextAddress(keychain: KeychainKind.external).address.description
 
         XCTAssertGreaterThan(
             wallet.getBalance().total.toSat(),
@@ -88,7 +88,7 @@ final class LiveTxBuilderTests: XCTestCase {
         )
         try wallet.applyUpdate(update: update)
         let _ = try wallet.commit()
-        let address = try wallet.revealNextAddress(keychain: KeychainKind.external).address.asString()
+        let address = try wallet.revealNextAddress(keychain: KeychainKind.external).address.description
 
         XCTAssertGreaterThan(
             wallet.getBalance().total.toSat(),

--- a/bdk-swift/Tests/BitcoinDevKitTests/LiveWalletTests.swift
+++ b/bdk-swift/Tests/BitcoinDevKitTests/LiveWalletTests.swift
@@ -46,7 +46,7 @@ final class LiveWalletTests: XCTestCase {
         )
         try wallet.applyUpdate(update: update)
         let _ = try wallet.commit()
-        let address = try wallet.revealNextAddress(keychain: KeychainKind.external).address.asString()
+        let address = try wallet.revealNextAddress(keychain: KeychainKind.external).address.description
 
         XCTAssertGreaterThan(
             wallet.getBalance().total.toSat(),
@@ -84,7 +84,7 @@ final class LiveWalletTests: XCTestCase {
         )
         try wallet.applyUpdate(update: update)
         let _ = try wallet.commit()
-        let address = try wallet.revealNextAddress(keychain: KeychainKind.external).address.asString()
+        let address = try wallet.revealNextAddress(keychain: KeychainKind.external).address.description
         
         XCTAssertGreaterThan(
             wallet.getBalance().total.toSat(),

--- a/bdk-swift/Tests/BitcoinDevKitTests/OfflineWalletTests.swift
+++ b/bdk-swift/Tests/BitcoinDevKitTests/OfflineWalletTests.swift
@@ -45,7 +45,7 @@ final class OfflineWalletTests: XCTestCase {
         XCTAssertFalse(addressInfo.address.isValidForNetwork(network: Network.bitcoin),
                       "Address is valid for bitcoin network, but it shouldn't be")
 
-        XCTAssertEqual(addressInfo.address.asString(), "tb1qzg4mckdh50nwdm9hkzq06528rsu73hjxxzem3e")
+        XCTAssertEqual(addressInfo.address.description, "tb1qzg4mckdh50nwdm9hkzq06528rsu73hjxxzem3e")
     }
     
     func testBalance() throws {


### PR DESCRIPTION
This is one of my favourite little PRs in a long time.

We cannot write an explicit toString() method on our objects because the name clashes with the `toString()` method on the JVM, and alternatively we cannot add a `description` field on objects because it clashes with the field in Swift. This means that for objects that have a requirement for this toString() method, we actually add a method called `asString()`. It works, but it's uglier than it needs to be and feels a little odd (_why is the toString() not implemented on this type?_, a developer might ask).

But as of the 0.26 release of uniffi, if you define a Display trait on a type, it will automatically use that for the toString() method in Kotlin and the `description` field in Swift! This means of course that we can remove the odd-looking `asString()` (which achieves the same thing), but also that this is can be derived automatically for us by Rust! Here's how it looks in the UDL:

```idl
[Traits=(Display)]
interface Address { }
```

Old printout in Kotlin:
```kotlin
println("Address asString: ${addressInfo.address.asString()}")
// Address asString: tb1qzg4mckdh50nwdm9hkzq06528rsu73hjxxzem3e

println("Address toString: ${addressInfo.address.toString()}")
// Address toString: org.bitcoindevkit.Address@ec2cc4
```

New printout:
```kotlin
// Old stuff
println("Address asString: ${addressInfo.address.asString()}")
// Address asString: tb1qzg4mckdh50nwdm9hkzq06528rsu73hjxxzem3e

// Better
println("Address toString: ${addressInfo.address.toString()}")
// Address toString: tb1qzg4mckdh50nwdm9hkzq06528rsu73hjxxzem3e

// Pure sugar!
println("Address with implicit toString: ${addressInfo.address}")
// Address with implicit toString: tb1qzg4mckdh50nwdm9hkzq06528rsu73hjxxzem3e
```
Note that the `toString()` method is also applied automatically in many places, removing the need to actually write it out explicitly.

In Swift it's just as good. The difference is that you would have gotten an error if you tried to use the `description` field before:
```swift
print("Address description: \(addressInfo.address.description)")
// error: value of type 'Address' has no member 'description'

print("Address implicit description: \(addressInfo.address)")
Address implicit description: BitcoinDevKit.Address
```

You now get:
```swift
// Old stuff
print("Address asString: \(addressInfo.address.asString())")
// Address asString: tb1qzg4mckdh50nwdm9hkzq06528rsu73hjxxzem3e

// Pretty good
print("Address description: \(addressInfo.address.description)")
Address description: tb1qzg4mckdh50nwdm9hkzq06528rsu73hjxxzem3e

// Awesome!
print("Address implicit description: \(addressInfo.address)")
Address implicit description: tb1qzg4mckdh50nwdm9hkzq06528rsu73hjxxzem3e
```

The structs currently affected (and made better by this change) are:
- `Address`
- `DescriptorSecretKey`
- `DescriptorPublicKey`
- `Mnemonic`
- `Descriptor`

But I suspect there might be many more that could use a clean `toString()` implementation which we did not have a clean way to provide.

### Changelog notice

TODO

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [x] I've added tests for the new feature
* [ ] I've added docs for the new feature
