### PR TITLE
chore: use macos-14 image in publish-jvm.yaml

### DIFF
--- a/.github/workflows/publish-jvm.yaml
+++ b/.github/workflows/publish-jvm.yaml
@@ -4,7 +4,7 @@ on: [workflow_dispatch]
 jobs:
   build-macOS-native-libs:
     name: "Create M1 and x86_64 native binaries"
-    runs-on: macos-12
+    runs-on: macos-14
     steps:
       - name: "Checkout publishing branch"
         uses: actions/checkout@v3


### PR DESCRIPTION
<!-- Erase any parts of this template not applicable to your Pull Request. -->

### Description

mirrors https://github.com/bitcoindevkit/bdk-ffi/pull/634 and https://github.com/bitcoindevkit/bdk-swift/pull/51

possibly fixes https://github.com/bitcoindevkit/bdk-ffi/actions/runs/12400132598 ...


The first time I ran the workflow I'm pretty sure it only had this error, which seemed opaque:

<img width="602" alt="Screenshot 2024-12-18 at 7 24 00 PM" src="https://github.com/user-attachments/assets/dbe668d2-a457-4f70-af19-bd335112a027" />

But then I re-ran that failed job later, and I got two errors:

<img width="1073" alt="Screenshot 2024-12-18 at 7 24 47 PM" src="https://github.com/user-attachments/assets/9c61a397-51ad-4cfd-a172-c2c610096ae1" />

Weird that I didn't get that macos error the first time, but since I saw it this time maybe that was the actual error, and this PR would fix that.

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Changelog notice

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
