### PR TITLE
deps: bump bdk to beta_5

### DIFF
--- a/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/LiveTxBuilderTest.kt
+++ b/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/LiveTxBuilderTest.kt
@@ -78,7 +78,6 @@ class LiveTxBuilderTest {
             .setRecipients(allRecipients)
             .feeRate(FeeRate.fromSatPerVb(4uL))
             .changePolicy(ChangeSpendPolicy.CHANGE_FORBIDDEN)
-            .enableRbf()
             .finish(wallet)
 
         wallet.sign(psbt)

--- a/bdk-ffi/Cargo.lock
+++ b/bdk-ffi/Cargo.lock
@@ -188,9 +188,9 @@ dependencies = [
 
 [[package]]
 name = "bdk_bitcoind_rpc"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5baa4cee070856947029bcaec4a5c070d1b34825909b364cfdb124f4ed3b7e40"
+checksum = "577233392985869b7b5d9e0eae638c5112c48d5edc07422de0e0726c15144e92"
 dependencies = [
  "bdk_core",
  "bitcoin",
@@ -199,9 +199,9 @@ dependencies = [
 
 [[package]]
 name = "bdk_chain"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e553c45ffed860aa7e0c6998c3a827fcdc039a2df76307563208ecfcae2f750"
+checksum = "3bee1fe68ec0015bce2e4c1754ebbf18d70750a1f0103e3785d34e8959fe8fd7"
 dependencies = [
  "bdk_core",
  "bitcoin",
@@ -213,9 +213,9 @@ dependencies = [
 
 [[package]]
 name = "bdk_core"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c0b45300422611971b0bbe84b04d18e38e81a056a66860c9dd3434f6d0f5396"
+checksum = "be5e187ee33d5f99f1997a700cc1dfa0524fd1de31e6414c612c9e89ccdaa133"
 dependencies = [
  "bitcoin",
  "hashbrown 0.9.1",
@@ -224,9 +224,9 @@ dependencies = [
 
 [[package]]
 name = "bdk_electrum"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d371f3684d55ab4fd741ac95840a9ba6e53a2654ad9edfbdb3c22f29fd48546f"
+checksum = "fee5560d6758855e5e0778bc3bc25648658684afac667321ddc0cba08aef933a"
 dependencies = [
  "bdk_core",
  "electrum-client",
@@ -234,9 +234,9 @@ dependencies = [
 
 [[package]]
 name = "bdk_esplora"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cc9b320b2042e9729739eed66c6fc47b208554c8c6e393785cd56d257045e9f"
+checksum = "bcae78230aedb46d07f7fa68e5082504111687d9df0e384c14dbf17d8cfa405a"
 dependencies = [
  "bdk_core",
  "esplora-client",
@@ -245,9 +245,9 @@ dependencies = [
 
 [[package]]
 name = "bdk_wallet"
-version = "1.0.0-beta.4"
+version = "1.0.0-beta.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aeb48cd8e0a15d0bf7351fc8c30e44c474be01f4f98eb29f20ab59b645bd29c"
+checksum = "627ad309b5dc5adec0491141d40fcb8d032209c373dd47a870c702e9e5eba36a"
 dependencies = [
  "bdk_chain",
  "bip39",
@@ -506,9 +506,9 @@ dependencies = [
 
 [[package]]
 name = "esplora-client"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b546e91283ebfc56337de34e0cf814e3ad98083afde593b8e58495ee5355d0e"
+checksum = "23be31c97b2e505ac6af0d72a201caead71298a957639061a10314f6d4860cd7"
 dependencies = [
  "bitcoin",
  "hex-conservative",

--- a/bdk-ffi/Cargo.toml
+++ b/bdk-ffi/Cargo.toml
@@ -18,11 +18,11 @@ path = "uniffi-bindgen.rs"
 default = ["uniffi/cli"]
 
 [dependencies]
-bdk_wallet = { version = "1.0.0-beta.4", features = ["all-keys", "keys-bip39", "rusqlite"] }
-bdk_core = { version = "0.2.0" }
-bdk_esplora = { version = "0.18.0", default-features = false, features = ["std", "blocking", "blocking-https-rustls"] }
-bdk_electrum = { version = "0.18.0", default-features = false, features = ["use-rustls-ring"] }
-bdk_bitcoind_rpc = { version = "0.15.0" }
+bdk_wallet = { version = "=1.0.0-beta.5", features = ["all-keys", "keys-bip39", "rusqlite"] }
+bdk_core = { version = "0.3.0" }
+bdk_esplora = { version = "0.19.0", default-features = false, features = ["std", "blocking", "blocking-https-rustls"] }
+bdk_electrum = { version = "0.19.0", default-features = false, features = ["use-rustls-ring"] }
+bdk_bitcoind_rpc = { version = "0.16.0" }
 bitcoin-ffi = { git = "https://github.com/bitcoindevkit/bitcoin-ffi", tag = "v0.1.2" }
 
 uniffi = { version = "=0.28.0" }

--- a/bdk-ffi/src/bdk.udl
+++ b/bdk-ffi/src/bdk.udl
@@ -61,8 +61,7 @@ interface CreateTxError {
   Version0();
   Version1Csv();
   LockTime(string requested, string required);
-  RbfSequence();
-  RbfSequenceCsv(string rbf, string csv);
+  RbfSequenceCsv(string sequence, string csv);
   FeeTooLow(string required);
   FeeRateTooLow(string required);
   NoUtxosSelected();
@@ -462,9 +461,7 @@ interface TxBuilder {
 
   TxBuilder drain_to([ByRef] Script script);
 
-  TxBuilder enable_rbf();
-
-  TxBuilder enable_rbf_with_sequence(u32 nsequence);
+  TxBuilder set_exact_sequence(u32 nsequence);
 
   [Throws=CreateTxError]
   Psbt finish([ByRef] Wallet wallet);
@@ -473,9 +470,7 @@ interface TxBuilder {
 interface BumpFeeTxBuilder {
   constructor(string txid, FeeRate fee_rate);
 
-  BumpFeeTxBuilder enable_rbf();
-
-  BumpFeeTxBuilder enable_rbf_with_sequence(u32 nsequence);
+  BumpFeeTxBuilder set_exact_sequence(u32 nsequence);
 
   [Throws=CreateTxError]
   Psbt finish([ByRef] Wallet wallet);

--- a/bdk-ffi/src/error.rs
+++ b/bdk-ffi/src/error.rs
@@ -154,11 +154,8 @@ pub enum CreateTxError {
     #[error("lock time conflict: requested {requested}, but required {required}")]
     LockTime { requested: String, required: String },
 
-    #[error("transaction requires rbf sequence number")]
-    RbfSequence,
-
-    #[error("rbf sequence: {rbf}, csv sequence: {csv}")]
-    RbfSequenceCsv { rbf: String, csv: String },
+    #[error("rbf sequence: {sequence}, csv sequence: {csv}")]
+    RbfSequenceCsv { sequence: String, csv: String },
 
     #[error("fee too low: required {required}")]
     FeeTooLow { required: String },
@@ -793,9 +790,8 @@ impl From<BdkCreateTxError> for CreateTxError {
                 requested: requested.to_string(),
                 required: required.to_string(),
             },
-            BdkCreateTxError::RbfSequence => CreateTxError::RbfSequence,
-            BdkCreateTxError::RbfSequenceCsv { rbf, csv } => CreateTxError::RbfSequenceCsv {
-                rbf: rbf.to_string(),
+            BdkCreateTxError::RbfSequenceCsv { sequence, csv } => CreateTxError::RbfSequenceCsv {
+                sequence: sequence.to_string(),
                 csv: csv.to_string(),
             },
             BdkCreateTxError::FeeTooLow { required } => CreateTxError::FeeTooLow {

--- a/bdk-ffi/src/types.rs
+++ b/bdk-ffi/src/types.rs
@@ -232,9 +232,3 @@ pub struct SentAndReceivedValues {
     pub sent: Arc<Amount>,
     pub received: Arc<Amount>,
 }
-
-#[derive(Clone, Debug)]
-pub enum RbfValue {
-    Default,
-    Value(u32),
-}

--- a/bdk-jvm/lib/src/test/kotlin/org/bitcoindevkit/LiveTxBuilderTest.kt
+++ b/bdk-jvm/lib/src/test/kotlin/org/bitcoindevkit/LiveTxBuilderTest.kt
@@ -86,7 +86,6 @@ class LiveTxBuilderTest {
             .setRecipients(allRecipients)
             .feeRate(FeeRate.fromSatPerVb(4uL))
             .changePolicy(ChangeSpendPolicy.CHANGE_FORBIDDEN)
-            .enableRbf()
             .finish(wallet)
 
         wallet.sign(psbt)

--- a/bdk-python/tests/test_live_tx_builder.py
+++ b/bdk-python/tests/test_live_tx_builder.py
@@ -105,7 +105,7 @@ class LiveTxBuilderTest(unittest.TestCase):
             ScriptAmount(recipient2.script_pubkey, 4200)
         )
         
-        psbt: Psbt = TxBuilder().set_recipients(all_recipients).fee_rate(fee_rate=FeeRate.from_sat_per_vb(2)).enable_rbf().finish(wallet)
+        psbt: Psbt = TxBuilder().set_recipients(all_recipients).fee_rate(fee_rate=FeeRate.from_sat_per_vb(2)).finish(wallet)
         wallet.sign(psbt)
         
         self.assertTrue(psbt.serialize().startswith("cHNi"), "The PSBT should start with cHNi")

--- a/bdk-swift/Tests/BitcoinDevKitTests/LiveTxBuilderTests.swift
+++ b/bdk-swift/Tests/BitcoinDevKitTests/LiveTxBuilderTests.swift
@@ -110,7 +110,6 @@ final class LiveTxBuilderTests: XCTestCase {
         let psbt: Psbt = try TxBuilder()
             .setRecipients(recipients: allRecipients)
             .feeRate(feeRate: FeeRate.fromSatPerVb(satPerVb: 4))
-            .enableRbf()
             .finish(wallet: wallet)
 
         let _ = try! wallet.sign(psbt: psbt)


### PR DESCRIPTION
<!-- Erase any parts of this template not applicable to your Pull Request. -->

### Description

This pull request updates the bdk-ffi crate to use the latest beta version of bdk, specifically version [1.0.0-beta.5](https://github.com/bitcoindevkit/bdk/releases/tag/v1.0.0-beta.5). 

The main changes include:
- Updating the Cargo.toml file.
- Adjusting the RBF functionality to align with the [changes](https://github.com/bitcoindevkit/bdk/pull/1616) in the new BDK version.
  - Removing deprecated methods like enable_rbf() and enable_rbf_with_sequence().
  - Introducing the new [set_exact_sequence](https://docs.rs/bdk_wallet/1.0.0-beta.5/bdk_wallet/struct.TxBuilder.html#method.set_exact_sequence) method to replace the old RBF-related methods
- Updating [errors](https://docs.rs/bdk_wallet/latest/bdk_wallet/error/enum.CreateTxError.html), particularly for the RbfSequenceCsv error variant.

### Notes to the reviewers

### Changelog notice

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
