### PR TITLE
Small fixes to Electrum and Esplora APIs

### DIFF
--- a/bdk-ffi/src/bdk.udl
+++ b/bdk-ffi/src/bdk.udl
@@ -1035,10 +1035,10 @@ interface EsploraClient {
   constructor(string url);
 
   [Throws=EsploraError]
-  Update full_scan(FullScanRequest full_scan_request, u64 stop_gap, u64 parallel_requests);
+  Update full_scan(FullScanRequest request, u64 stop_gap, u64 parallel_requests);
 
   [Throws=EsploraError]
-  Update sync(SyncRequest sync_request, u64 parallel_requests);
+  Update sync(SyncRequest request, u64 parallel_requests);
 
   [Throws=EsploraError]
   void broadcast([ByRef] Transaction transaction);
@@ -1064,7 +1064,7 @@ interface ElectrumClient {
   /// Full scan the keychain scripts specified with the blockchain (via an Electrum client) and
   /// returns updates for bdk_chain data structures.
   ///
-  /// - `full_scan_request`: struct with data required to perform a spk-based blockchain client
+  /// - `request`: struct with data required to perform a spk-based blockchain client
   ///   full scan, see `FullScanRequest`.
   /// - `stop_gap`: the full scan for each keychain stops after a gap of script pubkeys with no
   ///   associated transactions.
@@ -1077,11 +1077,11 @@ interface ElectrumClient {
   ///   `CalculateFeeError::MissingTxOut` error if those TxOuts are not present in the transaction
   ///   graph.
   [Throws=ElectrumError]
-  Update full_scan(FullScanRequest full_scan_request, u64 stop_gap, u64 batch_size, boolean fetch_prev_txouts);
+  Update full_scan(FullScanRequest request, u64 stop_gap, u64 batch_size, boolean fetch_prev_txouts);
 
   /// Sync a set of scripts with the blockchain (via an Electrum client) for the data specified and returns updates for bdk_chain data structures.
   ///
-  /// - `sync_request`: struct with data required to perform a spk-based blockchain client
+  /// - `request`: struct with data required to perform a spk-based blockchain client
   ///   sync, see `SyncRequest`.
   /// - `batch_size`: specifies the max number of script pubkeys to request for in a single batch
   ///   request.
@@ -1095,11 +1095,11 @@ interface ElectrumClient {
   /// If the scripts to sync are unknown, such as when restoring or importing a keychain that may
   /// include scripts that have been used, use full_scan with the keychain.
   [Throws=ElectrumError]
-  Update sync(SyncRequest sync_request, u64 batch_size, boolean fetch_prev_txouts);
+  Update sync(SyncRequest request, u64 batch_size, boolean fetch_prev_txouts);
 
   /// Broadcasts a transaction to the network.
   [Throws=ElectrumError]
-  string broadcast([ByRef] Transaction transaction);
+  string transaction_broadcast([ByRef] Transaction tx);
 
   /// Returns the capabilities of the server.
   [Throws=ElectrumError]

--- a/bdk-ffi/src/electrum.rs
+++ b/bdk-ffi/src/electrum.rs
@@ -89,8 +89,8 @@ impl ElectrumClient {
         Ok(Arc::new(Update(update)))
     }
 
-    pub fn broadcast(&self, transaction: &Transaction) -> Result<String, ElectrumError> {
-        let bdk_transaction: BdkTransaction = transaction.into();
+    pub fn transaction_broadcast(&self, tx: &Transaction) -> Result<String, ElectrumError> {
+        let bdk_transaction: BdkTransaction = tx.into();
         self.0
             .transaction_broadcast(&bdk_transaction)
             .map_err(ElectrumError::from)

--- a/bdk-swift/Tests/BitcoinDevKitTests/LiveElectrumClientTests.swift
+++ b/bdk-swift/Tests/BitcoinDevKitTests/LiveElectrumClientTests.swift
@@ -24,7 +24,7 @@ final class LiveElectrumClientTests: XCTestCase {
         let electrumClient: ElectrumClient = try ElectrumClient(url: SIGNET_ELECTRUM_URL)
         let fullScanRequest: FullScanRequest = try wallet.startFullScan().build()
         let update = try electrumClient.fullScan(
-            fullScanRequest: fullScanRequest,
+            request: fullScanRequest,
             stopGap: 10,
             batchSize: 10,
             fetchPrevTxouts: false

--- a/bdk-swift/Tests/BitcoinDevKitTests/LiveMemoryWalletTests.swift
+++ b/bdk-swift/Tests/BitcoinDevKitTests/LiveMemoryWalletTests.swift
@@ -25,7 +25,7 @@ final class LiveMemoryWalletTests: XCTestCase {
         let esploraClient = EsploraClient(url: SIGNET_ESPLORA_URL)
         let fullScanRequest: FullScanRequest = try wallet.startFullScan().build()
         let update = try esploraClient.fullScan(
-            fullScanRequest: fullScanRequest,
+            request: fullScanRequest,
             stopGap: 10,
             parallelRequests: 1
         )
@@ -61,7 +61,7 @@ final class LiveMemoryWalletTests: XCTestCase {
         let fullScanRequest = try wallet.startFullScan().inspectSpksForAllKeychains(inspector: scriptInspector).build()
 
         let update = try esploraClient.fullScan(
-            fullScanRequest: fullScanRequest,
+            request: fullScanRequest,
             stopGap: 21,
             parallelRequests: 1
         )

--- a/bdk-swift/Tests/BitcoinDevKitTests/LiveTransactionTests.swift
+++ b/bdk-swift/Tests/BitcoinDevKitTests/LiveTransactionTests.swift
@@ -26,7 +26,7 @@ final class LiveTransactionTests: XCTestCase {
         let esploraClient = EsploraClient(url: SIGNET_ESPLORA_URL)
         let fullScanRequest: FullScanRequest = try wallet.startFullScan().build()
         let update = try esploraClient.fullScan(
-            fullScanRequest: fullScanRequest,
+            request: fullScanRequest,
             stopGap: 10,
             parallelRequests: 1
         )

--- a/bdk-swift/Tests/BitcoinDevKitTests/LiveTxBuilderTests.swift
+++ b/bdk-swift/Tests/BitcoinDevKitTests/LiveTxBuilderTests.swift
@@ -45,7 +45,7 @@ final class LiveTxBuilderTests: XCTestCase {
         let esploraClient = EsploraClient(url: SIGNET_ESPLORA_URL)
         let fullScanRequest: FullScanRequest = try wallet.startFullScan().build()
         let update = try esploraClient.fullScan(
-            fullScanRequest: fullScanRequest,
+            request: fullScanRequest,
             stopGap: 10,
             parallelRequests: 1
         )
@@ -87,7 +87,7 @@ final class LiveTxBuilderTests: XCTestCase {
         let esploraClient = EsploraClient(url: SIGNET_ESPLORA_URL)
         let fullScanRequest: FullScanRequest = try wallet.startFullScan().build()
         let update = try esploraClient.fullScan(
-            fullScanRequest: fullScanRequest,
+            request: fullScanRequest,
             stopGap: 10,
             parallelRequests: 1
         )

--- a/bdk-swift/Tests/BitcoinDevKitTests/LiveWalletTests.swift
+++ b/bdk-swift/Tests/BitcoinDevKitTests/LiveWalletTests.swift
@@ -45,7 +45,7 @@ final class LiveWalletTests: XCTestCase {
         let esploraClient = EsploraClient(url: SIGNET_ESPLORA_URL)
         let fullScanRequest: FullScanRequest = try wallet.startFullScan().build()
         let update = try esploraClient.fullScan(
-            fullScanRequest: fullScanRequest,
+            request: fullScanRequest,
             stopGap: 10,
             parallelRequests: 1
         )
@@ -79,7 +79,7 @@ final class LiveWalletTests: XCTestCase {
         let esploraClient = EsploraClient(url: SIGNET_ESPLORA_URL)
         let fullScanRequest: FullScanRequest = try wallet.startFullScan().build()
         let update = try esploraClient.fullScan(
-            fullScanRequest: fullScanRequest,
+            request: fullScanRequest,
             stopGap: 10,
             parallelRequests: 1
         )


### PR DESCRIPTION
This PR cleans up some of the method and argument names we had not mirrored correctly from the Rust side.

- full_scan_request -> request [docs](https://docs.rs/bdk_electrum/latest/bdk_electrum/struct.BdkElectrumClient.html#method.full_scan)
- sync_request -> request [docs](https://docs.rs/bdk_electrum/latest/bdk_electrum/struct.BdkElectrumClient.html#method.sync)
- (Electrum) broadcast -> transaction_broadcast [docs](https://docs.rs/bdk_electrum/latest/bdk_electrum/struct.BdkElectrumClient.html#method.transaction_broadcast)

### Changelog notice

```md
Changed:
  - The full_scan and sync methods on the Electrum and Esplora clients now take a renamed `request` argument [#642]
  - ElectrumClient::broacast was renamed ElectrumClient::transaction_broadcast to mirror the Rust API [#642]

[#642]: https://github.com/bitcoindevkit/bdk-ffi/pull/642
```

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature
