### PR TITLE
Fix LiveTransactionTest JVM test name

### DIFF
--- a/bdk-jvm/lib/src/test/kotlin/org/bitcoindevkit/LiveTransactionTest.kt
+++ b/bdk-jvm/lib/src/test/kotlin/org/bitcoindevkit/LiveTransactionTest.kt
@@ -6,7 +6,7 @@ import org.rustbitcoin.bitcoin.Network
 private const val SIGNET_ESPLORA_URL = "http://signet.bitcoindevkit.net"
 private const val TESTNET_ESPLORA_URL = "https://esplora.testnet.kuutamo.cloud"
 
-class LiveTransactionTests {
+class LiveTransactionTest {
     private val descriptor: Descriptor = Descriptor(
         "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/0/*)",
         Network.SIGNET


### PR DESCRIPTION
The test was incorrectly named (with an `s` at the end) and so was not excluded as a live test from the CI runs. This fixes that.