### PR TITLE
deps: bump bdk to beta_6

### DIFF
--- a/bdk-ffi/Cargo.lock
+++ b/bdk-ffi/Cargo.lock
@@ -4,12 +4,6 @@ version = 3
 
 [[package]]
 name = "ahash"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0453232ace82dee0dd0b4c87a59bd90f7b53b314f3e0f61fe2ee7c8a16482289"
-
-[[package]]
-name = "ahash"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
@@ -181,34 +175,33 @@ dependencies = [
 
 [[package]]
 name = "bdk_chain"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bee1fe68ec0015bce2e4c1754ebbf18d70750a1f0103e3785d34e8959fe8fd7"
+checksum = "65db19f8952e6563c7c0ce38190b930ac57c02bb9f0da4f761e542639f99ed72"
 dependencies = [
  "bdk_core",
  "bitcoin",
  "miniscript",
  "rusqlite",
  "serde",
- "serde_json",
 ]
 
 [[package]]
 name = "bdk_core"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be5e187ee33d5f99f1997a700cc1dfa0524fd1de31e6414c612c9e89ccdaa133"
+checksum = "070ff23e275c978ca19d137a2ae3516262400868a04228394710b270d958afc6"
 dependencies = [
  "bitcoin",
- "hashbrown 0.9.1",
+ "hashbrown",
  "serde",
 ]
 
 [[package]]
 name = "bdk_electrum"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fee5560d6758855e5e0778bc3bc25648658684afac667321ddc0cba08aef933a"
+checksum = "8cda5b8cd1175044dc6cc5380b34954f0269ba81719fb238e15fa515b98f200b"
 dependencies = [
  "bdk_core",
  "electrum-client",
@@ -216,9 +209,9 @@ dependencies = [
 
 [[package]]
 name = "bdk_esplora"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcae78230aedb46d07f7fa68e5082504111687d9df0e384c14dbf17d8cfa405a"
+checksum = "ca55db88aed9ef98828457b428b6173698bda55db7bd8c97493532bdcc3ae595"
 dependencies = [
  "bdk_core",
  "esplora-client",
@@ -227,9 +220,9 @@ dependencies = [
 
 [[package]]
 name = "bdk_wallet"
-version = "1.0.0-beta.5"
+version = "1.0.0-beta.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "627ad309b5dc5adec0491141d40fcb8d032209c373dd47a870c702e9e5eba36a"
+checksum = "35ea570993f0d1a486b0f9204f14abaf4601c26992982ac78157ef3eb0fb49ac"
 dependencies = [
  "bdk_chain",
  "bip39",
@@ -447,9 +440,9 @@ checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
 
 [[package]]
 name = "electrum-client"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a0bd443023f9f5c4b7153053721939accc7113cbdf810a024434eed454b3db1"
+checksum = "d627e4feaf3009c10c8a0eb06d6ceb4ce1ff861849157fb35e8155d9706babb6"
 dependencies = [
  "bitcoin",
  "byteorder",
@@ -464,9 +457,9 @@ dependencies = [
 
 [[package]]
 name = "esplora-client"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23be31c97b2e505ac6af0d72a201caead71298a957639061a10314f6d4860cd7"
+checksum = "d0da3c186d286e046253ccdc4bb71aa87ef872e4eff2045947c0c4fe3d2b2efc"
 dependencies = [
  "bitcoin",
  "hex-conservative",
@@ -526,21 +519,12 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
-dependencies = [
- "ahash 0.4.8",
- "serde",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
- "ahash 0.8.11",
+ "ahash",
+ "serde",
 ]
 
 [[package]]
@@ -549,7 +533,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
 dependencies = [
- "hashbrown 0.14.5",
+ "hashbrown",
 ]
 
 [[package]]

--- a/bdk-ffi/Cargo.toml
+++ b/bdk-ffi/Cargo.toml
@@ -18,10 +18,10 @@ path = "uniffi-bindgen.rs"
 default = ["uniffi/cli"]
 
 [dependencies]
-bdk_wallet = { version = "=1.0.0-beta.5", features = ["all-keys", "keys-bip39", "rusqlite"] }
-bdk_core = { version = "0.3.0" }
-bdk_esplora = { version = "0.19.0", default-features = false, features = ["std", "blocking", "blocking-https-rustls"] }
-bdk_electrum = { version = "0.19.0", default-features = false, features = ["use-rustls-ring"] }
+bdk_wallet = { version = "=1.0.0-beta.6", features = ["all-keys", "keys-bip39", "rusqlite"] }
+bdk_core = { version = "0.4.0" }
+bdk_esplora = { version = "0.20.0", default-features = false, features = ["std", "blocking", "blocking-https-rustls"] }
+bdk_electrum = { version = "0.20.0", default-features = false, features = ["use-rustls-ring"] }
 bitcoin-ffi = { git = "https://github.com/bitcoindevkit/bitcoin-ffi", tag = "v0.1.2" }
 
 uniffi = { version = "=0.28.0" }

--- a/bdk-ffi/src/bdk.udl
+++ b/bdk-ffi/src/bdk.udl
@@ -146,6 +146,7 @@ interface EsploraError {
   InvalidHttpHeaderName(string name);
   InvalidHttpHeaderValue(string value);
   RequestAlreadyConsumed();
+  InvalidResponse();
 };
 
 [Error]
@@ -396,11 +397,11 @@ dictionary TxOut {
 /// Represents the observed position of some chain data.
 [Enum]
 interface ChainPosition {
-  /// The chain data is seen as confirmed, and in anchored by `A`.
-  Confirmed(ConfirmationBlockTime confirmation_block_time);
+  /// The chain data is confirmed as it is anchored in the best chain by `A`.
+  Confirmed(ConfirmationBlockTime confirmation_block_time, string? transitively);
 
   /// The chain data is not confirmed and last seen in the mempool at this timestamp.
-  Unconfirmed(u64 timestamp);
+  Unconfirmed(u64? timestamp);
 };
 
 dictionary ConfirmationBlockTime {

--- a/bdk-ffi/src/electrum.rs
+++ b/bdk-ffi/src/electrum.rs
@@ -4,9 +4,9 @@ use crate::types::Update;
 use crate::types::{FullScanRequest, SyncRequest};
 
 use bdk_core::spk_client::FullScanRequest as BdkFullScanRequest;
-use bdk_core::spk_client::FullScanResult as BdkFullScanResult;
+use bdk_core::spk_client::FullScanResponse as BdkFullScanResponse;
 use bdk_core::spk_client::SyncRequest as BdkSyncRequest;
-use bdk_core::spk_client::SyncResult as BdkSyncResult;
+use bdk_core::spk_client::SyncResponse as BdkSyncResponse;
 use bdk_electrum::BdkElectrumClient as BdkBdkElectrumClient;
 use bdk_wallet::bitcoin::Transaction as BdkTransaction;
 use bdk_wallet::KeychainKind;
@@ -43,7 +43,7 @@ impl ElectrumClient {
             .take()
             .ok_or(ElectrumError::RequestAlreadyConsumed)?;
 
-        let full_scan_result: BdkFullScanResult<KeychainKind> = self.0.full_scan(
+        let full_scan_result: BdkFullScanResponse<KeychainKind> = self.0.full_scan(
             request,
             stop_gap as usize,
             batch_size as usize,
@@ -73,7 +73,7 @@ impl ElectrumClient {
             .take()
             .ok_or(ElectrumError::RequestAlreadyConsumed)?;
 
-        let sync_result: BdkSyncResult =
+        let sync_result: BdkSyncResponse =
             self.0
                 .sync(request, batch_size as usize, fetch_prev_txouts)?;
 

--- a/bdk-ffi/src/error.rs
+++ b/bdk-ffi/src/error.rs
@@ -2,7 +2,7 @@ use bitcoin_ffi::OutPoint;
 
 use bdk_core::bitcoin::script::PushBytesError;
 use bdk_electrum::electrum_client::Error as BdkElectrumError;
-use bdk_esplora::esplora_client::{Error as BdkEsploraError, Error};
+use bdk_esplora::esplora_client::Error as BdkEsploraError;
 use bdk_wallet::bitcoin::address::ParseError as BdkParseError;
 use bdk_wallet::bitcoin::address::{FromScriptError as BdkFromScriptError, ParseError};
 use bdk_wallet::bitcoin::bip32::Error as BdkBip32Error;
@@ -364,6 +364,9 @@ pub enum EsploraError {
 
     #[error("the request has already been consumed")]
     RequestAlreadyConsumed,
+
+    #[error("the server sent an invalid response")]
+    InvalidResponse,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -1084,7 +1087,7 @@ impl From<BdkEsploraError> for EsploraError {
             BdkEsploraError::Parsing(e) => EsploraError::Parsing {
                 error_message: e.to_string(),
             },
-            Error::StatusCode(e) => EsploraError::StatusCode {
+            BdkEsploraError::StatusCode(e) => EsploraError::StatusCode {
                 error_message: e.to_string(),
             },
             BdkEsploraError::BitcoinEncoding(e) => EsploraError::BitcoinEncoding {
@@ -1101,10 +1104,13 @@ impl From<BdkEsploraError> for EsploraError {
                 EsploraError::HeaderHeightNotFound { height }
             }
             BdkEsploraError::HeaderHashNotFound(_) => EsploraError::HeaderHashNotFound,
-            Error::InvalidHttpHeaderName(name) => EsploraError::InvalidHttpHeaderName { name },
+            BdkEsploraError::InvalidHttpHeaderName(name) => {
+                EsploraError::InvalidHttpHeaderName { name }
+            }
             BdkEsploraError::InvalidHttpHeaderValue(value) => {
                 EsploraError::InvalidHttpHeaderValue { value }
             }
+            BdkEsploraError::InvalidResponse => EsploraError::InvalidResponse,
         }
     }
 }
@@ -1122,7 +1128,7 @@ impl From<Box<BdkEsploraError>> for EsploraError {
             BdkEsploraError::Parsing(e) => EsploraError::Parsing {
                 error_message: e.to_string(),
             },
-            Error::StatusCode(e) => EsploraError::StatusCode {
+            BdkEsploraError::StatusCode(e) => EsploraError::StatusCode {
                 error_message: e.to_string(),
             },
             BdkEsploraError::BitcoinEncoding(e) => EsploraError::BitcoinEncoding {
@@ -1139,10 +1145,13 @@ impl From<Box<BdkEsploraError>> for EsploraError {
                 EsploraError::HeaderHeightNotFound { height }
             }
             BdkEsploraError::HeaderHashNotFound(_) => EsploraError::HeaderHashNotFound,
-            Error::InvalidHttpHeaderName(name) => EsploraError::InvalidHttpHeaderName { name },
+            BdkEsploraError::InvalidHttpHeaderName(name) => {
+                EsploraError::InvalidHttpHeaderName { name }
+            }
             BdkEsploraError::InvalidHttpHeaderValue(value) => {
                 EsploraError::InvalidHttpHeaderValue { value }
             }
+            BdkEsploraError::InvalidResponse => EsploraError::InvalidResponse,
         }
     }
 }

--- a/bdk-ffi/src/esplora.rs
+++ b/bdk-ffi/src/esplora.rs
@@ -8,9 +8,9 @@ use bdk_esplora::EsploraExt;
 use bdk_wallet::bitcoin::Transaction as BdkTransaction;
 use bdk_wallet::bitcoin::Txid;
 use bdk_wallet::chain::spk_client::FullScanRequest as BdkFullScanRequest;
-use bdk_wallet::chain::spk_client::FullScanResult as BdkFullScanResult;
+use bdk_wallet::chain::spk_client::FullScanResponse as BdkFullScanResponse;
 use bdk_wallet::chain::spk_client::SyncRequest as BdkSyncRequest;
-use bdk_wallet::chain::spk_client::SyncResult as BdkSyncResult;
+use bdk_wallet::chain::spk_client::SyncResponse as BdkSyncResponse;
 use bdk_wallet::KeychainKind;
 use bdk_wallet::Update as BdkUpdate;
 
@@ -40,7 +40,7 @@ impl EsploraClient {
             .take()
             .ok_or(EsploraError::RequestAlreadyConsumed)?;
 
-        let result: BdkFullScanResult<KeychainKind> =
+        let result: BdkFullScanResponse<KeychainKind> =
             self.0
                 .full_scan(request, stop_gap as usize, parallel_requests as usize)?;
 
@@ -66,7 +66,7 @@ impl EsploraClient {
             .take()
             .ok_or(EsploraError::RequestAlreadyConsumed)?;
 
-        let result: BdkSyncResult = self.0.sync(request, parallel_requests as usize)?;
+        let result: BdkSyncResponse = self.0.sync(request, parallel_requests as usize)?;
 
         let update = BdkUpdate {
             last_active_indices: BTreeMap::default(),


### PR DESCRIPTION
<!-- Erase any parts of this template not applicable to your Pull Request. -->

### Description

This pull request updates the bdk-ffi crate to use the latest beta version of bdk, specifically version [1.0.0-beta.6](https://github.com/bitcoindevkit/bdk/releases/tag/v1.0.0-beta.6). 

The main changes include:
- Updating the Cargo.toml file.
- Add `InvalidResponse` to Esplora [Error](https://docs.rs/esplora-client/0.11.0/esplora_client/enum.Error.html) 
- Adding `transitively` to [ChainPosition](https://docs.rs/bdk_chain/0.21.0/bdk_chain/enum.ChainPosition.html)
- `FullScanResult` -> `FullScanResponse`
- `SyncResult` -> `SyncResponse`
- made a small change, unrelated to beta 6, to `error.rs` to use `BdkEsploraError` in places where it used `Error`, both work but it keeps a consistent convention (and allowed us to remove `Error` from `use bdk_esplora::esplora_client::{Error as BdkEsploraError, Error}`)... kinda hate throwing little things like this in a PR like this but since I was already updating that error I felt like it was worth it and not too confusing for reviewers hopefully

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Changelog notice

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [x] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
