### PR TITLE
Expose `add_global_xpubs()` method on transaction builder

### DIFF
--- a/bdk-ffi/src/bdk.udl
+++ b/bdk-ffi/src/bdk.udl
@@ -435,6 +435,8 @@ interface Update {};
 interface TxBuilder {
   constructor();
 
+  TxBuilder add_global_xpubs();
+
   TxBuilder add_recipient([ByRef] Script script, Amount amount);
 
   TxBuilder set_recipients(sequence<ScriptAmount> recipients);


### PR DESCRIPTION
This PR exposes the `add_global_xpubs()` method on the `TxBuilder`. See the [docs here](https://docs.rs/bdk_wallet/1.0.0-beta.1/bdk_wallet/struct.TxBuilder.html#method.add_global_xpubs).

Fixes #572

### Changelog notice

```md
Added
  - Add `add_global_xpubs()` method on `TxBuilder` [#574]

[#574]: https://github.com/bitcoindevkit/bdk-ffi/pull/574
```

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature
