### PR TITLE
feat: transactions use transactions_sort_by

### DIFF
--- a/bdk-ffi/src/wallet.rs
+++ b/bdk-ffi/src/wallet.rs
@@ -180,7 +180,8 @@ impl Wallet {
 
     pub fn transactions(&self) -> Vec<CanonicalTx> {
         self.get_wallet()
-            .transactions()
+            .transactions_sort_by(|tx1, tx2| tx2.chain_position.cmp(&tx1.chain_position))
+            .into_iter()
             .map(|tx| tx.into())
             .collect()
     }


### PR DESCRIPTION
<!-- Erase any parts of this template not applicable to your Pull Request. -->

### Description

After discussing possible paths in #592 I believe the consensus was to just use [transactions_sort_by](https://docs.rs/bdk_wallet/latest/bdk_wallet/struct.Wallet.html#method.transactions_sort_by) under the hood in `transactions` because the [example](https://docs.rs/bdk_wallet/latest/bdk_wallet/struct.Wallet.html#example-1) is likely what clients would expect out of the box.

### Notes to the reviewers

I tested a local build of this in BDKSwiftExampleWallet to verify it worked as intended.

### Changelog notice

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
