### PR TITLE
Build Kotlin API docs in CI

### DIFF
--- a/.github/workflows/kotlin-api-docs.yaml
+++ b/.github/workflows/kotlin-api-docs.yaml
@@ -1,0 +1,41 @@
+name: Build JVM and Android API Docs Websites
+
+on: workflow_dispatch
+
+jobs:
+  deploy:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v3
+
+      - name: "Set up JDK 17"
+        uses: actions/setup-java@v2
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: "Build JVM API documentation"
+        run: |
+          cd ./bdk-jvm/
+          bash ./scripts/build-linux-x86_64.sh
+          ./gradlew dokkaHtml
+      
+      - name: "Upload JVM website"
+        uses: actions/upload-artifact@v4
+        with:
+          name: artifact-jvm-api-docs
+          path: /home/runner/work/bdk-ffi/bdk-ffi/bdk-jvm/lib/build/dokka/html/
+
+      - name: "Build Android API documentation"
+        run: |
+          cd ./bdk-android/
+          bash ./scripts/build-linux-x86_64.sh
+          ./gradlew dokkaHtml
+
+      - name: "Upload Android website"
+        uses: actions/upload-artifact@v3
+        with:
+          name: artifact-android-api-docs
+          path: /home/runner/work/bdk-ffi/bdk-ffi/bdk-android/lib/build/dokka/html/
+  

--- a/bdk-android/build.gradle.kts
+++ b/bdk-android/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     id("org.gradle.maven-publish")
     id("org.gradle.signing")
     id("io.github.gradle-nexus.publish-plugin").version("1.1.0").apply(true)
+    id("org.jetbrains.dokka").version("1.9.0").apply(false)
 }
 
 // library version is defined in gradle.properties

--- a/bdk-android/lib/build.gradle.kts
+++ b/bdk-android/lib/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
     id("org.jetbrains.kotlin.android")
     id("org.gradle.maven-publish")
     id("org.gradle.signing")
+    id("org.jetbrains.dokka")
 }
 
 android {

--- a/bdk-jvm/build.gradle.kts
+++ b/bdk-jvm/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     id("org.gradle.maven-publish")
     id("org.gradle.signing")
     id("io.github.gradle-nexus.publish-plugin") version "1.1.0"
+    id("org.jetbrains.dokka").version("1.9.0").apply(false)
 }
 
 // library version is defined in gradle.properties

--- a/bdk-jvm/lib/build.gradle.kts
+++ b/bdk-jvm/lib/build.gradle.kts
@@ -10,6 +10,7 @@ plugins {
     id("org.gradle.java-library")
     id("org.gradle.maven-publish")
     id("org.gradle.signing")
+    id("org.jetbrains.dokka")
 }
 
 java {


### PR DESCRIPTION
This PR is WIP.

It should allow us to trigger the build for the API docs for JVM and Android in the CI, and the resulting website could be downloaded as an artifact (to then be PR'd on the website).