### PR TITLE
Add address from_script method

### DIFF
--- a/bdk-ffi/src/bdk.udl
+++ b/bdk-ffi/src/bdk.udl
@@ -616,6 +616,9 @@ interface Address {
   [Throws=AddressError]
   constructor(string address, Network network);
 
+  [Name=from_script, Throws=AddressError]
+  constructor(Script script, Network network);
+
   Network network();
 
   Script script_pubkey();

--- a/bdk-ffi/src/bitcoin.rs
+++ b/bdk-ffi/src/bitcoin.rs
@@ -89,6 +89,12 @@ impl Address {
         Ok(Address(network_checked_address))
     }
 
+    pub fn from_script(script: Arc<Script>, network: Network) -> Result<Self, AddressError> {
+        let address = BdkAddress::from_script(&script.0.clone(), network)?;
+
+        Ok(Address(address))
+    }
+
     pub fn network(&self) -> Network {
         *self.0.network()
     }


### PR DESCRIPTION
<!-- Erase any parts of this template not applicable to your Pull Request. -->

### Description

Per #522 adding back in [Address.from_script() method](https://docs.rs/bitcoin/0.31.2/bitcoin/address/struct.Address.html#method.from_script)

We already had the [AddressError](https://docs.rs/bitcoin/0.31.2/bitcoin/address/error/enum.Error.html) implemented so that was nice to not have to implement an error.

### Notes to the reviewers

Pre-1.0 
- `lib.rs`: https://github.com/bitcoindevkit/bdk-ffi/blob/release/0.31/bdk-ffi/src/lib.rs#L391C1-L396C6
- `wallet.rs`: https://github.com/bitcoindevkit/bdk-ffi/blob/release/0.31/bdk-ffi/src/wallet.rs#L622
- `.udl`: https://github.com/bitcoindevkit/bdk-ffi/blob/release/0.31/bdk-ffi/src/bdk.udl#L461

One thing I couldn't find a good spot for was adding `from_script` into an existing test (like in TxBuilder tests) that made a whole lot of sense to me without feeling like I was trying to shoehorn it in, let me know if you think of a good spot that I'm not thinking of though? But I did test out a local build of the Swift bindings with this addition to it, with the BDK iOS app, and it worked as expected calling `fromScript` initializer. 

### Changelog notice

```
Added
  - Address.from_script() [#554]

[#554]: https://github.com/bitcoindevkit/bdk-ffi/pull/554
```

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
