### PR TITLE
Update download-artifact action to v4

### DIFF
--- a/.github/workflows/publish-jvm.yaml
+++ b/.github/workflows/publish-jvm.yaml
@@ -89,13 +89,13 @@ jobs:
           bash ./scripts/build-linux-x86_64.sh
 
       - name: "Download macOS native binaries from previous job"
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: artifact-macos
           path: ./bdk-jvm/lib/src/main/resources/
 
       - name: "Download Windows native libraries from previous job"
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: artifact-windows
           path: ./bdk-jvm/lib/src/main/resources/

--- a/.github/workflows/publish-python.yaml
+++ b/.github/workflows/publish-python.yaml
@@ -169,7 +169,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: "Download artifacts in dist/ directory"
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: dist/
 


### PR DESCRIPTION
This is a cherry-pick of the fix we applied on the beta 7 release branch.