### PR TITLE
Expose `ElectrumClient::ping` method

### DIFF
--- a/bdk-ffi/src/bdk.udl
+++ b/bdk-ffi/src/bdk.udl
@@ -1234,6 +1234,10 @@ interface ElectrumClient {
   /// Subscribes to notifications for new block headers, by sending a blockchain.headers.subscribe call.
   [Throws=ElectrumError]
   HeaderNotification block_headers_subscribe();
+
+  /// Pings the server.
+  [Throws=ElectrumError]
+  void ping();
 };
 
 /// Response to an ElectrumClient.server_features request.

--- a/bdk-ffi/src/electrum.rs
+++ b/bdk-ffi/src/electrum.rs
@@ -120,6 +120,10 @@ impl ElectrumClient {
             .map_err(ElectrumError::from)
             .map(HeaderNotification::from)
     }
+
+    pub fn ping(&self) -> Result<(), ElectrumError> {
+        self.0.inner.ping().map_err(ElectrumError::from)
+    }
 }
 
 pub struct ServerFeaturesRes {

--- a/bdk-jvm/lib/src/test/kotlin/org/bitcoindevkit/LiveElectrumClientTest.kt
+++ b/bdk-jvm/lib/src/test/kotlin/org/bitcoindevkit/LiveElectrumClientTest.kt
@@ -58,4 +58,12 @@ class LiveElectrumClientTest {
         val headerNotification: HeaderNotification = electrumClient.blockHeadersSubscribe()
         println("Latest known block:\n$headerNotification")
     }
+
+    @Test
+    fun testPing() {
+        val electrumClient: ElectrumClient = ElectrumClient("ssl://electrum.blockstream.info:60002")
+        val ping = electrumClient.ping()
+
+        assert(ping == Unit)
+    }
 }


### PR DESCRIPTION
Somehow I had forgotten this one as part of #662.

The ping either returns the unit type or an error.

### Changelog notice

```md
Added:
    - New `ElectrumClient::ping` method [#689]

[#689]: https://github.com/bitcoindevkit/bdk-ffi/pull/689
```

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [x] I've added tests for the new feature
* [x] I've added docs for the new feature
