### PR TITLE
Use macros where possible

### DIFF
--- a/bdk-ffi/src/bitcoin.rs
+++ b/bdk-ffi/src/bitcoin.rs
@@ -200,17 +200,8 @@ impl Display for Address {
     }
 }
 
-impl From<Address> for BdkAddress {
-    fn from(address: Address) -> Self {
-        address.0
-    }
-}
-
-impl From<BdkAddress> for Address {
-    fn from(address: BdkAddress) -> Self {
-        Address(address)
-    }
-}
+impl_from_core_type!(BdkAddress, Address);
+impl_into_core_type!(Address, BdkAddress);
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Transaction(BdkTransaction);

--- a/bdk-ffi/src/types.rs
+++ b/bdk-ffi/src/types.rs
@@ -28,6 +28,7 @@ use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::sync::{Arc, Mutex};
 
+use crate::{impl_from_core_type, impl_into_core_type};
 use bdk_esplora::esplora_client::api::Tx as BdkTx;
 use bdk_esplora::esplora_client::api::TxStatus as BdkTxStatus;
 
@@ -264,16 +265,10 @@ pub struct KeychainAndIndex {
 /// Descriptor spending policy
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Policy(BdkPolicy);
-impl From<BdkPolicy> for Policy {
-    fn from(value: BdkPolicy) -> Self {
-        Policy(value)
-    }
-}
-impl From<Policy> for BdkPolicy {
-    fn from(value: Policy) -> Self {
-        value.0
-    }
-}
+
+impl_from_core_type!(BdkPolicy, Policy);
+impl_into_core_type!(Policy, BdkPolicy);
+
 impl Policy {
     pub fn id(&self) -> String {
         self.0.id.clone()


### PR DESCRIPTION
We brought in the macros from bitcoin-ffi in #673. This PR makes use of them on types that can.