### PR TITLE
Small refactors

### DIFF
--- a/bdk-ffi/Cargo.lock
+++ b/bdk-ffi/Cargo.lock
@@ -140,7 +140,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c8d66485a3a2ea485c1913c4572ce0256067a5377ac8c75c4960e1cda98605f"
 dependencies = [
- "bitcoin-internals 0.3.0",
+ "bitcoin-internals",
  "bitcoin_hashes 0.14.0",
 ]
 
@@ -182,7 +182,6 @@ dependencies = [
  "bdk_esplora",
  "bdk_wallet",
  "bitcoin-ffi",
- "bitcoin-internals 0.2.0",
  "thiserror",
  "uniffi",
 ]
@@ -294,7 +293,7 @@ dependencies = [
  "base58ck",
  "base64 0.21.7",
  "bech32",
- "bitcoin-internals 0.3.0",
+ "bitcoin-internals",
  "bitcoin-io",
  "bitcoin-units",
  "bitcoin_hashes 0.14.0",
@@ -313,12 +312,6 @@ dependencies = [
  "thiserror",
  "uniffi",
 ]
-
-[[package]]
-name = "bitcoin-internals"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9425c3bf7089c983facbae04de54513cce73b41c7f9ff8c845b54e7bc64ebbfb"
 
 [[package]]
 name = "bitcoin-internals"
@@ -341,7 +334,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb54da0b28892f3c52203a7191534033e051b6f4b52bc15480681b57b7e036f5"
 dependencies = [
- "bitcoin-internals 0.3.0",
+ "bitcoin-internals",
  "serde",
 ]
 

--- a/bdk-ffi/Cargo.toml
+++ b/bdk-ffi/Cargo.toml
@@ -23,7 +23,6 @@ bdk_core = { version = "0.2.0" }
 bdk_esplora = { version = "0.18.0", default-features = false, features = ["std", "blocking", "blocking-https-rustls"] }
 bdk_electrum = { version = "0.18.0", default-features = false, features = ["use-rustls-ring"] }
 bdk_bitcoind_rpc = { version = "0.15.0" }
-bitcoin-internals = { version = "0.2.0", features = ["alloc"] }
 bitcoin-ffi = { git = "https://github.com/bitcoindevkit/bitcoin-ffi", tag = "v0.1.2" }
 
 uniffi = { version = "=0.28.0" }

--- a/bdk-ffi/src/error.rs
+++ b/bdk-ffi/src/error.rs
@@ -22,7 +22,7 @@ use bdk_wallet::signer::SignerError as BdkSignerError;
 use bdk_wallet::tx_builder::AddUtxoError;
 use bdk_wallet::LoadWithPersistError as BdkLoadWithPersistError;
 use bdk_wallet::{chain, CreateWithPersistError as BdkCreateWithPersistError};
-use bitcoin_internals::hex::display::DisplayHex;
+use bdk_wallet::bitcoin::hex::DisplayHex;
 
 use std::convert::TryInto;
 

--- a/bdk-ffi/src/error.rs
+++ b/bdk-ffi/src/error.rs
@@ -7,6 +7,7 @@ use bdk_wallet::bitcoin::address::FromScriptError as BdkFromScriptError;
 use bdk_wallet::bitcoin::address::ParseError as BdkParseError;
 use bdk_wallet::bitcoin::bip32::Error as BdkBip32Error;
 use bdk_wallet::bitcoin::consensus::encode::Error as BdkEncodeError;
+use bdk_wallet::bitcoin::hex::DisplayHex;
 use bdk_wallet::bitcoin::psbt::Error as BdkPsbtError;
 use bdk_wallet::bitcoin::psbt::ExtractTxError as BdkExtractTxError;
 use bdk_wallet::bitcoin::psbt::PsbtParseError as BdkPsbtParseError;
@@ -22,7 +23,6 @@ use bdk_wallet::signer::SignerError as BdkSignerError;
 use bdk_wallet::tx_builder::AddUtxoError;
 use bdk_wallet::LoadWithPersistError as BdkLoadWithPersistError;
 use bdk_wallet::{chain, CreateWithPersistError as BdkCreateWithPersistError};
-use bdk_wallet::bitcoin::hex::DisplayHex;
 
 use std::convert::TryInto;
 

--- a/bdk-ffi/src/lib.rs
+++ b/bdk-ffi/src/lib.rs
@@ -5,6 +5,7 @@ mod error;
 mod esplora;
 mod keys;
 mod store;
+mod tx_builder;
 mod types;
 mod wallet;
 
@@ -43,6 +44,8 @@ use crate::keys::DescriptorPublicKey;
 use crate::keys::DescriptorSecretKey;
 use crate::keys::Mnemonic;
 use crate::store::Connection;
+use crate::tx_builder::BumpFeeTxBuilder;
+use crate::tx_builder::TxBuilder;
 use crate::types::AddressInfo;
 use crate::types::Balance;
 use crate::types::BlockId;
@@ -58,9 +61,7 @@ use crate::types::SyncRequest;
 use crate::types::SyncRequestBuilder;
 use crate::types::SyncScriptInspector;
 use crate::types::Update;
-use crate::wallet::BumpFeeTxBuilder;
 use crate::wallet::SentAndReceivedValues;
-use crate::wallet::TxBuilder;
 use crate::wallet::Wallet;
 
 use bitcoin_ffi::Amount;

--- a/bdk-ffi/src/lib.rs
+++ b/bdk-ffi/src/lib.rs
@@ -57,11 +57,11 @@ use crate::types::FullScanRequestBuilder;
 use crate::types::FullScanScriptInspector;
 use crate::types::LocalOutput;
 use crate::types::ScriptAmount;
+use crate::types::SentAndReceivedValues;
 use crate::types::SyncRequest;
 use crate::types::SyncRequestBuilder;
 use crate::types::SyncScriptInspector;
 use crate::types::Update;
-use crate::wallet::SentAndReceivedValues;
 use crate::wallet::Wallet;
 
 use bitcoin_ffi::Amount;

--- a/bdk-ffi/src/tx_builder.rs
+++ b/bdk-ffi/src/tx_builder.rs
@@ -1,0 +1,282 @@
+use crate::bitcoin::Psbt;
+use crate::error::CreateTxError;
+use crate::types::ScriptAmount;
+use crate::wallet::{RbfValue, Wallet};
+
+use bitcoin_ffi::{Amount, FeeRate, Script};
+
+use bdk_bitcoind_rpc::bitcoincore_rpc::bitcoin::{OutPoint, Sequence, Txid};
+use bdk_wallet::bitcoin::amount::Amount as BdkAmount;
+use bdk_wallet::bitcoin::Psbt as BdkPsbt;
+use bdk_wallet::bitcoin::ScriptBuf as BdkScriptBuf;
+use bdk_wallet::ChangeSpendPolicy;
+
+use std::collections::HashSet;
+use std::str::FromStr;
+use std::sync::Arc;
+
+#[derive(Clone)]
+pub struct TxBuilder {
+    pub(crate) add_global_xpubs: bool,
+    pub(crate) recipients: Vec<(BdkScriptBuf, BdkAmount)>,
+    pub(crate) utxos: Vec<OutPoint>,
+    pub(crate) unspendable: HashSet<OutPoint>,
+    pub(crate) change_policy: ChangeSpendPolicy,
+    pub(crate) manually_selected_only: bool,
+    pub(crate) fee_rate: Option<FeeRate>,
+    pub(crate) fee_absolute: Option<Arc<Amount>>,
+    pub(crate) drain_wallet: bool,
+    pub(crate) drain_to: Option<BdkScriptBuf>,
+    pub(crate) rbf: Option<RbfValue>,
+    // pub(crate) data: Vec<u8>,
+}
+
+impl TxBuilder {
+    pub(crate) fn new() -> Self {
+        TxBuilder {
+            add_global_xpubs: false,
+            recipients: Vec::new(),
+            utxos: Vec::new(),
+            unspendable: HashSet::new(),
+            change_policy: ChangeSpendPolicy::ChangeAllowed,
+            manually_selected_only: false,
+            fee_rate: None,
+            fee_absolute: None,
+            drain_wallet: false,
+            drain_to: None,
+            rbf: None,
+            // data: Vec::new(),
+        }
+    }
+
+    pub(crate) fn add_global_xpubs(&self) -> Arc<Self> {
+        Arc::new(TxBuilder {
+            add_global_xpubs: true,
+            ..self.clone()
+        })
+    }
+
+    pub(crate) fn add_recipient(&self, script: &Script, amount: Arc<Amount>) -> Arc<Self> {
+        let mut recipients: Vec<(BdkScriptBuf, BdkAmount)> = self.recipients.clone();
+        recipients.append(&mut vec![(script.0.clone(), amount.0)]);
+
+        Arc::new(TxBuilder {
+            recipients,
+            ..self.clone()
+        })
+    }
+
+    pub(crate) fn set_recipients(&self, recipients: Vec<ScriptAmount>) -> Arc<Self> {
+        let recipients = recipients
+            .iter()
+            .map(|script_amount| (script_amount.script.0.clone(), script_amount.amount.0)) //;
+            .collect();
+        Arc::new(TxBuilder {
+            recipients,
+            ..self.clone()
+        })
+    }
+
+    pub(crate) fn add_unspendable(&self, unspendable: OutPoint) -> Arc<Self> {
+        let mut unspendable_hash_set = self.unspendable.clone();
+        unspendable_hash_set.insert(unspendable);
+        Arc::new(TxBuilder {
+            unspendable: unspendable_hash_set,
+            ..self.clone()
+        })
+    }
+
+    pub(crate) fn unspendable(&self, unspendable: Vec<OutPoint>) -> Arc<Self> {
+        Arc::new(TxBuilder {
+            unspendable: unspendable.into_iter().collect(),
+            ..self.clone()
+        })
+    }
+
+    pub(crate) fn add_utxo(&self, outpoint: OutPoint) -> Arc<Self> {
+        self.add_utxos(vec![outpoint])
+    }
+
+    pub(crate) fn add_utxos(&self, mut outpoints: Vec<OutPoint>) -> Arc<Self> {
+        let mut utxos = self.utxos.to_vec();
+        utxos.append(&mut outpoints);
+        Arc::new(TxBuilder {
+            utxos,
+            ..self.clone()
+        })
+    }
+
+    pub(crate) fn change_policy(&self, change_policy: ChangeSpendPolicy) -> Arc<Self> {
+        Arc::new(TxBuilder {
+            change_policy,
+            ..self.clone()
+        })
+    }
+
+    pub(crate) fn do_not_spend_change(&self) -> Arc<Self> {
+        Arc::new(TxBuilder {
+            change_policy: ChangeSpendPolicy::ChangeForbidden,
+            ..self.clone()
+        })
+    }
+
+    pub(crate) fn only_spend_change(&self) -> Arc<Self> {
+        Arc::new(TxBuilder {
+            change_policy: ChangeSpendPolicy::OnlyChange,
+            ..self.clone()
+        })
+    }
+
+    pub(crate) fn manually_selected_only(&self) -> Arc<Self> {
+        Arc::new(TxBuilder {
+            manually_selected_only: true,
+            ..self.clone()
+        })
+    }
+
+    pub(crate) fn fee_rate(&self, fee_rate: &FeeRate) -> Arc<Self> {
+        Arc::new(TxBuilder {
+            fee_rate: Some(fee_rate.clone()),
+            ..self.clone()
+        })
+    }
+
+    pub(crate) fn fee_absolute(&self, fee_amount: Arc<Amount>) -> Arc<Self> {
+        Arc::new(TxBuilder {
+            fee_absolute: Some(fee_amount),
+            ..self.clone()
+        })
+    }
+
+    pub(crate) fn drain_wallet(&self) -> Arc<Self> {
+        Arc::new(TxBuilder {
+            drain_wallet: true,
+            ..self.clone()
+        })
+    }
+
+    pub(crate) fn drain_to(&self, script: &Script) -> Arc<Self> {
+        Arc::new(TxBuilder {
+            drain_to: Some(script.0.clone()),
+            ..self.clone()
+        })
+    }
+
+    pub(crate) fn enable_rbf(&self) -> Arc<Self> {
+        Arc::new(TxBuilder {
+            rbf: Some(RbfValue::Default),
+            ..self.clone()
+        })
+    }
+
+    pub(crate) fn enable_rbf_with_sequence(&self, nsequence: u32) -> Arc<Self> {
+        Arc::new(TxBuilder {
+            rbf: Some(RbfValue::Value(nsequence)),
+            ..self.clone()
+        })
+    }
+
+    pub(crate) fn finish(&self, wallet: &Arc<Wallet>) -> Result<Arc<Psbt>, CreateTxError> {
+        // TODO: I had to change the wallet here to be mutable. Why is that now required with the 1.0 API?
+        let mut wallet = wallet.get_wallet();
+        let mut tx_builder = wallet.build_tx();
+        if self.add_global_xpubs {
+            tx_builder.add_global_xpubs();
+        }
+        for (script, amount) in &self.recipients {
+            tx_builder.add_recipient(script.clone(), *amount);
+        }
+        tx_builder.change_policy(self.change_policy);
+        if !self.utxos.is_empty() {
+            tx_builder
+                .add_utxos(&self.utxos)
+                .map_err(CreateTxError::from)?;
+        }
+        if !self.unspendable.is_empty() {
+            let bdk_unspendable: Vec<OutPoint> = self.unspendable.clone().into_iter().collect();
+            tx_builder.unspendable(bdk_unspendable);
+        }
+        if self.manually_selected_only {
+            tx_builder.manually_selected_only();
+        }
+        if let Some(fee_rate) = &self.fee_rate {
+            tx_builder.fee_rate(fee_rate.0);
+        }
+        if let Some(fee_amount) = &self.fee_absolute {
+            tx_builder.fee_absolute(fee_amount.0);
+        }
+        if self.drain_wallet {
+            tx_builder.drain_wallet();
+        }
+        if let Some(script) = &self.drain_to {
+            tx_builder.drain_to(script.clone());
+        }
+        if let Some(rbf) = &self.rbf {
+            match *rbf {
+                RbfValue::Default => {
+                    tx_builder.enable_rbf();
+                }
+                RbfValue::Value(nsequence) => {
+                    tx_builder.enable_rbf_with_sequence(Sequence(nsequence));
+                }
+            }
+        }
+
+        let psbt = tx_builder.finish().map_err(CreateTxError::from)?;
+
+        Ok(Arc::new(psbt.into()))
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct BumpFeeTxBuilder {
+    pub(crate) txid: String,
+    pub(crate) fee_rate: Arc<FeeRate>,
+    pub(crate) rbf: Option<RbfValue>,
+}
+
+impl BumpFeeTxBuilder {
+    pub(crate) fn new(txid: String, fee_rate: Arc<FeeRate>) -> Self {
+        Self {
+            txid,
+            fee_rate,
+            rbf: None,
+        }
+    }
+
+    pub(crate) fn enable_rbf(&self) -> Arc<Self> {
+        Arc::new(Self {
+            rbf: Some(RbfValue::Default),
+            ..self.clone()
+        })
+    }
+
+    pub(crate) fn enable_rbf_with_sequence(&self, nsequence: u32) -> Arc<Self> {
+        Arc::new(Self {
+            rbf: Some(RbfValue::Value(nsequence)),
+            ..self.clone()
+        })
+    }
+
+    pub(crate) fn finish(&self, wallet: &Arc<Wallet>) -> Result<Arc<Psbt>, CreateTxError> {
+        let txid = Txid::from_str(self.txid.as_str()).map_err(|_| CreateTxError::UnknownUtxo {
+            outpoint: self.txid.clone(),
+        })?;
+        let mut wallet = wallet.get_wallet();
+        let mut tx_builder = wallet.build_fee_bump(txid).map_err(CreateTxError::from)?;
+        tx_builder.fee_rate(self.fee_rate.0);
+        if let Some(rbf) = &self.rbf {
+            match *rbf {
+                RbfValue::Default => {
+                    tx_builder.enable_rbf();
+                }
+                RbfValue::Value(nsequence) => {
+                    tx_builder.enable_rbf_with_sequence(Sequence(nsequence));
+                }
+            }
+        }
+        let psbt: BdkPsbt = tx_builder.finish()?;
+
+        Ok(Arc::new(psbt.into()))
+    }
+}

--- a/bdk-ffi/src/tx_builder.rs
+++ b/bdk-ffi/src/tx_builder.rs
@@ -1,7 +1,7 @@
 use crate::bitcoin::Psbt;
 use crate::error::CreateTxError;
-use crate::types::ScriptAmount;
-use crate::wallet::{RbfValue, Wallet};
+use crate::types::{RbfValue, ScriptAmount};
+use crate::wallet::Wallet;
 
 use bitcoin_ffi::{Amount, FeeRate, Script};
 

--- a/bdk-ffi/src/types.rs
+++ b/bdk-ffi/src/types.rs
@@ -227,3 +227,14 @@ impl FullScanRequestBuilder {
 }
 
 pub struct Update(pub(crate) BdkUpdate);
+
+pub struct SentAndReceivedValues {
+    pub sent: Arc<Amount>,
+    pub received: Arc<Amount>,
+}
+
+#[derive(Clone, Debug)]
+pub enum RbfValue {
+    Default,
+    Value(u32),
+}

--- a/bdk-ffi/src/wallet.rs
+++ b/bdk-ffi/src/wallet.rs
@@ -5,19 +5,16 @@ use crate::error::{
     SignerError, SqliteError, TxidParseError,
 };
 use crate::store::Connection;
-use crate::types::{AddressInfo, Balance, CanonicalTx, LocalOutput};
-use crate::types::{FullScanRequestBuilder, SyncRequestBuilder, Update};
+use crate::types::{
+    AddressInfo, Balance, CanonicalTx, FullScanRequestBuilder, LocalOutput, SentAndReceivedValues,
+    SyncRequestBuilder, Update,
+};
 
-use bitcoin_ffi::Amount;
-use bitcoin_ffi::FeeRate;
-use bitcoin_ffi::Script;
+use bitcoin_ffi::{Amount, FeeRate, Script};
 
-use bdk_wallet::bitcoin::Network;
-use bdk_wallet::bitcoin::Txid;
+use bdk_wallet::bitcoin::{Network, Txid};
 use bdk_wallet::rusqlite::Connection as BdkConnection;
-use bdk_wallet::PersistedWallet;
-use bdk_wallet::Wallet as BdkWallet;
-use bdk_wallet::{KeychainKind, SignOptions};
+use bdk_wallet::{KeychainKind, PersistedWallet, SignOptions, Wallet as BdkWallet};
 
 use std::borrow::BorrowMut;
 use std::str::FromStr;
@@ -177,15 +174,4 @@ impl Wallet {
                 rusqlite_error: e.to_string(),
             })
     }
-}
-
-pub struct SentAndReceivedValues {
-    pub sent: Arc<Amount>,
-    pub received: Arc<Amount>,
-}
-
-#[derive(Clone, Debug)]
-pub enum RbfValue {
-    Default,
-    Value(u32),
 }

