### PR TITLE
Bump minimum supported Android version to 24

### DIFF
--- a/bdk-android/lib/build.gradle.kts
+++ b/bdk-android/lib/build.gradle.kts
@@ -18,7 +18,7 @@ android {
     compileSdk = 34
 
     defaultConfig {
-        minSdk = 21
+        minSdk = 24
         targetSdk = 34
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")

--- a/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/LiveTxBuilderTest.kt
+++ b/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/LiveTxBuilderTest.kt
@@ -62,7 +62,7 @@ class LiveTxBuilderTest {
         println("Balance: ${wallet.getBalance().total.toSat()}")
 
         assert(wallet.getBalance().total.toSat() > 0uL) {
-            "Wallet balance must be greater than 0! Please send funds to ${wallet.revealNextAddress(KeychainKind.EXTERNAL).address.asString()} and try again."
+            "Wallet balance must be greater than 0! Please send funds to ${wallet.revealNextAddress(KeychainKind.EXTERNAL).address} and try again."
         }
 
         val recipient1: Address = Address("tb1qrnfslnrve9uncz9pzpvf83k3ukz22ljgees989", Network.SIGNET)

--- a/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/LiveWalletTest.kt
+++ b/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/LiveWalletTest.kt
@@ -38,7 +38,7 @@ class LiveWalletTest {
         println("Balance: $balance")
 
         assert(wallet.getBalance().total.toSat() > 0uL) {
-            "Wallet balance must be greater than 0! Please send funds to ${wallet.revealNextAddress(KeychainKind.EXTERNAL).address.asString()} and try again."
+            "Wallet balance must be greater than 0! Please send funds to ${wallet.revealNextAddress(KeychainKind.EXTERNAL).address} and try again."
         }
 
         println("Transactions count: ${wallet.transactions().count()}")

--- a/bdk-android/plugins/src/main/kotlin/org/bitcoindevkit/plugins/UniFfiAndroidPlugin.kt
+++ b/bdk-android/plugins/src/main/kotlin/org/bitcoindevkit/plugins/UniFfiAndroidPlugin.kt
@@ -34,10 +34,10 @@ internal class UniFfiAndroidPlugin : Plugin<Project> {
             environment(
                 // add build toolchain to PATH
                 Pair("PATH", "${System.getenv("PATH")}:${System.getenv("ANDROID_NDK_ROOT")}/toolchains/llvm/prebuilt/$llvmArchPath/bin"),
-                Pair("CFLAGS", "-D__ANDROID_MIN_SDK_VERSION__=21"),
+                Pair("CFLAGS", "-D__ANDROID_MIN_SDK_VERSION__=24"),
                 Pair("AR", "llvm-ar"),
-                Pair("CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER", "aarch64-linux-android21-clang"),
-                Pair("CC", "aarch64-linux-android21-clang")
+                Pair("CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER", "aarch64-linux-android24-clang"),
+                Pair("CC", "aarch64-linux-android24-clang")
             )
 
             doLast {
@@ -57,10 +57,10 @@ internal class UniFfiAndroidPlugin : Plugin<Project> {
             environment(
                 // add build toolchain to PATH
                 Pair("PATH", "${System.getenv("PATH")}:${System.getenv("ANDROID_NDK_ROOT")}/toolchains/llvm/prebuilt/$llvmArchPath/bin"),
-                Pair("CFLAGS", "-D__ANDROID_MIN_SDK_VERSION__=21"),
+                Pair("CFLAGS", "-D__ANDROID_MIN_SDK_VERSION__=24"),
                 Pair("AR", "llvm-ar"),
-                Pair("CARGO_TARGET_X86_64_LINUX_ANDROID_LINKER", "x86_64-linux-android21-clang"),
-                Pair("CC", "x86_64-linux-android21-clang")
+                Pair("CARGO_TARGET_X86_64_LINUX_ANDROID_LINKER", "x86_64-linux-android24-clang"),
+                Pair("CC", "x86_64-linux-android24-clang")
             )
 
             doLast {
@@ -80,10 +80,10 @@ internal class UniFfiAndroidPlugin : Plugin<Project> {
             environment(
                 // add build toolchain to PATH
                 Pair("PATH", "${System.getenv("PATH")}:${System.getenv("ANDROID_NDK_ROOT")}/toolchains/llvm/prebuilt/$llvmArchPath/bin"),
-                Pair("CFLAGS", "-D__ANDROID_MIN_SDK_VERSION__=21"),
+                Pair("CFLAGS", "-D__ANDROID_MIN_SDK_VERSION__=24"),
                 Pair("AR", "llvm-ar"),
-                Pair("CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_LINKER", "armv7a-linux-androideabi21-clang"),
-                Pair("CC", "armv7a-linux-androideabi21-clang")
+                Pair("CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_LINKER", "armv7a-linux-androideabi24-clang"),
+                Pair("CC", "armv7a-linux-androideabi24-clang")
             )
 
             doLast {


### PR DESCRIPTION
This PR bumps our minimum supported Android version to 24. The lowest version I was able to find a user of bdk supporting was 24 (a very conservative choice, see [here](https://apilevels.com/). 21 at this point was a bit ludicrous, and will probably not be available in future NDKs, which we will have to update at some point for CI and just overall health of the Android libs. I think this gets ahead of those issues while being extremely conservative (API level 24 came out in 2016).

I have tested this locally on emulators and in the example application.

Fixes #500.

_Note: I'm sorry this PR actually contains a second commit which fixes the live tests (I noticed the failure and fixed it without realizing it was on this branch). But now it's here I'm just going to leave it here anyway. It's a good fix that was missed as part of the Display trait PRs because it's part of the live tests that don't get run on all normal PR CI runs._