### PR TITLE
Remove dependency on bdk_bitcoind_rpc

### DIFF
--- a/bdk-ffi/Cargo.lock
+++ b/bdk-ffi/Cargo.lock
@@ -152,12 +152,6 @@ checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
 
 [[package]]
 name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
-name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
@@ -176,7 +170,6 @@ name = "bdk-ffi"
 version = "1.0.0-alpha.11"
 dependencies = [
  "assert_matches",
- "bdk_bitcoind_rpc",
  "bdk_core",
  "bdk_electrum",
  "bdk_esplora",
@@ -184,17 +177,6 @@ dependencies = [
  "bitcoin-ffi",
  "thiserror",
  "uniffi",
-]
-
-[[package]]
-name = "bdk_bitcoind_rpc"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "577233392985869b7b5d9e0eae638c5112c48d5edc07422de0e0726c15144e92"
-dependencies = [
- "bdk_core",
- "bitcoin",
- "bitcoincore-rpc",
 ]
 
 [[package]]
@@ -353,30 +335,6 @@ dependencies = [
  "bitcoin-io",
  "hex-conservative",
  "serde",
-]
-
-[[package]]
-name = "bitcoincore-rpc"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aedd23ae0fd321affb4bbbc36126c6f49a32818dc6b979395d24da8c9d4e80ee"
-dependencies = [
- "bitcoincore-rpc-json",
- "jsonrpc",
- "log",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "bitcoincore-rpc-json"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8909583c5fab98508e80ef73e5592a651c954993dc6b7739963257d19f0e71a"
-dependencies = [
- "bitcoin",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -626,18 +584,6 @@ name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
-
-[[package]]
-name = "jsonrpc"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3662a38d341d77efecb73caf01420cfa5aa63c0253fd7bc05289ef9f6616e1bf"
-dependencies = [
- "base64 0.13.1",
- "minreq",
- "serde",
- "serde_json",
-]
 
 [[package]]
 name = "libc"

--- a/bdk-ffi/Cargo.toml
+++ b/bdk-ffi/Cargo.toml
@@ -22,7 +22,6 @@ bdk_wallet = { version = "=1.0.0-beta.5", features = ["all-keys", "keys-bip39", 
 bdk_core = { version = "0.3.0" }
 bdk_esplora = { version = "0.19.0", default-features = false, features = ["std", "blocking", "blocking-https-rustls"] }
 bdk_electrum = { version = "0.19.0", default-features = false, features = ["use-rustls-ring"] }
-bdk_bitcoind_rpc = { version = "0.16.0" }
 bitcoin-ffi = { git = "https://github.com/bitcoindevkit/bitcoin-ffi", tag = "v0.1.2" }
 
 uniffi = { version = "=0.28.0" }

--- a/bdk-ffi/src/bitcoin.rs
+++ b/bdk-ffi/src/bitcoin.rs
@@ -5,7 +5,6 @@ use crate::error::{
 use bitcoin_ffi::OutPoint;
 use bitcoin_ffi::Script;
 
-use bdk_bitcoind_rpc::bitcoincore_rpc::jsonrpc::serde_json;
 use bdk_wallet::bitcoin::address::{NetworkChecked, NetworkUnchecked};
 use bdk_wallet::bitcoin::consensus::encode::serialize;
 use bdk_wallet::bitcoin::consensus::Decodable;
@@ -17,6 +16,7 @@ use bdk_wallet::bitcoin::Psbt as BdkPsbt;
 use bdk_wallet::bitcoin::Transaction as BdkTransaction;
 use bdk_wallet::bitcoin::TxIn as BdkTxIn;
 use bdk_wallet::bitcoin::TxOut as BdkTxOut;
+use bdk_wallet::serde_json;
 
 use std::fmt::Display;
 use std::ops::Deref;

--- a/bdk-ffi/src/error.rs
+++ b/bdk-ffi/src/error.rs
@@ -1,10 +1,9 @@
 use bitcoin_ffi::OutPoint;
 
-use bdk_bitcoind_rpc::bitcoincore_rpc::bitcoin::address::ParseError;
 use bdk_electrum::electrum_client::Error as BdkElectrumError;
 use bdk_esplora::esplora_client::{Error as BdkEsploraError, Error};
-use bdk_wallet::bitcoin::address::FromScriptError as BdkFromScriptError;
 use bdk_wallet::bitcoin::address::ParseError as BdkParseError;
+use bdk_wallet::bitcoin::address::{FromScriptError as BdkFromScriptError, ParseError};
 use bdk_wallet::bitcoin::bip32::Error as BdkBip32Error;
 use bdk_wallet::bitcoin::consensus::encode::Error as BdkEncodeError;
 use bdk_wallet::bitcoin::hashes::hex::HexToArrayError as BdkHexToArrayError;

--- a/bdk-ffi/src/tx_builder.rs
+++ b/bdk-ffi/src/tx_builder.rs
@@ -5,10 +5,10 @@ use crate::wallet::Wallet;
 
 use bitcoin_ffi::{Amount, FeeRate, Script};
 
-use bdk_bitcoind_rpc::bitcoincore_rpc::bitcoin::{OutPoint, Sequence, Txid};
 use bdk_wallet::bitcoin::amount::Amount as BdkAmount;
 use bdk_wallet::bitcoin::Psbt as BdkPsbt;
 use bdk_wallet::bitcoin::ScriptBuf as BdkScriptBuf;
+use bdk_wallet::bitcoin::{OutPoint, Sequence, Txid};
 use bdk_wallet::ChangeSpendPolicy;
 
 use std::collections::HashSet;


### PR DESCRIPTION
This one had been nagging at me for a while. We were using bdk_bitcoincore_rpc as a way to get to some types that are part of rust-bitcoin. No need to depend on bdk_bitcoincore_rpc until we add the RPC client.

### Changelog notice

No changelog notice

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
