### PR TITLE
Print satoshi amounts in all tests

### DIFF
--- a/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/LiveWalletTest.kt
+++ b/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/LiveWalletTest.kt
@@ -50,8 +50,8 @@ class LiveWalletTest {
         for (tx in transactions) {
             val sentAndReceived = wallet.sentAndReceived(tx.transaction)
             println("Transaction: ${tx.transaction.computeTxid()}")
-            println("Sent ${sentAndReceived.sent}")
-            println("Received ${sentAndReceived.received}")
+            println("Sent ${sentAndReceived.sent.toSat()}")
+            println("Received ${sentAndReceived.received.toSat()}")
         }
     }
 

--- a/bdk-jvm/lib/src/test/kotlin/org/bitcoindevkit/LiveWalletTest.kt
+++ b/bdk-jvm/lib/src/test/kotlin/org/bitcoindevkit/LiveWalletTest.kt
@@ -53,8 +53,8 @@ class LiveWalletTest {
         for (tx in transactions) {
             val sentAndReceived = wallet.sentAndReceived(tx.transaction)
             println("Transaction: ${tx.transaction.computeTxid()}")
-            println("Sent ${sentAndReceived.sent}")
-            println("Received ${sentAndReceived.received}")
+            println("Sent ${sentAndReceived.sent.toSat()}")
+            println("Received ${sentAndReceived.received.toSat()}")
         }
     }
 
@@ -91,7 +91,7 @@ class LiveWalletTest {
         println("Txid is: ${tx.computeTxid()}")
 
         val txFee: Amount = wallet.calculateFee(tx)
-        println("Tx fee is: ${txFee}")
+        println("Tx fee is: ${txFee.toSat()}")
 
         val feeRate: FeeRate = wallet.calculateFeeRate(tx)
         println("Tx fee rate is: ${feeRate.toSatPerVbCeil()} sat/vB")

--- a/bdk-python/.gitignore
+++ b/bdk-python/.gitignore
@@ -14,3 +14,4 @@ src/bdkpython/*.so
 build/
 
 testing-setup-py-simple-example.py
+localenvironment/

--- a/bdk-swift/Tests/BitcoinDevKitTests/LiveWalletTests.swift
+++ b/bdk-swift/Tests/BitcoinDevKitTests/LiveWalletTests.swift
@@ -110,7 +110,7 @@ final class LiveWalletTests: XCTestCase {
         let tx: Transaction = try! psbt.extractTx()
         print(tx.computeTxid())
         let fee: Amount = try wallet.calculateFee(tx: tx)
-        print("Transaction Fee: \(fee)")
+        print("Transaction Fee: \(fee.toSat())")
         let feeRate: FeeRate = try wallet.calculateFeeRate(tx: tx)
         print("Transaction Fee Rate: \(feeRate.toSatPerVbCeil()) sat/vB")
 


### PR DESCRIPTION
Small fixes to print statements I keep seeing when I run tests locally, where we print statement shows the `Amount` type name instead of the satoshi amount.

Python was also giving me a ton of grief because of the new requirements that packages be installed at the virtual environment level rather than globally (not a bad thing, just a darn mess to deal with when you're not writing Python all day every day). Anyway I created a local virtual environment that I will leave in my repo for ease of use but I needed to add that to the gitignore.