### PR TITLE
Callback to Foreign Trait

### DIFF
--- a/bdk-ffi/src/bdk.udl
+++ b/bdk-ffi/src/bdk.udl
@@ -333,11 +333,13 @@ interface SyncRequest {
   SyncRequest inspect_spks(SyncScriptInspector inspector);
 };
 
-callback interface SyncScriptInspector {
+[Trait, WithForeign]
+interface SyncScriptInspector {
   void inspect(Script script, u64 total);
 };
 
-callback interface FullScanScriptInspector {
+[Trait, WithForeign]
+interface FullScanScriptInspector {
   void inspect(KeychainKind keychain, u32 index, Script script);
 };
 

--- a/bdk-ffi/src/types.rs
+++ b/bdk-ffi/src/types.rs
@@ -127,7 +127,7 @@ pub struct SyncRequest(pub(crate) Mutex<Option<BdkSyncRequest>>);
 impl SyncRequest {
     pub fn inspect_spks(
         &self,
-        inspector: Box<dyn SyncScriptInspector>,
+        inspector: Arc<dyn SyncScriptInspector>,
     ) -> Result<Arc<Self>, InspectError> {
         let mut guard = self.0.lock().unwrap();
         if let Some(sync_request) = guard.take() {
@@ -145,7 +145,7 @@ impl SyncRequest {
 impl FullScanRequest {
     pub fn inspect_spks_for_all_keychains(
         &self,
-        inspector: Box<dyn FullScanScriptInspector>,
+        inspector: Arc<dyn FullScanScriptInspector>,
     ) -> Result<Arc<Self>, InspectError> {
         let mut guard = self.0.lock().unwrap();
         if let Some(full_scan_request) = guard.take() {


### PR DESCRIPTION
<!-- Erase any parts of this template not applicable to your Pull Request. -->

### Description

This PR refactors the `SyncScriptInspector` and `FullScanScriptInspector` interfaces from using [callback](https://mozilla.github.io/uniffi-rs/0.27/udl/callback_interfaces.html) interfaces to [foreign traits](https://mozilla.github.io/uniffi-rs/0.27/foreign_traits.html). This change aligns with the latest recommendations from uniffi docs and [examples](https://github.com/mozilla/uniffi-rs/blob/main/examples/callbacks/src/callbacks.udl), which discourages the use of callback interfaces in favor of foreign traits:

<img width="516" alt="Screenshot 2024-06-07 at 7 46 12 PM" src="https://github.com/bitcoindevkit/bdk-ffi/assets/6657488/f796ed1c-e6d8-4a89-8eb9-5fb95e954817">


### Notes to the reviewers

I built the bindings for this pr locally and tested on the BDK iOS app, no changes needed on the client side, which was nice, and everything worked as expected.

### Changelog notice

_Lemme know if this needs a changelog, still newer to adding changelog info so not sure if this chore qualifies._

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
