### PR TITLE
Add `finalize` to `Psbt`

### DIFF
--- a/bdk-ffi/src/bdk.udl
+++ b/bdk-ffi/src/bdk.udl
@@ -259,6 +259,13 @@ interface PsbtParseError {
 };
 
 [Error]
+interface PsbtFinalizeError {
+  InputError(string reason, u32 index);
+  WrongInputCount(u32 in_tx, u32 in_map);
+  InputIdxOutofBounds(u32 psbt_inp, u32 requested);
+};
+
+[Error]
 interface RequestBuilderError {
   RequestAlreadyConsumed();
 };
@@ -958,7 +965,15 @@ interface Psbt {
   [Throws=PsbtError]
   Psbt combine(Psbt other);
 
+  FinalizedPsbtResult finalize();
+
   string json_serialize();
+};
+
+dictionary FinalizedPsbtResult {
+  Psbt psbt;
+  boolean could_finalize;
+  sequence<PsbtFinalizeError>? errors;
 };
 
 dictionary TxIn {

--- a/bdk-ffi/src/lib.rs
+++ b/bdk-ffi/src/lib.rs
@@ -10,6 +10,7 @@ mod types;
 mod wallet;
 
 use crate::bitcoin::Address;
+use crate::bitcoin::FinalizedPsbtResult;
 use crate::bitcoin::Psbt;
 use crate::bitcoin::Transaction;
 use crate::bitcoin::TxIn;
@@ -33,6 +34,7 @@ use crate::error::LoadWithPersistError;
 use crate::error::MiniscriptError;
 use crate::error::PersistenceError;
 use crate::error::PsbtError;
+use crate::error::PsbtFinalizeError;
 use crate::error::PsbtParseError;
 use crate::error::RequestBuilderError;
 use crate::error::SignerError;


### PR DESCRIPTION
### Description

#580 does the initial work to adding `finalize` to `Psbt`. I would like to get this in for @andreasgriffin and revisit this later in `bitcoin-ffi`. I think #580 has the right idea, but I would like a more detailed system of _why_ finalizing might have failed. Unfortunately, the `finalize` function using a `Vec<E>` of errors, which is not expressible by UniFFI types, so I created a new `FinalizedPsbtResult` type that contains either the original `Psbt` or the finalized `Psbt`, and any errors that may be associated with the `finalize` step.

I have thought about this for a while and I think this is the best approach, but open to any ideas.

### Notes to the reviewers

Please confirm this works with your example `Psbt` @andreasgriffin 

### Changelog notice

- Add `finalize` method to `Psbt`

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
