### PR TITLE
Add dokka setup for Kotlin API docs

### DIFF
--- a/bdk-android/build.gradle.kts
+++ b/bdk-android/build.gradle.kts
@@ -4,7 +4,8 @@ plugins {
     id("org.gradle.maven-publish")
     id("org.gradle.signing")
     id("io.github.gradle-nexus.publish-plugin").version("1.1.0").apply(true)
-    id("org.jetbrains.dokka").version("1.9.0").apply(false)
+    id("org.jetbrains.dokka").version("2.0.0").apply(false)
+    id("org.jetbrains.dokka-javadoc").version("2.0.0").apply(false)
 }
 
 // library version is defined in gradle.properties

--- a/bdk-android/gradle.properties
+++ b/bdk-android/gradle.properties
@@ -3,3 +3,4 @@ android.useAndroidX=true
 android.enableJetifier=true
 kotlin.code.style=official
 libraryVersion=1.0.0-beta.7-SNAPSHOT
+org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled

--- a/bdk-android/justfile
+++ b/bdk-android/justfile
@@ -24,3 +24,6 @@ test:
 
 test-specific TEST:
   ./gradlew test --tests {{TEST}}
+
+build-docs:
+  ./gradlew :lib:dokkaGeneratePublicationHtml

--- a/bdk-android/lib/README.md
+++ b/bdk-android/lib/README.md
@@ -1,0 +1,11 @@
+# Module bdk-android
+
+The [bitcoindevkit](https://bitcoindevkit.org/) language bindings library for Kotlin on the JVM.
+
+# Package org.bitcoindevkit
+
+The types coming from BDK directly. The functionality exposed in this package is in fact a combination of the [bdk_wallet](https://crates.io/crates/bdk_wallet), [bdk_core](https://crates.io/crates/bdk_core), [bdk_electrum](https://crates.io/crates/bdk_electrum), and [bdk_esplora](https://crates.io/crates/bdk_esplora) crates.
+
+# Package org.rustbitcoin.bitcoin
+
+The types exposed from the [rust-bitcoin](https://crates.io/crates/bitcoin) library.

--- a/bdk-android/lib/build.gradle.kts
+++ b/bdk-android/lib/build.gradle.kts
@@ -9,6 +9,7 @@ plugins {
     id("org.gradle.maven-publish")
     id("org.gradle.signing")
     id("org.jetbrains.dokka")
+    id("org.jetbrains.dokka-javadoc")
 }
 
 android {
@@ -115,4 +116,22 @@ signing {
     val signingPassword: String? by project
     useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword)
     sign(publishing.publications)
+}
+
+dokka {
+    moduleName.set("bdk-android")
+    moduleVersion.set(libraryVersion)
+    dokkaSourceSets.main {
+        includes.from("README.md")
+        sourceLink {
+            localDirectory.set(file("src/main/kotlin"))
+            remoteUrl("https://bitcoindevkit.org/")
+            remoteLineSuffix.set("#L")
+        }
+    }
+    pluginsConfiguration.html {
+        // customStyleSheets.from("styles.css")
+        // customAssets.from("logo.svg")
+        footerMessage.set("(c) Bitcoin Dev Kit Developers")
+    }
 }

--- a/bdk-jvm/build.gradle.kts
+++ b/bdk-jvm/build.gradle.kts
@@ -4,7 +4,8 @@ plugins {
     id("org.gradle.maven-publish")
     id("org.gradle.signing")
     id("io.github.gradle-nexus.publish-plugin") version "1.1.0"
-    id("org.jetbrains.dokka").version("1.9.0").apply(false)
+    id("org.jetbrains.dokka").version("2.0.0").apply(false)
+    id("org.jetbrains.dokka-javadoc").version("2.0.0").apply(false)
 }
 
 // library version is defined in gradle.properties

--- a/bdk-jvm/gradle.properties
+++ b/bdk-jvm/gradle.properties
@@ -2,3 +2,4 @@ org.gradle.jvmargs=-Xmx1536m
 android.enableJetifier=true
 kotlin.code.style=official
 libraryVersion=1.0.0-beta.7-SNAPSHOT
+org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled

--- a/bdk-jvm/justfile
+++ b/bdk-jvm/justfile
@@ -29,3 +29,6 @@ test-offline:
 
 test-specific TEST:
   ./gradlew test --tests {{TEST}}
+
+build-docs:
+  ./gradlew :lib:dokkaGeneratePublicationHtml

--- a/bdk-jvm/lib/README.md
+++ b/bdk-jvm/lib/README.md
@@ -1,0 +1,11 @@
+# Module bdk-jvm
+
+The [bitcoindevkit](https://bitcoindevkit.org/) language bindings library for Kotlin on the JVM.
+
+# Package org.bitcoindevkit
+
+The types coming from BDK directly. The functionality exposed in this package is in fact a combination of the [bdk_wallet](https://crates.io/crates/bdk_wallet), [bdk_core](https://crates.io/crates/bdk_core), [bdk_electrum](https://crates.io/crates/bdk_electrum), and [bdk_esplora](https://crates.io/crates/bdk_esplora) crates.
+
+# Package org.rustbitcoin.bitcoin
+
+The types exposed from the [rust-bitcoin](https://crates.io/crates/bitcoin) library.

--- a/bdk-jvm/lib/build.gradle.kts
+++ b/bdk-jvm/lib/build.gradle.kts
@@ -11,6 +11,7 @@ plugins {
     id("org.gradle.maven-publish")
     id("org.gradle.signing")
     id("org.jetbrains.dokka")
+    id("org.jetbrains.dokka-javadoc")
 }
 
 java {
@@ -123,4 +124,22 @@ signing {
     val signingPassword: String? by project
     useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword)
     sign(publishing.publications)
+}
+
+dokka {
+    moduleName.set("bdk-jvm")
+    moduleVersion.set(libraryVersion)
+    dokkaSourceSets.main {
+        includes.from("README.md")
+        sourceLink {
+            localDirectory.set(file("src/main/kotlin"))
+            remoteUrl("https://bitcoindevkit.org/")
+            remoteLineSuffix.set("#L")
+        }
+    }
+    pluginsConfiguration.html {
+        // customStyleSheets.from("styles.css")
+        // customAssets.from("logo.svg")
+        footerMessage.set("(c) Bitcoin Dev Kit Developers")
+    }
 }


### PR DESCRIPTION
This PR adds the required setup for Dokka 2.0, allowing us to build the API documentation for bdk-jvm and bdk-android. Note that the README files are what ends up on the homepage/landing page of the API docs website. You can build and test for yourself by running 

```shell
cd bdk-jvm/
just build-docs
```

And open the `lib/build/dokka/html/index.html` file using a small live server like the one provided in vscode, or the built-in python one which should serve the website at `http://localhost:8000/`:
```shell
cd lib/build/dokka/html/
python -m http.server 8000
```

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
