### PR TITLE
Expose get_tx in Blockchain

### DIFF
--- a/bdk-ffi/src/bdk.udl
+++ b/bdk-ffi/src/bdk.udl
@@ -178,6 +178,9 @@ interface Blockchain {
 
   [Throws=BdkError]
   string get_block_hash(u32 height);
+
+  [Throws=BdkError]
+  Transaction? get_tx(string txid);
 };
 
 callback interface Progress {

--- a/bdk-ffi/src/blockchain.rs
+++ b/bdk-ffi/src/blockchain.rs
@@ -1,19 +1,21 @@
 // use crate::BlockchainConfig;
 use crate::Network;
 use crate::{BdkError, Transaction};
+use bdk::bitcoin::Txid;
 use bdk::blockchain::any::{AnyBlockchain, AnyBlockchainConfig};
 use bdk::blockchain::rpc::Auth as BdkAuth;
 use bdk::blockchain::rpc::RpcSyncParams as BdkRpcSyncParams;
-use bdk::blockchain::Blockchain as BdkBlockchain;
 use bdk::blockchain::GetBlockHash;
 use bdk::blockchain::GetHeight;
 use bdk::blockchain::{
     electrum::ElectrumBlockchainConfig, esplora::EsploraBlockchainConfig,
     rpc::RpcConfig as BdkRpcConfig, ConfigurableBlockchain,
 };
+use bdk::blockchain::{Blockchain as BdkBlockchain, GetTx};
 use bdk::FeeRate;
 use std::convert::{From, TryFrom};
 use std::path::PathBuf;
+use std::str::FromStr;
 use std::sync::{Arc, Mutex, MutexGuard};
 
 pub(crate) struct Blockchain {
@@ -79,6 +81,12 @@ impl Blockchain {
         self.get_blockchain()
             .get_block_hash(u64::from(height))
             .map(|hash| hash.to_string())
+    }
+
+    pub(crate) fn get_tx(&self, txid: String) -> Result<Option<Arc<Transaction>>, BdkError> {
+        let txid = Txid::from_str(txid.as_str())?;
+        let tx_opt = self.get_blockchain().get_tx(&txid)?;
+        Ok(tx_opt.map(|inner| Arc::new(Transaction { inner })))
     }
 }
 


### PR DESCRIPTION
### Description

We'd like to be able to query the Blockchain for transaction information with a txid. This lets us look up ancestor transactions from a TxIn.

### Notes to the reviewers

Not sure if this is the right base branch to upstream to. Let me know! We'd love to get a release cut for this as soon as conveniently possible!

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [x] Query blockchain for transaction by txid.