### PR TITLE
Add missing Wallet APIs related to revealing and querying the wallet for addresses and indices

### DIFF
--- a/bdk-ffi/src/bdk.udl
+++ b/bdk-ffi/src/bdk.udl
@@ -384,6 +384,8 @@ interface Wallet {
 
   u32 next_derivation_index(KeychainKind keychain);
 
+  AddressInfo next_unused_address(KeychainKind keychain);
+
   Network network();
 
   Balance balance();

--- a/bdk-ffi/src/bdk.udl
+++ b/bdk-ffi/src/bdk.udl
@@ -386,6 +386,8 @@ interface Wallet {
 
   AddressInfo next_unused_address(KeychainKind keychain);
 
+  boolean mark_used(KeychainKind keychain, u32 index);
+
   Network network();
 
   Balance balance();

--- a/bdk-ffi/src/bdk.udl
+++ b/bdk-ffi/src/bdk.udl
@@ -380,6 +380,8 @@ interface Wallet {
 
   AddressInfo reveal_next_address(KeychainKind keychain);
 
+  AddressInfo peek_address(KeychainKind keychain, u32 index);
+
   Network network();
 
   Balance balance();

--- a/bdk-ffi/src/bdk.udl
+++ b/bdk-ffi/src/bdk.udl
@@ -388,6 +388,8 @@ interface Wallet {
 
   boolean mark_used(KeychainKind keychain, u32 index);
 
+  sequence<AddressInfo> reveal_addresses_to(KeychainKind keychain, u32 index);
+
   Network network();
 
   Balance balance();

--- a/bdk-ffi/src/bdk.udl
+++ b/bdk-ffi/src/bdk.udl
@@ -382,6 +382,8 @@ interface Wallet {
 
   AddressInfo peek_address(KeychainKind keychain, u32 index);
 
+  u32 next_derivation_index(KeychainKind keychain);
+
   Network network();
 
   Balance balance();

--- a/bdk-ffi/src/bdk.udl
+++ b/bdk-ffi/src/bdk.udl
@@ -390,6 +390,8 @@ interface Wallet {
 
   sequence<AddressInfo> reveal_addresses_to(KeychainKind keychain, u32 index);
 
+  sequence<AddressInfo> list_unused_addresses(KeychainKind keychain);
+
   Network network();
 
   Balance balance();

--- a/bdk-ffi/src/wallet.rs
+++ b/bdk-ffi/src/wallet.rs
@@ -72,8 +72,8 @@ impl Wallet {
         self.inner_mutex.lock().expect("wallet")
     }
 
-    pub fn reveal_next_address(&self, keychain_kind: KeychainKind) -> AddressInfo {
-        self.get_wallet().reveal_next_address(keychain_kind).into()
+    pub fn reveal_next_address(&self, keychain: KeychainKind) -> AddressInfo {
+        self.get_wallet().reveal_next_address(keychain).into()
     }
 
     pub fn peek_address(&self, keychain: KeychainKind, index: u32) -> AddressInfo {

--- a/bdk-ffi/src/wallet.rs
+++ b/bdk-ffi/src/wallet.rs
@@ -88,6 +88,10 @@ impl Wallet {
         self.get_wallet().next_unused_address(keychain).into()
     }
 
+    pub fn mark_used(&self, keychain: KeychainKind, index: u32) -> bool {
+        self.get_wallet().mark_used(keychain, index)
+    }
+
     pub fn apply_update(&self, update: Arc<Update>) -> Result<(), CannotConnectError> {
         self.get_wallet()
             .apply_update(update.0.clone())

--- a/bdk-ffi/src/wallet.rs
+++ b/bdk-ffi/src/wallet.rs
@@ -76,6 +76,10 @@ impl Wallet {
         self.get_wallet().reveal_next_address(keychain_kind).into()
     }
 
+    pub fn peek_address(&self, keychain_kind: KeychainKind, index: u32) -> AddressInfo {
+        self.get_wallet().peek_address(keychain_kind, index).into()
+    }
+
     pub fn apply_update(&self, update: Arc<Update>) -> Result<(), CannotConnectError> {
         self.get_wallet()
             .apply_update(update.0.clone())

--- a/bdk-ffi/src/wallet.rs
+++ b/bdk-ffi/src/wallet.rs
@@ -99,6 +99,13 @@ impl Wallet {
             .collect()
     }
 
+    pub fn list_unused_addresses(&self, keychain: KeychainKind) -> Vec<AddressInfo> {
+        self.get_wallet()
+            .list_unused_addresses(keychain)
+            .map(|address_info| address_info.into())
+            .collect()
+    }
+
     pub fn apply_update(&self, update: Arc<Update>) -> Result<(), CannotConnectError> {
         self.get_wallet()
             .apply_update(update.0.clone())

--- a/bdk-ffi/src/wallet.rs
+++ b/bdk-ffi/src/wallet.rs
@@ -92,6 +92,13 @@ impl Wallet {
         self.get_wallet().mark_used(keychain, index)
     }
 
+    pub fn reveal_addresses_to(&self, keychain: KeychainKind, index: u32) -> Vec<AddressInfo> {
+        self.get_wallet()
+            .reveal_addresses_to(keychain, index)
+            .map(|address_info| address_info.into())
+            .collect()
+    }
+
     pub fn apply_update(&self, update: Arc<Update>) -> Result<(), CannotConnectError> {
         self.get_wallet()
             .apply_update(update.0.clone())

--- a/bdk-ffi/src/wallet.rs
+++ b/bdk-ffi/src/wallet.rs
@@ -76,8 +76,12 @@ impl Wallet {
         self.get_wallet().reveal_next_address(keychain_kind).into()
     }
 
-    pub fn peek_address(&self, keychain_kind: KeychainKind, index: u32) -> AddressInfo {
-        self.get_wallet().peek_address(keychain_kind, index).into()
+    pub fn peek_address(&self, keychain: KeychainKind, index: u32) -> AddressInfo {
+        self.get_wallet().peek_address(keychain, index).into()
+    }
+
+    pub fn next_derivation_index(&self, keychain: KeychainKind) -> u32 {
+        self.get_wallet().next_derivation_index(keychain)
     }
 
     pub fn apply_update(&self, update: Arc<Update>) -> Result<(), CannotConnectError> {

--- a/bdk-ffi/src/wallet.rs
+++ b/bdk-ffi/src/wallet.rs
@@ -84,6 +84,10 @@ impl Wallet {
         self.get_wallet().next_derivation_index(keychain)
     }
 
+    pub fn next_unused_address(&self, keychain: KeychainKind) -> AddressInfo {
+        self.get_wallet().next_unused_address(keychain).into()
+    }
+
     pub fn apply_update(&self, update: Arc<Update>) -> Result<(), CannotConnectError> {
         self.get_wallet()
             .apply_update(update.0.clone())


### PR DESCRIPTION
This PR adds a bunch of the little methods we found last week were missing from the Wallet APIs. They're all mostly one-liners so it was easy to tackle.

### Changelog notice

```md
Added:
  - Wallet::peek_address method [#599]
  - Wallet::next_derivation_index [#599]
  - Wallet::next_unused_address [#599]
  - Wallet::mark_used [#599]
  - Wallet::reveal_addresses_to [#599]
  - Wallet::list_unused_addresses [#599]

[#599]: https://github.com/bitcoindevkit/bdk-ffi/pull/599
```

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
