### PR TITLE
Add display trait to descriptor

### DIFF
--- a/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/OfflineDescriptorTest.kt
+++ b/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/OfflineDescriptorTest.kt
@@ -15,7 +15,7 @@ class OfflineDescriptorTest {
 
         assertEquals(
             expected = "tr([be1eec8f/86'/1'/0']tpubDCTtszwSxPx3tATqDrsSyqScPNnUChwQAVAkanuDUCJQESGBbkt68nXXKRDifYSDbeMa2Xg2euKbXaU3YphvGWftDE7ozRKPriT6vAo3xsc/0/*)#m7puekcx",
-            actual = descriptor.asString()
+            actual = descriptor.toString()
         )
     }
 }

--- a/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/OfflineWalletTest.kt
+++ b/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/OfflineWalletTest.kt
@@ -29,7 +29,7 @@ class OfflineWalletTest {
         val descriptorSecretKey: DescriptorSecretKey = DescriptorSecretKey(Network.TESTNET, mnemonic, null)
         val descriptor: Descriptor = Descriptor.newBip86(descriptorSecretKey, KeychainKind.EXTERNAL, Network.TESTNET)
 
-        assertTrue(descriptor.asString().startsWith("tr"), "Bip86 Descriptor does not start with 'tr'")
+        assertTrue(descriptor.toString().startsWith("tr"), "Bip86 Descriptor does not start with 'tr'")
     }
 
    @Test

--- a/bdk-ffi/src/bdk.udl
+++ b/bdk-ffi/src/bdk.udl
@@ -502,6 +502,7 @@ interface DescriptorPublicKey {
   string as_string();
 };
 
+[Traits=(Display)]
 interface Descriptor {
   [Throws=DescriptorError]
   constructor(string descriptor, Network network);
@@ -530,9 +531,7 @@ interface Descriptor {
   [Name=new_bip86_public]
   constructor([ByRef] DescriptorPublicKey public_key, string fingerprint, KeychainKind keychain, Network network);
 
-  string as_string();
-
-  string as_string_private();
+  string to_string_with_secret();
 };
 
 // ------------------------------------------------------------------------

--- a/bdk-ffi/src/descriptor.rs
+++ b/bdk-ffi/src/descriptor.rs
@@ -1,6 +1,7 @@
 use crate::error::DescriptorError;
 use crate::keys::DescriptorPublicKey;
 use crate::keys::DescriptorSecretKey;
+use std::fmt::Display;
 
 use bdk_wallet::bitcoin::bip32::Fingerprint;
 use bdk_wallet::bitcoin::key::Secp256k1;
@@ -260,14 +261,16 @@ impl Descriptor {
         }
     }
 
-    pub(crate) fn as_string_private(&self) -> String {
+    pub(crate) fn to_string_with_secret(&self) -> String {
         let descriptor = &self.extended_descriptor;
         let key_map = &self.key_map;
         descriptor.to_string_with_secret(key_map)
     }
+}
 
-    pub(crate) fn as_string(&self) -> String {
-        self.extended_descriptor.to_string()
+impl Display for Descriptor {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.extended_descriptor)
     }
 }
 
