### PR TITLE
Use `macos-14` image in CI

### DIFF
--- a/.github/workflows/live-tests.yaml
+++ b/.github/workflows/live-tests.yaml
@@ -38,7 +38,7 @@ jobs:
 
   swift-tests:
     name: "Build and test iOS library on macOS"
-    runs-on: macos-12
+    runs-on: macos-14
     steps:
       - name: "Checkout"
         uses: actions/checkout@v3


### PR DESCRIPTION
The [live tests failed this week](https://github.com/bitcoindevkit/bdk-ffi/actions/runs/12217757204/job/34082417471) because the macos-12 image is deprecated. This bumps it to macos-14.