### PR TITLE
Add `finalize_psbt`method to wallet

### DIFF
--- a/bdk-ffi/src/bdk.udl
+++ b/bdk-ffi/src/bdk.udl
@@ -405,6 +405,9 @@ interface Wallet {
   [Throws=SignerError]
   boolean sign(Psbt psbt);
 
+  [Throws=SignerError]
+  boolean finalize_psbt(Psbt psbt);
+
   SentAndReceivedValues sent_and_received([ByRef] Transaction tx);
 
   sequence<CanonicalTx> transactions();

--- a/bdk-ffi/src/wallet.rs
+++ b/bdk-ffi/src/wallet.rs
@@ -144,6 +144,13 @@ impl Wallet {
             .map_err(SignerError::from)
     }
 
+    pub fn finalize_psbt(&self, psbt: Arc<Psbt>) -> Result<bool, SignerError> {
+        let mut psbt = psbt.0.lock().unwrap();
+        self.get_wallet()
+            .finalize_psbt(&mut psbt, SignOptions::default())
+            .map_err(SignerError::from)
+    }
+
     pub fn sent_and_received(&self, tx: &Transaction) -> SentAndReceivedValues {
         let (sent, received) = self.get_wallet().sent_and_received(&tx.into());
         SentAndReceivedValues {


### PR DESCRIPTION
### Description

Add the `finalize_psbt` method on the wallet. One of the methods in #596 

### Notes to the reviewers

We keep the `SignOptions` default here considering that's how it is used for `sign`. The only reason `SignOptions` is used is whether we assume the height in the PSBT or not. 

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