@@ -321,10 +324,10 @@ mod test {
         let template_private_86 =
             Descriptor::new_bip86(&master, KeychainKind::External, Network::Testnet);
         // the extended public keys are the same when creating them manually as they are with the templates
-        println!("Template 49: {}", template_private_49.as_string());
-        println!("Template 44: {}", template_private_44.as_string());
-        println!("Template 84: {}", template_private_84.as_string());
-        println!("Template 86: {}", template_private_86.as_string());
+        println!("Template 49: {}", template_private_49);
+        println!("Template 44: {}", template_private_44);
+        println!("Template 84: {}", template_private_84);
+        println!("Template 86: {}", template_private_86);
         let template_public_44 = Descriptor::new_bip44_public(
             &handmade_public_44,
             "d1d04177".to_string(),
@@ -349,43 +352,43 @@ mod test {
             KeychainKind::External,
             Network::Testnet,
         );
-        println!("Template public 49: {}", template_public_49.as_string());
-        println!("Template public 44: {}", template_public_44.as_string());
-        println!("Template public 84: {}", template_public_84.as_string());
-        println!("Template public 86: {}", template_public_86.as_string());
-        // when using a public key, both as_string and as_string_private return the same string
+        println!("Template public 49: {}", template_public_49);
+        println!("Template public 44: {}", template_public_44);
+        println!("Template public 84: {}", template_public_84);
+        println!("Template public 86: {}", template_public_86);
+        // when using a public key, both to_string and as_string_private return the same string
         assert_eq!(
-            template_public_44.as_string_private(),
-            template_public_44.as_string()
+            template_public_44.to_string_with_secret(),
+            template_public_44.to_string()
         );
         assert_eq!(
-            template_public_49.as_string_private(),
-            template_public_49.as_string()
+            template_public_49.to_string_with_secret(),
+            template_public_49.to_string()
         );
         assert_eq!(
-            template_public_84.as_string_private(),
-            template_public_84.as_string()
+            template_public_84.to_string_with_secret(),
+            template_public_84.to_string()
         );
         assert_eq!(
-            template_public_86.as_string_private(),
-            template_public_86.as_string()
+            template_public_86.to_string_with_secret(),
+            template_public_86.to_string()
         );
-        // when using as_string on a private key, we get the same result as when using it on a public key
+        // when using to_string on a private key, we get the same result as when using it on a public key
         assert_eq!(
-            template_private_44.as_string(),
-            template_public_44.as_string()
-        );
-        assert_eq!(
-            template_private_49.as_string(),
-            template_public_49.as_string()
+            template_private_44.to_string(),
+            template_public_44.to_string()
         );
         assert_eq!(
-            template_private_84.as_string(),
-            template_public_84.as_string()
+            template_private_49.to_string(),
+            template_public_49.to_string()
         );
         assert_eq!(
-            template_private_86.as_string(),
-            template_public_86.as_string()
+            template_private_84.to_string(),
+            template_public_84.to_string()
+        );
+        assert_eq!(
+            template_private_86.to_string(),
+            template_public_86.to_string()
         );
     }
     #[test]

--- a/bdk-ffi/src/wallet.rs
+++ b/bdk-ffi/src/wallet.rs
@@ -36,8 +36,8 @@ impl Wallet {
         persistence_backend_path: String,
         network: Network,
     ) -> Result<Self, WalletCreationError> {
-        let descriptor = descriptor.as_string_private();
-        let change_descriptor = change_descriptor.map(|d| d.as_string_private());
+        let descriptor = descriptor.to_string_with_secret();
+        let change_descriptor = change_descriptor.map(|d| d.to_string_with_secret());
         let connection = Connection::open(persistence_backend_path)?;
         let db = Store::new(connection)?;
 
@@ -54,8 +54,8 @@ impl Wallet {
         change_descriptor: Option<Arc<Descriptor>>,
         network: Network,
     ) -> Result<Self, DescriptorError> {
-        let descriptor = descriptor.as_string_private();
-        let change_descriptor = change_descriptor.map(|d| d.as_string_private());
+        let descriptor = descriptor.to_string_with_secret();
+        let change_descriptor = change_descriptor.map(|d| d.to_string_with_secret());
 
         let wallet: BdkWallet =
             BdkWallet::new_no_persist(&descriptor, change_descriptor.as_ref(), network)?;

--- a/bdk-jvm/lib/src/test/kotlin/org/bitcoindevkit/OfflineDescriptorTest.kt
+++ b/bdk-jvm/lib/src/test/kotlin/org/bitcoindevkit/OfflineDescriptorTest.kt
@@ -12,7 +12,7 @@ class OfflineDescriptorTest {
 
         assertEquals(
             expected = "tr([be1eec8f/86'/1'/0']tpubDCTtszwSxPx3tATqDrsSyqScPNnUChwQAVAkanuDUCJQESGBbkt68nXXKRDifYSDbeMa2Xg2euKbXaU3YphvGWftDE7ozRKPriT6vAo3xsc/0/*)#m7puekcx",
-            actual = descriptor.asString()
+            actual = descriptor.toString()
         )
     }
 }

--- a/bdk-jvm/lib/src/test/kotlin/org/bitcoindevkit/OfflineWalletTest.kt
+++ b/bdk-jvm/lib/src/test/kotlin/org/bitcoindevkit/OfflineWalletTest.kt
@@ -27,7 +27,7 @@ class OfflineWalletTest {
         val descriptorSecretKey: DescriptorSecretKey = DescriptorSecretKey(Network.TESTNET, mnemonic, null)
         val descriptor: Descriptor = Descriptor.newBip86(descriptorSecretKey, KeychainKind.EXTERNAL, Network.TESTNET)
 
-        assertTrue(descriptor.asString().startsWith("tr"), "Bip86 Descriptor does not start with 'tr'")
+        assertTrue(descriptor.toString().startsWith("tr"), "Bip86 Descriptor does not start with 'tr'")
     }
 
    @Test

--- a/bdk-python/tests/test_offline_descriptor.py
+++ b/bdk-python/tests/test_offline_descriptor.py
@@ -10,7 +10,7 @@ class OfflineDescriptorTest(unittest.TestCase):
 
         self.assertEqual(
             "tr([be1eec8f/86'/1'/0']tpubDCTtszwSxPx3tATqDrsSyqScPNnUChwQAVAkanuDUCJQESGBbkt68nXXKRDifYSDbeMa2Xg2euKbXaU3YphvGWftDE7ozRKPriT6vAo3xsc/0/*)#m7puekcx",
-            descriptor.as_string()
+            descriptor.__str__()
         )
 
 

--- a/bdk-swift/Tests/BitcoinDevKitTests/OfflineDescriptorTests.swift
+++ b/bdk-swift/Tests/BitcoinDevKitTests/OfflineDescriptorTests.swift
@@ -15,6 +15,6 @@ final class OfflineDescriptorTests: XCTestCase {
             network: Network.testnet
         )
 
-        XCTAssertEqual(descriptor.asString(), "tr([be1eec8f/86'/1'/0']tpubDCTtszwSxPx3tATqDrsSyqScPNnUChwQAVAkanuDUCJQESGBbkt68nXXKRDifYSDbeMa2Xg2euKbXaU3YphvGWftDE7ozRKPriT6vAo3xsc/0/*)#m7puekcx")
+        XCTAssertEqual(descriptor.description, "tr([be1eec8f/86'/1'/0']tpubDCTtszwSxPx3tATqDrsSyqScPNnUChwQAVAkanuDUCJQESGBbkt68nXXKRDifYSDbeMa2Xg2euKbXaU3YphvGWftDE7ozRKPriT6vAo3xsc/0/*)#m7puekcx")
     }
 }


### PR DESCRIPTION
<!-- Erase any parts of this template not applicable to your Pull Request. -->

### Description

Adds more to #551 , I was working on BDK iOS and just saw that I was using `Descriptor.asString()` so I wanted to make that nicer by using the display trait on `Mnemonic` instead now after seeing #551 .

This also removes the `asString()` method which is nice.


### Notes to the reviewers

We still have the `as_string_private()`, I couldnt think of an immediately good way to change that, let me know if you know of one or I'll keep thinking on it to see if something strikes me; but I dont see any reason for that to hold this up even though the pairing of to_string and as_string_private might be a little awkward, we are already walking the path of using this new to_string from the Display trait so we should keep using it on types like this because its really nice.

Let me know any thoughts on that though-

### Changelog notice

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
