### PR TITLE
feat: add testnet4 network

### DIFF
--- a/bdk-ffi/Cargo.lock
+++ b/bdk-ffi/Cargo.lock
@@ -261,9 +261,9 @@ dependencies = [
 
 [[package]]
 name = "bitcoin"
-version = "0.32.2"
+version = "0.32.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea507acc1cd80fc084ace38544bbcf7ced7c2aa65b653b102de0ce718df668f6"
+checksum = "ce6bc65742dea50536e35ad42492b234c27904a27f0abdcbce605015cb4ea026"
 dependencies = [
  "base58ck",
  "base64 0.21.7",
@@ -281,7 +281,7 @@ dependencies = [
 [[package]]
 name = "bitcoin-ffi"
 version = "0.1.2"
-source = "git+https://github.com/bitcoindevkit/bitcoin-ffi?tag=v0.1.2#402a23a94424c9ca554874d58499d5b5709fd593"
+source = "git+https://github.com/reez/bitcoin-ffi.git?branch=t4#4583cb2cacc543384d8eaf602e62316962b17f3f"
 dependencies = [
  "bitcoin",
  "thiserror",

--- a/bdk-ffi/Cargo.toml
+++ b/bdk-ffi/Cargo.toml
@@ -22,7 +22,7 @@ bdk_wallet = { version = "1.0.0", features = ["all-keys", "keys-bip39", "rusqlit
 bdk_core = { version = "0.4.1" }
 bdk_esplora = { version = "0.20.1", default-features = false, features = ["std", "blocking", "blocking-https-rustls"] }
 bdk_electrum = { version = "0.20.1", default-features = false, features = ["use-rustls-ring"] }
-bitcoin-ffi = { git = "https://github.com/bitcoindevkit/bitcoin-ffi", tag = "v0.1.2" }
+bitcoin-ffi = { git = "https://github.com/reez/bitcoin-ffi.git", branch = "t4" }
 
 uniffi = { version = "=0.28.0" }
 thiserror = "1.0.58"


### PR DESCRIPTION
<!-- Erase any parts of this template not applicable to your Pull Request. -->

### Description

Resolves #663 

Testnets are tough right now, testnet4 is another option we should give people to help them build with bdk-ffi.

@valuedmammal added this same thing it in [bdk](https://github.com/bitcoindevkit/bdk/pull/1805), which was included in the [bdk_wallet 1.1 release](https://github.com/bitcoindevkit/bdk/releases/tag/wallet-1.1.0)

We should have it in bdk-ffi as well.

Currently we rely on bitcoin-ffi for our `Network` type so I think our only option if we use bitcoin-ffi is to [update bitcoin-ffi](https://github.com/bitcoindevkit/bitcoin-ffi/pull/31) and then pull that new version of bitcoin-ffi with testnet4 into bdk-ffi.

### Notes to the reviewers

Points to a PR branch in bitcoin-ffi.

### Changelog notice

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
