### PR TITLE
Add Spending Policy API

### DIFF
--- a/bdk-ffi/src/bdk.udl
+++ b/bdk-ffi/src/bdk.udl
@@ -444,7 +444,9 @@ interface Wallet {
 
 interface Update {};
 
-interface Policy {};
+interface Policy {
+  string id();
+};
 
 interface TxBuilder {
   constructor();

--- a/bdk-ffi/src/bdk.udl
+++ b/bdk-ffi/src/bdk.udl
@@ -461,6 +461,8 @@ interface TxBuilder {
 
   TxBuilder add_utxo(OutPoint outpoint);
 
+  TxBuilder policy_path(record<string, sequence<u64>> policy_path, KeychainKind keychain);
+
   TxBuilder change_policy(ChangeSpendPolicy change_policy);
 
   TxBuilder do_not_spend_change();

--- a/bdk-ffi/src/bdk.udl
+++ b/bdk-ffi/src/bdk.udl
@@ -401,6 +401,9 @@ interface Wallet {
 
   string descriptor_checksum(KeychainKind keychain);
 
+  [Throws=DescriptorError]
+  Policy? policies(KeychainKind keychain);
+
   Balance balance();
 
   [Throws=CannotConnectError]
@@ -440,6 +443,8 @@ interface Wallet {
 };
 
 interface Update {};
+
+interface Policy {};
 
 interface TxBuilder {
   constructor();

--- a/bdk-ffi/src/lib.rs
+++ b/bdk-ffi/src/lib.rs
@@ -57,6 +57,7 @@ use crate::types::FullScanRequestBuilder;
 use crate::types::FullScanScriptInspector;
 use crate::types::KeychainAndIndex;
 use crate::types::LocalOutput;
+use crate::types::Policy;
 use crate::types::ScriptAmount;
 use crate::types::SentAndReceivedValues;
 use crate::types::SyncRequest;

--- a/bdk-ffi/src/types.rs
+++ b/bdk-ffi/src/types.rs
@@ -251,3 +251,8 @@ impl From<Policy> for BdkPolicy {
         value.0
     }
 }
+impl Policy {
+    pub fn id(&self) -> String {
+        self.0.id.clone()
+    }
+}

--- a/bdk-ffi/src/types.rs
+++ b/bdk-ffi/src/types.rs
@@ -15,12 +15,12 @@ use bdk_wallet::chain::tx_graph::CanonicalTx as BdkCanonicalTx;
 use bdk_wallet::chain::{
     ChainPosition as BdkChainPosition, ConfirmationBlockTime as BdkConfirmationBlockTime,
 };
+use bdk_wallet::descriptor::Policy as BdkPolicy;
 use bdk_wallet::AddressInfo as BdkAddressInfo;
 use bdk_wallet::Balance as BdkBalance;
 use bdk_wallet::KeychainKind;
 use bdk_wallet::LocalOutput as BdkLocalOutput;
 use bdk_wallet::Update as BdkUpdate;
-
 use std::sync::{Arc, Mutex};
 
 #[derive(Debug)]
@@ -236,4 +236,18 @@ pub struct SentAndReceivedValues {
 pub struct KeychainAndIndex {
     pub keychain: KeychainKind,
     pub index: u32,
+}
+
+/// Descriptor spending policy
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct Policy(BdkPolicy);
+impl From<BdkPolicy> for Policy {
+    fn from(value: BdkPolicy) -> Self {
+        Policy(value)
+    }
+}
+impl From<Policy> for BdkPolicy {
+    fn from(value: Policy) -> Self {
+        value.0
+    }
 }

--- a/bdk-ffi/src/wallet.rs
+++ b/bdk-ffi/src/wallet.rs
@@ -1,13 +1,13 @@
 use crate::bitcoin::{Psbt, Transaction};
 use crate::descriptor::Descriptor;
 use crate::error::{
-    CalculateFeeError, CannotConnectError, CreateWithPersistError, LoadWithPersistError,
-    SignerError, SqliteError, TxidParseError,
+    CalculateFeeError, CannotConnectError, CreateWithPersistError, DescriptorError,
+    LoadWithPersistError, SignerError, SqliteError, TxidParseError,
 };
 use crate::store::Connection;
 use crate::types::{
     AddressInfo, Balance, CanonicalTx, FullScanRequestBuilder, KeychainAndIndex, LocalOutput,
-    SentAndReceivedValues, SyncRequestBuilder, Update,
+    Policy, SentAndReceivedValues, SyncRequestBuilder, Update,
 };
 
 use bitcoin_ffi::{Amount, FeeRate, OutPoint, Script};
@@ -139,6 +139,13 @@ impl Wallet {
         self.get_wallet().descriptor_checksum(keychain)
     }
 
+    pub fn policies(&self, keychain: KeychainKind) -> Result<Option<Arc<Policy>>, DescriptorError> {
+        self.get_wallet()
+            .policies(keychain)
+            .map_err(DescriptorError::from)
+            .map(|e| e.map(|p| Arc::new(p.into())))
+    }
+
     pub fn network(&self) -> Network {
         self.get_wallet().network()
     }
@@ -154,8 +161,7 @@ impl Wallet {
 
     pub(crate) fn sign(
         &self,
-        psbt: Arc<Psbt>,
-        // sign_options: Option<SignOptions>,
+        psbt: Arc<Psbt>, // sign_options: Option<SignOptions>,
     ) -> Result<bool, SignerError> {
         let mut psbt = psbt.0.lock().unwrap();
         self.get_wallet()


### PR DESCRIPTION
<!-- Erase any parts of this template not applicable to your Pull Request. -->

### Description

Fixes the follwoing bug:

Encountering a Spending policy required: External error when attempting to build a transaction using a multi-sig descriptor. Currently, bdk-ffi does not provide a policy_path() in txBuilder, which is necessary for specifying the correct policy path during transaction creation.

The PR fix has the following changes:

- Expose policies() from the wallet to retrieve available spending policies.
- Add support for policy_path() in txBuilder to allow specifying the correct policy path when building the transaction.

### Changelog notice

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [ ] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [x] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] I've added tests to reproduce the issue which are now passing
* [x] I'm linking the issue being fixed by this PR
Fixes https://github.com/bitcoindevkit/bdk-ffi/issues/605