### PR TITLE
chore: small fixes for swift packaging

### DIFF
--- a/bdk-swift/build-xcframework.sh
+++ b/bdk-swift/build-xcframework.sh
@@ -50,6 +50,7 @@ mv "${HEADERPATH_BITCOIN_FFI}" "${NEW_HEADER_DIR}"
 mv "${MODMAPPATH}" "${NEW_HEADER_DIR}/module.modulemap"
 echo -e "\n" >> "${NEW_HEADER_DIR}/module.modulemap"
 cat "${MODMAPPATH_BITCOIN_FFI}" >> "${NEW_HEADER_DIR}/module.modulemap"
+rm "${MODMAPPATH_BITCOIN_FFI}"
 
 # remove old xcframework directory
 rm -rf "${OUTDIR}/${NAME}.xcframework"


### PR DESCRIPTION
### Description

Remove unneeded `BitcoinFFI.modulemap` from "Sources/BitcoinDevKit" folder. 

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