--- a/bdk-ffi/src/wallet.rs
+++ b/bdk-ffi/src/wallet.rs
@@ -1,31 +1,25 @@
 use crate::bitcoin::{Psbt, Transaction};
 use crate::descriptor::Descriptor;
 use crate::error::{
-    CalculateFeeError, CannotConnectError, CreateTxError, CreateWithPersistError,
-    LoadWithPersistError, SignerError, SqliteError, TxidParseError,
+    CalculateFeeError, CannotConnectError, CreateWithPersistError, LoadWithPersistError,
+    SignerError, SqliteError, TxidParseError,
 };
 use crate::store::Connection;
-use crate::types::{AddressInfo, Balance, CanonicalTx, LocalOutput, ScriptAmount};
+use crate::types::{AddressInfo, Balance, CanonicalTx, LocalOutput};
 use crate::types::{FullScanRequestBuilder, SyncRequestBuilder, Update};
 
 use bitcoin_ffi::Amount;
 use bitcoin_ffi::FeeRate;
-use bitcoin_ffi::OutPoint;
 use bitcoin_ffi::Script;
 
-use bdk_wallet::bitcoin::amount::Amount as BdkAmount;
 use bdk_wallet::bitcoin::Network;
-use bdk_wallet::bitcoin::Psbt as BdkPsbt;
-use bdk_wallet::bitcoin::ScriptBuf as BdkScriptBuf;
-use bdk_wallet::bitcoin::{Sequence, Txid};
+use bdk_wallet::bitcoin::Txid;
 use bdk_wallet::rusqlite::Connection as BdkConnection;
-use bdk_wallet::tx_builder::ChangeSpendPolicy;
 use bdk_wallet::PersistedWallet;
 use bdk_wallet::Wallet as BdkWallet;
 use bdk_wallet::{KeychainKind, SignOptions};
 
 use std::borrow::BorrowMut;
-use std::collections::HashSet;
 use std::str::FromStr;
 use std::sync::{Arc, Mutex, MutexGuard};
 
@@ -190,271 +184,6 @@ pub struct SentAndReceivedValues {
     pub received: Arc<Amount>,
 }
 
-#[derive(Clone)]
-pub struct TxBuilder {
-    pub(crate) add_global_xpubs: bool,
-    pub(crate) recipients: Vec<(BdkScriptBuf, BdkAmount)>,
-    pub(crate) utxos: Vec<OutPoint>,
-    pub(crate) unspendable: HashSet<OutPoint>,
-    pub(crate) change_policy: ChangeSpendPolicy,
-    pub(crate) manually_selected_only: bool,
-    pub(crate) fee_rate: Option<FeeRate>,
-    pub(crate) fee_absolute: Option<Arc<Amount>>,
-    pub(crate) drain_wallet: bool,
-    pub(crate) drain_to: Option<BdkScriptBuf>,
-    pub(crate) rbf: Option<RbfValue>,
-    // pub(crate) data: Vec<u8>,
-}
-
-impl TxBuilder {
-    pub(crate) fn new() -> Self {
-        TxBuilder {
-            add_global_xpubs: false,
-            recipients: Vec::new(),
-            utxos: Vec::new(),
-            unspendable: HashSet::new(),
-            change_policy: ChangeSpendPolicy::ChangeAllowed,
-            manually_selected_only: false,
-            fee_rate: None,
-            fee_absolute: None,
-            drain_wallet: false,
-            drain_to: None,
-            rbf: None,
-            // data: Vec::new(),
-        }
-    }
-
-    pub(crate) fn add_global_xpubs(&self) -> Arc<Self> {
-        Arc::new(TxBuilder {
-            add_global_xpubs: true,
-            ..self.clone()
-        })
-    }
-
-    pub(crate) fn add_recipient(&self, script: &Script, amount: Arc<Amount>) -> Arc<Self> {
-        let mut recipients: Vec<(BdkScriptBuf, BdkAmount)> = self.recipients.clone();
-        recipients.append(&mut vec![(script.0.clone(), amount.0)]);
-
-        Arc::new(TxBuilder {
-            recipients,
-            ..self.clone()
-        })
-    }
-
-    pub(crate) fn set_recipients(&self, recipients: Vec<ScriptAmount>) -> Arc<Self> {
-        let recipients = recipients
-            .iter()
-            .map(|script_amount| (script_amount.script.0.clone(), script_amount.amount.0)) //;
-            .collect();
-        Arc::new(TxBuilder {
-            recipients,
-            ..self.clone()
-        })
-    }
-
-    pub(crate) fn add_unspendable(&self, unspendable: OutPoint) -> Arc<Self> {
-        let mut unspendable_hash_set = self.unspendable.clone();
-        unspendable_hash_set.insert(unspendable);
-        Arc::new(TxBuilder {
-            unspendable: unspendable_hash_set,
-            ..self.clone()
-        })
-    }
-
-    pub(crate) fn unspendable(&self, unspendable: Vec<OutPoint>) -> Arc<Self> {
-        Arc::new(TxBuilder {
-            unspendable: unspendable.into_iter().collect(),
-            ..self.clone()
-        })
-    }
-
-    pub(crate) fn add_utxo(&self, outpoint: OutPoint) -> Arc<Self> {
-        self.add_utxos(vec![outpoint])
-    }
-
-    pub(crate) fn add_utxos(&self, mut outpoints: Vec<OutPoint>) -> Arc<Self> {
-        let mut utxos = self.utxos.to_vec();
-        utxos.append(&mut outpoints);
-        Arc::new(TxBuilder {
-            utxos,
-            ..self.clone()
-        })
-    }
-
-    pub(crate) fn change_policy(&self, change_policy: ChangeSpendPolicy) -> Arc<Self> {
-        Arc::new(TxBuilder {
-            change_policy,
-            ..self.clone()
-        })
-    }
-
-    pub(crate) fn do_not_spend_change(&self) -> Arc<Self> {
-        Arc::new(TxBuilder {
-            change_policy: ChangeSpendPolicy::ChangeForbidden,
-            ..self.clone()
-        })
-    }
-
-    pub(crate) fn only_spend_change(&self) -> Arc<Self> {
-        Arc::new(TxBuilder {
-            change_policy: ChangeSpendPolicy::OnlyChange,
-            ..self.clone()
-        })
-    }
-
-    pub(crate) fn manually_selected_only(&self) -> Arc<Self> {
-        Arc::new(TxBuilder {
-            manually_selected_only: true,
-            ..self.clone()
-        })
-    }
-
-    pub(crate) fn fee_rate(&self, fee_rate: &FeeRate) -> Arc<Self> {
-        Arc::new(TxBuilder {
-            fee_rate: Some(fee_rate.clone()),
-            ..self.clone()
-        })
-    }
-
-    pub(crate) fn fee_absolute(&self, fee_amount: Arc<Amount>) -> Arc<Self> {
-        Arc::new(TxBuilder {
-            fee_absolute: Some(fee_amount),
-            ..self.clone()
-        })
-    }
-
-    pub(crate) fn drain_wallet(&self) -> Arc<Self> {
-        Arc::new(TxBuilder {
-            drain_wallet: true,
-            ..self.clone()
-        })
-    }
-
-    pub(crate) fn drain_to(&self, script: &Script) -> Arc<Self> {
-        Arc::new(TxBuilder {
-            drain_to: Some(script.0.clone()),
-            ..self.clone()
-        })
-    }
-
-    pub(crate) fn enable_rbf(&self) -> Arc<Self> {
-        Arc::new(TxBuilder {
-            rbf: Some(RbfValue::Default),
-            ..self.clone()
-        })
-    }
-
-    pub(crate) fn enable_rbf_with_sequence(&self, nsequence: u32) -> Arc<Self> {
-        Arc::new(TxBuilder {
-            rbf: Some(RbfValue::Value(nsequence)),
-            ..self.clone()
-        })
-    }
-
-    pub(crate) fn finish(&self, wallet: &Arc<Wallet>) -> Result<Arc<Psbt>, CreateTxError> {
-        // TODO: I had to change the wallet here to be mutable. Why is that now required with the 1.0 API?
-        let mut wallet = wallet.get_wallet();
-        let mut tx_builder = wallet.build_tx();
-        if self.add_global_xpubs {
-            tx_builder.add_global_xpubs();
-        }
-        for (script, amount) in &self.recipients {
-            tx_builder.add_recipient(script.clone(), *amount);
-        }
-        tx_builder.change_policy(self.change_policy);
-        if !self.utxos.is_empty() {
-            tx_builder
-                .add_utxos(&self.utxos)
-                .map_err(CreateTxError::from)?;
-        }
-        if !self.unspendable.is_empty() {
-            let bdk_unspendable: Vec<OutPoint> = self.unspendable.clone().into_iter().collect();
-            tx_builder.unspendable(bdk_unspendable);
-        }
-        if self.manually_selected_only {
-            tx_builder.manually_selected_only();
-        }
-        if let Some(fee_rate) = &self.fee_rate {
-            tx_builder.fee_rate(fee_rate.0);
-        }
-        if let Some(fee_amount) = &self.fee_absolute {
-            tx_builder.fee_absolute(fee_amount.0);
-        }
-        if self.drain_wallet {
-            tx_builder.drain_wallet();
-        }
-        if let Some(script) = &self.drain_to {
-            tx_builder.drain_to(script.clone());
-        }
-        if let Some(rbf) = &self.rbf {
-            match *rbf {
-                RbfValue::Default => {
-                    tx_builder.enable_rbf();
-                }
-                RbfValue::Value(nsequence) => {
-                    tx_builder.enable_rbf_with_sequence(Sequence(nsequence));
-                }
-            }
-        }
-
-        let psbt = tx_builder.finish().map_err(CreateTxError::from)?;
-
-        Ok(Arc::new(psbt.into()))
-    }
-}
-
-#[derive(Clone)]
-pub(crate) struct BumpFeeTxBuilder {
-    pub(crate) txid: String,
-    pub(crate) fee_rate: Arc<FeeRate>,
-    pub(crate) rbf: Option<RbfValue>,
-}
-
-impl BumpFeeTxBuilder {
-    pub(crate) fn new(txid: String, fee_rate: Arc<FeeRate>) -> Self {
-        Self {
-            txid,
-            fee_rate,
-            rbf: None,
-        }
-    }
-
-    pub(crate) fn enable_rbf(&self) -> Arc<Self> {
-        Arc::new(Self {
-            rbf: Some(RbfValue::Default),
-            ..self.clone()
-        })
-    }
-
-    pub(crate) fn enable_rbf_with_sequence(&self, nsequence: u32) -> Arc<Self> {
-        Arc::new(Self {
-            rbf: Some(RbfValue::Value(nsequence)),
-            ..self.clone()
-        })
-    }
-
-    pub(crate) fn finish(&self, wallet: &Arc<Wallet>) -> Result<Arc<Psbt>, CreateTxError> {
-        let txid = Txid::from_str(self.txid.as_str()).map_err(|_| CreateTxError::UnknownUtxo {
-            outpoint: self.txid.clone(),
-        })?;
-        let mut wallet = wallet.get_wallet();
-        let mut tx_builder = wallet.build_fee_bump(txid).map_err(CreateTxError::from)?;
-        tx_builder.fee_rate(self.fee_rate.0);
-        if let Some(rbf) = &self.rbf {
-            match *rbf {
-                RbfValue::Default => {
-                    tx_builder.enable_rbf();
-                }
-                RbfValue::Value(nsequence) => {
-                    tx_builder.enable_rbf_with_sequence(Sequence(nsequence));
-                }
-            }
-        }
-        let psbt: BdkPsbt = tx_builder.finish()?;
-
-        Ok(Arc::new(psbt.into()))
-    }
-}
 #[derive(Clone, Debug)]
 pub enum RbfValue {
     Default,


### PR DESCRIPTION
### Description

This PR:
1. Removes our dependency on bitcoin-internals (it was used for one method in the errors in order to convert an array of bytes to a hex string). The library is not recommended for usage outside of the rust-bitcoin org, and indeed it was the wrong dependency for the job. We can simply use the DisplayHex trait implemented in `bdk_wallet::bitcoin::hex::DisplayHex`.
2. Creates a tx_builder module to mirror the BDK side of things, and moves the TxBuilder types there.
3. Moves two smaller types that were forgotten in the wallet module to their correct `types` module.

### Notes to the reviewers
These are simply refactors and do not impact the public API.

### Changelog notice
No changelog notice.

Fixes #583.
