### PR TITLE
Prepare 1.1.0-rc.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
+# Rust related
 target
 build
+
+# Kotlin related
 .gradle
 wallet_db
 bdk_ffi_test
@@ -9,13 +12,12 @@ local.properties
 *.so
 .DS_Store
 testdb
-xcuserdata
 .lsp
 .clj-kondo
 .idea/
 .editorconfig
 bdk.kt
-bitcoin.kt
+.kotlin/
 
 # Swift related
 /.build
@@ -35,12 +37,10 @@ bdk.swift
 .build
 *.xcframework/
 Info.plist
-BitcoinFFI.h
-Bitcoin.swift
-BitcoinFFi.modulemap
 bdkffi.xcframework
 Sources/
+xcuserdata
 
 # Python related
 __pycache__
-bitcoin.py
+.localenvironment/

--- a/bdk-android/gradle.properties
+++ b/bdk-android/gradle.properties
@@ -2,5 +2,6 @@ org.gradle.jvmargs=-Xmx1536m
 android.useAndroidX=true
 android.enableJetifier=true
 kotlin.code.style=official
-libraryVersion=1.0.0-beta.8-SNAPSHOT
+libraryVersion=1.1.0-rc.1
 org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
+org.jetbrains.dokka.experimental.gradle.pluginMode.noWarn=true

--- a/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/LiveTxBuilderTest.kt
+++ b/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/LiveTxBuilderTest.kt
@@ -7,7 +7,6 @@ import org.junit.runner.RunWith
 import kotlin.test.AfterTest
 import kotlin.test.assertTrue
 import java.io.File
-import org.rustbitcoin.bitcoin.FeeRate
 
 private const val SIGNET_ESPLORA_URL = "http://signet.bitcoindevkit.net"
 private const val TESTNET_ESPLORA_URL = "https://esplora.testnet.kuutamo.cloud"

--- a/bdk-ffi/Cargo.lock
+++ b/bdk-ffi/Cargo.lock
@@ -121,7 +121,7 @@ dependencies = [
 
 [[package]]
 name = "bdk-ffi"
-version = "1.0.0-beta.7"
+version = "1.1.0-rc.1"
 dependencies = [
  "assert_matches",
  "bdk_core",

--- a/bdk-ffi/Cargo.toml
+++ b/bdk-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk-ffi"
-version = "1.0.0-beta.7"
+version = "1.1.0-rc.1"
 homepage = "https://bitcoindevkit.org"
 repository = "https://github.com/bitcoindevkit/bdk"
 edition = "2018"

--- a/bdk-jvm/gradle.properties
+++ b/bdk-jvm/gradle.properties
@@ -1,5 +1,6 @@
 org.gradle.jvmargs=-Xmx1536m
 android.enableJetifier=true
 kotlin.code.style=official
-libraryVersion=1.0.0-beta.8-SNAPSHOT
+libraryVersion=1.1.0-rc.1
 org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
+org.jetbrains.dokka.experimental.gradle.pluginMode.noWarn=true

--- a/bdk-python/setup.py
+++ b/bdk-python/setup.py
@@ -18,7 +18,7 @@ import bdkpython as bdk
 
 setup(
     name="bdkpython",
-    version="1.0.0b8.dev",
+    version="1.1.0rc1",
     description="The Python language bindings for the Bitcoin Development Kit",
     long_description=LONG_DESCRIPTION,
     long_description_content_type="text/markdown",

--- a/bdk-python/tests/test_live_tx_builder.py
+++ b/bdk-python/tests/test_live_tx_builder.py
@@ -9,6 +9,8 @@ from bdkpython import Psbt
 from bdkpython import TxBuilder
 from bdkpython import Connection
 from bdkpython import Network
+from bdkpython import Amount
+from bdkpython import FeeRate
 
 import unittest
 import os

--- a/bdk-python/tests/test_live_wallet.py
+++ b/bdk-python/tests/test_live_wallet.py
@@ -8,6 +8,8 @@ from bdkpython import Psbt
 from bdkpython import TxBuilder
 from bdkpython import Connection
 from bdkpython import Network
+from bdkpython import Amount
+from bdkpython import FeeRate
 
 import unittest
 import os

--- a/bdk-swift/build-xcframework.sh
+++ b/bdk-swift/build-xcframework.sh
@@ -5,8 +5,6 @@
 
 HEADERPATH="Sources/BitcoinDevKit/BitcoinDevKitFFI.h"
 MODMAPPATH="Sources/BitcoinDevKit/BitcoinDevKitFFI.modulemap"
-HEADERPATH_BITCOIN_FFI="Sources/BitcoinDevKit/BitcoinFFI.h"
-MODMAPPATH_BITCOIN_FFI="Sources/BitcoinDevKit/BitcoinFFI.modulemap"
 TARGETDIR="../bdk-ffi/target"
 OUTDIR="."
 RELDIR="release-smaller"
@@ -46,11 +44,8 @@ cd ../bdk-swift/ || exit
 # move bdk-ffi static lib header files to temporary directory
 mkdir -p "${NEW_HEADER_DIR}"
 mv "${HEADERPATH}" "${NEW_HEADER_DIR}"
-mv "${HEADERPATH_BITCOIN_FFI}" "${NEW_HEADER_DIR}"
 mv "${MODMAPPATH}" "${NEW_HEADER_DIR}/module.modulemap"
 echo -e "\n" >> "${NEW_HEADER_DIR}/module.modulemap"
-cat "${MODMAPPATH_BITCOIN_FFI}" >> "${NEW_HEADER_DIR}/module.modulemap"
-rm "${MODMAPPATH_BITCOIN_FFI}"
 
 # remove old xcframework directory
 rm -rf "${OUTDIR}/${NAME}.xcframework"


### PR DESCRIPTION
This PR bumps the library versions to `1.1.0-rc.1`.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
