### PR TITLE
Make justfiles awesome

### DIFF
--- a/.github/workflows/test-swift.yaml
+++ b/.github/workflows/test-swift.yaml
@@ -24,4 +24,4 @@ jobs:
 
       - name: "Run Swift tests"
         working-directory: bdk-swift
-        run: swift test --skip LiveElectrumClientTests --skip LiveMemoryWalletTests --skip LiveTransactionTests --skip LiveTxBuilderTests --skip LiveWalletTests
+        run: swift test --filter Offline

--- a/bdk-android/justfile
+++ b/bdk-android/justfile
@@ -1,29 +1,45 @@
-default:
-  just --list
+[group("Repo")]
+[doc("Default command; list all available commands.")]
+@list:
+  just --list --unsorted
 
-build-linux:
-  bash ./scripts/build-linux-x86_64.sh
+[group("Repo")]
+[doc("Open repo on GitHub in your default browser.")]
+repo:
+  open https://github.com/bitcoindevkit/bdk-ffi
 
-build-macos:
-  bash ./scripts/build-macos-aarch64.sh
+[group("Repo")]
+[doc("Build the API docs.")]
+docs:
+  ./gradlew :lib:dokkaGeneratePublicationHtml
 
-build-windows:
-  bash ./scripts/build-windows-x86_64.sh
+[group("Repo")]
+[doc("Publish the library to your local Maven repository.")]
+publish-local:
+  ./gradlew publishToMavenLocal -P localBuild
 
+[group("Build")]
+[doc("Build the library for given ARCH.")]
+build ARCH="macos-aarch64":
+  bash ./scripts/build-{{ARCH}}.sh
+
+[group("Build")]
+[doc("List available architectures for the build command.")]
+@list-architectures:
+    echo "Available architectures:"
+    echo "    - linux-x86_64"
+    echo "    - macos-aarch64"
+    echo "    - windows-x86_64"
+
+[group("Build")]
+[doc("Remove all caches and previous build directories to start from scratch.")]
 clean:
   rm -rf ../bdk-ffi/target/
   rm -rf ./build/
   rm -rf ./lib/build/
   rm -rf ./plugins/build/
 
-publish-local:
-  ./gradlew publishToMavenLocal -P localBuild
-
+[group("Test")]
+[doc("Run all tests.")]
 test:
   ./gradlew connectedAndroidTest
-
-test-specific TEST:
-  ./gradlew test --tests {{TEST}}
-
-build-docs:
-  ./gradlew :lib:dokkaGeneratePublicationHtml

--- a/bdk-jvm/justfile
+++ b/bdk-jvm/justfile
@@ -1,34 +1,50 @@
-default:
-  just --list
+[group("Repo")]
+[doc("Default command; list all available commands.")]
+@list:
+  just --list --unsorted
 
-build-linux:
-  bash ./scripts/build-linux-x86_64.sh
+[group("Repo")]
+[doc("Open repo on GitHub in your default browser.")]
+repo:
+  open https://github.com/bitcoindevkit/bdk-ffi
 
-build-macos-aarch64:
-  bash ./scripts/build-macos-aarch64.sh
+[group("Repo")]
+[doc("Build the API docs.")]
+docs:
+  ./gradlew :lib:dokkaGeneratePublicationHtml
 
-build-macos-x86_64:
-  bash ./scripts/build-macos-x86_64.sh
-  
-build-windows:
-  bash ./scripts/build-windows-x86_64.sh
+[group("Repo")]
+[doc("Publish the library to your local Maven repository.")]
+publish-local:
+  ./gradlew publishToMavenLocal -P localBuild
 
+[group("Build")]
+[doc("Build the library for given ARCH.")]
+build ARCH="macos-aarch64":
+  bash ./scripts/build-{{ARCH}}.sh
+
+[group("Build")]
+[doc("List available architectures for the build command.")]
+@list-architectures:
+    echo "Available architectures:"
+    echo "    - linux-x86_64"
+    echo "    - macos-aarch64"
+    echo "    - macos-x86_64"
+    echo "    - windows-x86_64"
+
+[group("Build")]
+[doc("Remove all caches and previous build directories to start from scratch.")]
 clean:
   rm -rf ../bdk-ffi/target/
   rm -rf ./build/
   rm -rf ./lib/build/
 
-publish-local:
-  ./gradlew publishToMavenLocal -P localBuild
+[group("Test")]
+[doc("Run all tests, unless a specific test is provided.")]
+test *TEST:
+  ./gradlew test {{ if TEST == "" { "" } else { "--tests " + TEST } }}
 
-test:
-  ./gradlew test
-
+[group("Test")]
+[doc("Run only offline tests.")]
 test-offline:
   ./gradlew test -P excludeConnectedTests
-
-test-specific TEST:
-  ./gradlew test --tests {{TEST}}
-
-build-docs:
-  ./gradlew :lib:dokkaGeneratePublicationHtml

--- a/bdk-python/justfile
+++ b/bdk-python/justfile
@@ -1,14 +1,22 @@
-default:
-  just --list
+[group("Repo")]
+[doc("Default command; list all available commands.")]
+@list:
+  just --list --unsorted
 
-build-local-mac:
-  bash ./scripts/generate-macos-arm64.sh && python3 setup.py bdist_wheel --verbose
+[group("Repo")]
+[doc("Open repo on GitHub in your default browser.")]
+repo:
+  open https://github.com/bitcoindevkit/bdk-ffi
 
+[group("Build")]
+[doc("Remove all caches and previous builds to start from scratch.")]
 clean:
   rm -rf ../bdk-ffi/target/
   rm -rf ./bdkpython.egg-info/
   rm -rf ./build/
   rm -rf ./dist/
 
+[group("Test")]
+[doc("Run all tests.")]
 test:
   python3 -m unittest --verbose

--- a/bdk-swift/justfile
+++ b/bdk-swift/justfile
@@ -1,14 +1,29 @@
-default:
-  just --list
+[group("Repo")]
+[doc("Default command; list all available commands.")]
+@list:
+  just --list --unsorted
 
+[group("Repo")]
+[doc("Open repo on GitHub in your default browser.")]
+repo:
+  open https://github.com/bitcoindevkit/bdk-ffi
+
+[group("Build")]
+[doc("Build the library.")]
 build:
   bash ./build-xcframework.sh
 
+[group("Build")]
+[doc("Remove all caches and previous builds to start from scratch.")]
 clean:
   rm -rf ../bdk-ffi/target/
 
-test:
-  swift test
+[group("Test")]
+[doc("Run all tests, unless a filter is provided.")]
+test *FILTER:
+  swift test {{ if FILTER == "" { "" } else { "--filter " + FILTER } }}
 
+[group("Test")]
+[doc("Run only offline tests.")]
 test-offline:
-  swift test --skip LiveElectrumClientTests --skip LiveMemoryWalletTests --skip LiveTransactionTests --skip LiveTxBuilderTests --skip LiveWalletTests
+  swift test --filter Offline


### PR DESCRIPTION
This PR brings in significant improvements to the justfiles.

See for yourself by running the `just` command in all 4 main directories, which will list the available commands well grouped and documented. Of note are the cleaning up of the ever-tiresome `build` commands which had to be qualified per architecture. The command now accepts an argument you can pass for the architecture you want to build on, but also has a default argument of `macos-aarch64`, which is I think what the devs on this team use the most. You can therefore call `just build` if you are on a mac with silicon chip and it will work.
