### PR TITLE
Add get_fee_estimates to EsploraClient

### DIFF
--- a/bdk-ffi/src/bdk.udl
+++ b/bdk-ffi/src/bdk.udl
@@ -1031,23 +1031,46 @@ interface Descriptor {
 // bdk_esplora crate
 // ------------------------------------------------------------------------
 
+/// Wrapper around an esplora_client::BlockingClient which includes an internal in-memory transaction
+/// cache to avoid re-fetching already downloaded transactions.
 interface EsploraClient {
+  /// Creates a new bdk client from a esplora_client::BlockingClient
   constructor(string url);
 
+  /// Scan keychain scripts for transactions against Esplora, returning an update that can be
+  /// applied to the receiving structures.
+  ///
+  /// `request` provides the data required to perform a script-pubkey-based full scan
+  /// (see [`FullScanRequest`]). The full scan for each keychain (`K`) stops after a gap of
+  /// `stop_gap` script pubkeys with no associated transactions. `parallel_requests` specifies
+  /// the maximum number of HTTP requests to make in parallel.
   [Throws=EsploraError]
   Update full_scan(FullScanRequest request, u64 stop_gap, u64 parallel_requests);
 
+  /// Sync a set of scripts, txids, and/or outpoints against Esplora.
+  ///
+  /// `request` provides the data required to perform a script-pubkey-based sync (see
+  /// [`SyncRequest`]). `parallel_requests` specifies the maximum number of HTTP requests to make
+  /// in parallel.
   [Throws=EsploraError]
   Update sync(SyncRequest request, u64 parallel_requests);
 
+  /// Broadcast a [`Transaction`] to Esplora.
   [Throws=EsploraError]
   void broadcast([ByRef] Transaction transaction);
 
+  /// Get a [`Transaction`] option given its [`Txid`].
   [Throws=EsploraError]
   Transaction? get_tx(string txid);
 
+  /// Get the height of the current blockchain tip.
   [Throws=EsploraError]
   u32 get_height();
+
+  /// Get a map where the key is the confirmation target (in number of
+  /// blocks) and the value is the estimated feerate (in sat/vB).
+  [Throws=EsploraError]
+  record<u16, f64> get_fee_estimates();
 };
 
 // ------------------------------------------------------------------------

--- a/bdk-ffi/src/esplora.rs
+++ b/bdk-ffi/src/esplora.rs
@@ -14,7 +14,7 @@ use bdk_wallet::chain::spk_client::SyncResponse as BdkSyncResponse;
 use bdk_wallet::KeychainKind;
 use bdk_wallet::Update as BdkUpdate;
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::str::FromStr;
 use std::sync::Arc;
 
@@ -92,5 +92,9 @@ impl EsploraClient {
 
     pub fn get_height(&self) -> Result<u32, EsploraError> {
         self.0.get_height().map_err(EsploraError::from)
+    }
+
+    pub fn get_fee_estimates(&self) -> Result<HashMap<u16, f64>, EsploraError> {
+        self.0.get_fee_estimates().map_err(EsploraError::from)
     }
 }


### PR DESCRIPTION
<!-- Erase any parts of this template not applicable to your Pull Request. -->

### Description

Add [get_fee_estimates](https://docs.rs/esplora-client/latest/esplora_client/blocking/struct.BlockingClient.html#method.get_fee_estimates) on `EsploraClient`

### Notes to the reviewers

Similar method was added for Electrum in #641 and I believe this is the closest comp for Esplora so I wanted to add it.

Can run test locally similar to what thunder laid out [here](https://github.com/bitcoindevkit/bdk-ffi/pull/641#issue-2748207130) by `import org.bitcoindevkit.EsploraClient` then adding something like:

```
val feeEstimates = client.getFeeEstimates()
println("Fee estimates: $feeEstimates")
```

<img width="1512" alt="Screenshot 2025-01-10 at 9 22 03 AM" src="https://github.com/user-attachments/assets/fb9eda4e-3c56-4aa7-b26e-2c0b8370c1ae" />

### Changelog notice

```md
Added:
  - EsploraClient::get_fee_estimates [#648]

[#648]: https://github.com/bitcoindevkit/bdk-ffi/pull/641
```

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
