### PR TITLE
Expose derivation_index method on wallet type

### DIFF
--- a/bdk-ffi/src/bdk.udl
+++ b/bdk-ffi/src/bdk.udl
@@ -391,6 +391,8 @@ interface Wallet {
   [Name=load, Throws=LoadWithPersistError]
   constructor(Descriptor descriptor, Descriptor change_descriptor, Connection connection);
 
+  u32? derivation_index(KeychainKind keychain);
+
   AddressInfo reveal_next_address(KeychainKind keychain);
 
   Network network();

--- a/bdk-ffi/src/wallet.rs
+++ b/bdk-ffi/src/wallet.rs
@@ -85,6 +85,10 @@ impl Wallet {
             .map_err(CannotConnectError::from)
     }
 
+    pub(crate) fn derivation_index(&self, keychain: KeychainKind) -> Option<u32> {
+        self.get_wallet().derivation_index(keychain)
+    }
+
     pub fn network(&self) -> Network {
         self.get_wallet().network()
     }


### PR DESCRIPTION
Title says it all.

[The method](https://docs.rs/bdk_wallet/1.0.0-beta.1/bdk_wallet/struct.Wallet.html) allows you to get the highest derivation index used for a given keychain.

### Changelog notice

```md
Added
    - Add `wallet.derivation_index` method on Wallet type [#579]

[#579]: https://github.com/bitcoindevkit/bdk-ffi/pull/579
```

### Checklists

#### All Submissions:

* [ ] I've signed all my commits
* [ ] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [ ] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
