### PR TITLE
chore: ci test-swift from macos-12 to macos-13

### DIFF
--- a/.github/workflows/test-swift.yaml
+++ b/.github/workflows/test-swift.yaml
@@ -13,7 +13,7 @@ on:
 jobs:
   build:
     name: "Build and test"
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
       - name: "Checkout"
         uses: actions/checkout@v3


### PR DESCRIPTION
<!-- Erase any parts of this template not applicable to your Pull Request. -->

### Description

Attempts to fix CI failures when I ran CI on #617 

<img width="1148" alt="macos bdk-ffi pr" src="https://github.com/user-attachments/assets/d967d480-23d3-4022-affe-2b55e6ae1edb">


### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Changelog notice

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
