### PR TITLE
Add get_block_hash to esplora

### DIFF
--- a/bdk-ffi/src/bdk.udl
+++ b/bdk-ffi/src/bdk.udl
@@ -1120,6 +1120,10 @@ interface EsploraClient {
   /// blocks) and the value is the estimated feerate (in sat/vB).
   [Throws=EsploraError]
   record<u16, f64> get_fee_estimates();
+
+  /// Get the [`BlockHash`] of a specific block height
+  [Throws=EsploraError]
+  string get_block_hash(u32 block_height);
 };
 
 // ------------------------------------------------------------------------

--- a/bdk-ffi/src/esplora.rs
+++ b/bdk-ffi/src/esplora.rs
@@ -97,4 +97,11 @@ impl EsploraClient {
     pub fn get_fee_estimates(&self) -> Result<HashMap<u16, f64>, EsploraError> {
         self.0.get_fee_estimates().map_err(EsploraError::from)
     }
+
+    pub fn get_block_hash(&self, block_height: u32) -> Result<String, EsploraError> {
+        self.0
+            .get_block_hash(block_height)
+            .map(|hash| hash.to_string())
+            .map_err(EsploraError::from)
+    }
 }


### PR DESCRIPTION
<!-- Erase any parts of this template not applicable to your Pull Request. -->

### Description

Add [get_block_hash](https://docs.rs/esplora-client/0.11.0/esplora_client/blocking/struct.BlockingClient.html#method.get_block_hash) to Esplora.

### Notes to the reviewers

Related to #662

### Changelog notice

```
Added:
    - Expose EsploraClient::get_block_hash method [#665]

[#665]: https://github.com/bitcoindevkit/bdk-ffi/pull/665
```

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
