### PR TITLE
Add display trait to mnemonic

### DIFF
--- a/bdk-ffi/src/bdk.udl
+++ b/bdk-ffi/src/bdk.udl
@@ -454,6 +454,7 @@ interface BumpFeeTxBuilder {
 // bdk crate - descriptor module
 // ------------------------------------------------------------------------
 
+[Traits=(Display)]
 interface Mnemonic {
   constructor(WordCount word_count);
 
@@ -462,8 +463,6 @@ interface Mnemonic {
 
   [Name=from_entropy, Throws=Bip39Error]
   constructor(sequence<u8> entropy);
-
-  string as_string();
 };
 
 interface DerivationPath {

--- a/bdk-ffi/src/keys.rs
+++ b/bdk-ffi/src/keys.rs
@@ -1,4 +1,5 @@
 use crate::error::{Bip32Error, Bip39Error, DescriptorKeyError};
+use std::fmt::Display;
 
 use bdk_wallet::bitcoin::bip32::DerivationPath as BdkDerivationPath;
 use bdk_wallet::bitcoin::key::Secp256k1;
@@ -44,9 +45,11 @@ impl Mnemonic {
             .map(Mnemonic)
             .map_err(Bip39Error::from)
     }
+}
 
-    pub(crate) fn as_string(&self) -> String {
-        self.0.to_string()
+impl Display for Mnemonic {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
     }
 }
 


### PR DESCRIPTION
<!-- Erase any parts of this template not applicable to your Pull Request. -->

### Description

Adds more to #551 , I was working on BDK iOS and just saw that I was using `Mnemonic.asString()` so I wanted to make that nicer by using the display trait on `Mnemonic` instead now after seeing #551 .

This also removes the `asString()` method which is nice.

### Notes to the reviewers


### Changelog notice

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
