### PR TITLE
Small post-release fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,6 +161,11 @@ This release is the first alpha release of the 1.0 API for the bindings librarie
 - Create and sign transactions using the transaction builder
 - Broadcast transactions
 
+## [v0.32.1]
+This is a patch release, updating the bindings libraries to bdk version 0.30.2, fixing an issue with syncing very large wallets.
+
+See https://github.com/bitcoindevkit/bdk/releases/tag/v0.30.2 for details.
+
 ## [v0.31.0]
 This release updates the bindings libraries to bdk version 0.29.0, updating rust-bitcoin to version 0.30.2.
 
@@ -398,6 +403,7 @@ This release has a number of new APIs, and adds support for Windows in bdk-jvm.
 [v1.0.0-alpha.11]: https://github.com/bitcoindevkit/bdk-ffi/compare/v1.0.0-alpha.7...v1.0.0-alpha.11
 [v1.0.0-alpha.7]: https://github.com/bitcoindevkit/bdk-ffi/compare/v1.0.0-alpha.2a...v1.0.0-alpha.7
 [v1.0.0-alpha.2a]: https://github.com/bitcoindevkit/bdk-ffi/compare/v0.31.0...v1.0.0-alpha.2a
+[v0.32.1]: (https://github.com/bitcoindevkit/bdk-ffi/compare/v0.32.0...v0.32.1)
 [v0.31.0]: https://github.com/bitcoindevkit/bdk-ffi/compare/v0.30.0...v0.31.0
 [v0.30.0]: https://github.com/bitcoindevkit/bdk-ffi/compare/v0.29.0...v0.30.0
 [v0.29.0]: https://github.com/bitcoindevkit/bdk-ffi/compare/v0.28.0...v0.29.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,36 @@ Changelog information can also be found in each release's git tag (which can be 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.1.0]
+
+This is our first stable release!
+
+This release uses the following Rust dependencies:
+    - bdk_wallet 1.1.0
+    - bdk_electrum 0.21.0
+    - bdk_esplora 0.20.1
+    - uniffi 0.29.0
+    - rust-bitcoin 0.32.5
+
+#### Added
+    - Expose `ElectrumClient::block_headers_subscribe` method [#664]
+    - Expose `EsploraClient::get_block_hash` method [#665]
+    - Expose `EsploraClient::get_tx_status` method [#666]
+    - Expose `EsploraClient::get_tx_info` method [#666]
+    - Support for Testnet 4 [#674]
+    - Add `AddressData` and `WitnessProgram` types from rust bitcoin [#671]
+    - Expose `Address::to_address_data` method [#671]
+
+#### Changed
+    - More complete `LocalOutput` type [#667]
+
+[#664]: https://github.com/bitcoindevkit/bdk-ffi/pull/664
+[#665]: https://github.com/bitcoindevkit/bdk-ffi/pull/665
+[#666]: https://github.com/bitcoindevkit/bdk-ffi/pull/666
+[#667]: https://github.com/bitcoindevkit/bdk-ffi/pull/667
+[#671]: https://github.com/bitcoindevkit/bdk-ffi/pull/671
+[#674]: https://github.com/bitcoindevkit/bdk-ffi/pull/674
+
 ## [v1.0.0-beta.7]
 This release updates the `bdk-ffi` libraries to the final `bdk_wallet` `1.0.0` and related libraries (Esplora, Electrum, etc).
 
@@ -396,6 +426,7 @@ This release has a number of new APIs, and adds support for Windows in bdk-jvm.
 
 [BIP 0174]:https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki#encoding
 
+[v1.1.0]: https://github.com/bitcoindevkit/bdk-ffi/compare/v1.0.0-beta.7...v1.1.0
 [v1.0.0-beta.7]: https://github.com/bitcoindevkit/bdk-ffi/compare/v1.0.0-beta.6...v1.0.0-beta.7
 [v1.0.0-beta.6]: https://github.com/bitcoindevkit/bdk-ffi/compare/v1.0.0-beta.5...v1.0.0-beta.6
 [v1.0.0-beta.5]: https://github.com/bitcoindevkit/bdk-ffi/compare/v1.0.0-beta.2...v1.0.0-beta.5

--- a/bdk-android/README.md
+++ b/bdk-android/README.md
@@ -1,8 +1,11 @@
 # bdk-android
-This project builds an .aar package for the Android platform that provide Kotlin language bindings for the [`bdk`] library. The Kotlin language bindings are created by the [`bdk-ffi`] project which is included in the root of this repository.
+
+This project builds an .aar package for the Android platform that provide Kotlin language bindings for the [BDK] libraries. The Kotlin language bindings are created by the [`bdk-ffi`] project which is included in the root of this repository.
 
 ## How to Use
-To use the Kotlin language bindings for [`bdk`] in your Android project add the following to your gradle dependencies:
+
+To use the Kotlin language bindings for BDK in your Android project add the following to your gradle dependencies:
+
 ```kotlin
 repositories {
     mavenCentral()
@@ -14,6 +17,7 @@ dependencies {
 ```
 
 ### Snapshot releases
+
 To use a snapshot release, specify the snapshot repository url in the `repositories` block and use the snapshot version in the `dependencies` block:
 ```kotlin
 repositories {
@@ -26,49 +30,48 @@ dependencies {
 ```
 
 ### Example Projects
-* [bdk-kotlin-example-wallet](https://github.com/bitcoindevkit/bdk-kotlin-example-wallet)
-* [Devkit Wallet](https://github.com/thunderbiscuit/devkit-wallet)
+
+* [Devkit Wallet](https://github.com/bitcoindevkit/devkit-wallet)
 * [Padawan Wallet](https://github.com/thunderbiscuit/padawan-wallet)
 
 ### How to build
-_Note that Kotlin version `1.9.23` or later is required to build the library._
+
+_Note that Kotlin version `2.1.10` or later is required to build the library._
 
 1. Clone this repository.
 ```shell
 git clone https://github.com/bitcoindevkit/bdk-ffi
 ```
-2. Follow the "General" bdk-ffi ["Getting Started (Developer)"] instructions. 
-3. Install Android SDK and Build-Tools for API level 30+
-4. Setup `ANDROID_SDK_ROOT` and `ANDROID_NDK_ROOT` path variables which are required by the build tool. Note that currently, NDK version 25.2.9519653 or above is required. For example:
+2. Install Android SDK and Build-Tools for API level 30+
+3. Setup `ANDROID_SDK_ROOT` and `ANDROID_NDK_ROOT` path variables which are required by the build tool. Note that currently, NDK version 25.2.9519653 or above is required. For example:
 ```shell
 # macOS
 export ANDROID_SDK_ROOT=~/Library/Android/sdk
 export ANDROID_NDK_ROOT=$ANDROID_SDK_ROOT/ndk/25.2.9519653
 
-# linux
+# Linux
 export ANDROID_SDK_ROOT=/usr/local/lib/android/sdk
 export ANDROID_NDK_ROOT=$ANDROID_SDK_ROOT/ndk/25.2.9519653
 ```
-
-7. Build kotlin bindings
+4. Build Kotlin bindings
 ```sh
 # build Android library
 cd bdk-android
 bash ./scripts/build-<your-local-architecture>.sh
 ```
-
-8. Start android emulator and run tests
+5. Start android emulator and run tests
 ```sh
 ./gradlew connectedAndroidTest
 ```
 
 ## How to publish to your local Maven repo
+
 ```shell
 cd bdk-android
 ./gradlew publishToMavenLocal -P localBuild
 ```
 
-Note that the commands assume you don't need the local libraries to be signed. If you do wish to sign them, simply set your `~/.gradle/gradle.properties` signing key values like so:
+Note that the command above assumes you don't need the local libraries to be signed. If you do wish to sign them, simply set your `~/.gradle/gradle.properties` signing key values like so:
 ```properties
 signing.gnupg.keyName=<YOUR_GNUPG_ID>
 signing.gnupg.passphrase=<YOUR_GNUPG_PASSPHRASE>
@@ -80,12 +83,17 @@ and use the `publishToMavenLocal` task without the `localBuild` flag:
 ```
 
 ## Known issues
+
 ### JNA dependency
+
 Depending on the JVM version you use, you might not have the JNA dependency on your classpath. The exception thrown will be
+
 ```shell
 class file for com.sun.jna.Pointer not found
 ```
+
 The solution is to add JNA as a dependency like so:
+
 ```kotlin
 dependencies {
     implementation("net.java.dev.jna:jna:5.12.1")
@@ -93,7 +101,8 @@ dependencies {
 ```
 
 ### x86 emulators
+
 For some older versions of macOS, Android Studio will recommend users install the x86 version of the emulator by default. This will not work with the bdk-android library, as we do not support 32-bit architectures. Make sure you install an x86_64 emulator to work with bdk-android.
 
-[`bdk`]: https://github.com/bitcoindevkit/bdk
+[BDK]: https://github.com/bitcoindevkit/
 [`bdk-ffi`]: https://github.com/bitcoindevkit/bdk-ffi

--- a/bdk-android/gradle.properties
+++ b/bdk-android/gradle.properties
@@ -2,6 +2,6 @@ org.gradle.jvmargs=-Xmx1536m
 android.useAndroidX=true
 android.enableJetifier=true
 kotlin.code.style=official
-libraryVersion=1.0.0-beta.8-SNAPSHOT
+libraryVersion=1.2.0-SNAPSHOT
 org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 org.jetbrains.dokka.experimental.gradle.pluginMode.noWarn=true

--- a/bdk-android/gradle.properties
+++ b/bdk-android/gradle.properties
@@ -4,3 +4,4 @@ android.enableJetifier=true
 kotlin.code.style=official
 libraryVersion=1.0.0-beta.8-SNAPSHOT
 org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
+org.jetbrains.dokka.experimental.gradle.pluginMode.noWarn=true

--- a/bdk-android/lib/README.md
+++ b/bdk-android/lib/README.md
@@ -4,4 +4,4 @@ The [bitcoindevkit](https://bitcoindevkit.org/) language bindings library for Ko
 
 # Package org.bitcoindevkit
 
-The types coming from BDK directly. The functionality exposed in this package is in fact a combination of the [bdk_wallet](https://crates.io/crates/bdk_wallet), [bdk_core](https://crates.io/crates/bdk_core), [bdk_electrum](https://crates.io/crates/bdk_electrum), and [bdk_esplora](https://crates.io/crates/bdk_esplora) crates.
+The functionality exposed in this package is in fact a combination of the [bdk_wallet](https://crates.io/crates/bdk_wallet), [bdk_core](https://crates.io/crates/bdk_core), [bdk_electrum](https://crates.io/crates/bdk_electrum), [bdk_esplora](https://crates.io/crates/bdk_esplora), [bitcoin](https://crates.io/crates/bitcoin), and [miniscript](https://crates.io/crates/miniscript) crates.

--- a/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/LiveTxBuilderTest.kt
+++ b/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/LiveTxBuilderTest.kt
@@ -14,8 +14,8 @@ private const val TESTNET_ESPLORA_URL = "https://esplora.testnet.kuutamo.cloud"
 @RunWith(AndroidJUnit4::class)
 class LiveTxBuilderTest {
     private val persistenceFilePath = InstrumentationRegistry.getInstrumentation().targetContext.filesDir.path + "/bdk_persistence3.sqlite"
-    private val descriptor = Descriptor("wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/0/*)", Network.SIGNET)
-    private val changeDescriptor = Descriptor("wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/1/*)", Network.SIGNET)
+    private val descriptor = Descriptor("wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/1h/0/*)", Network.SIGNET)
+    private val changeDescriptor = Descriptor("wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/1h/1/*)", Network.SIGNET)
 
     @AfterTest
     fun cleanup() {

--- a/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/LiveWalletTest.kt
+++ b/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/LiveWalletTest.kt
@@ -15,8 +15,8 @@ private const val TESTNET_ESPLORA_URL = "https://esplora.testnet.kuutamo.cloud"
 class LiveWalletTest {
     private val persistenceFilePath = InstrumentationRegistry
         .getInstrumentation().targetContext.filesDir.path + "/bdk_persistence2.sqlite"
-    private val descriptor: Descriptor = Descriptor("wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/0/*)", Network.SIGNET)
-    private val changeDescriptor: Descriptor = Descriptor("wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/1/*)", Network.SIGNET)
+    private val descriptor: Descriptor = Descriptor("wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/1h/0/*)", Network.SIGNET)
+    private val changeDescriptor: Descriptor = Descriptor("wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/1h/1/*)", Network.SIGNET)
 
     @AfterTest
     fun cleanup() {

--- a/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/OfflineWalletTest.kt
+++ b/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/OfflineWalletTest.kt
@@ -14,8 +14,8 @@ import java.io.File
 class OfflineWalletTest {
     private val persistenceFilePath = InstrumentationRegistry
         .getInstrumentation().targetContext.filesDir.path + "/bdk_persistence1.sqlite"
-    private val descriptor = Descriptor("wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/0/*)", Network.TESTNET)
-    private val changeDescriptor = Descriptor("wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/1/*)", Network.TESTNET)
+    private val descriptor = Descriptor("wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/1h/0/*)", Network.TESTNET)
+    private val changeDescriptor = Descriptor("wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/1h/1/*)", Network.TESTNET)
 
     @AfterTest
     fun cleanup() {
@@ -51,7 +51,7 @@ class OfflineWalletTest {
         assertFalse(addressInfo.address.isValidForNetwork(Network.BITCOIN), "Address is valid for bitcoin network, but it shouldn't be")
 
         assertEquals(
-            expected = "tb1qrnfslnrve9uncz9pzpvf83k3ukz22ljgees989",
+            expected = "tb1qhjys9wxlfykmte7ftryptx975uqgd6kcm6a7z4",
             actual = addressInfo.address.toString()
         )
     }

--- a/bdk-ffi/Cargo.toml
+++ b/bdk-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk-ffi"
-version = "1.0.0-beta.7"
+version = "1.2.0-dev"
 homepage = "https://bitcoindevkit.org"
 repository = "https://github.com/bitcoindevkit/bdk"
 edition = "2018"

--- a/bdk-jvm/README.md
+++ b/bdk-jvm/README.md
@@ -1,8 +1,9 @@
 # bdk-jvm
-This project builds a .jar package for the JVM platform that provides Kotlin language bindings for the [`bdk`] library. The Kotlin language bindings are created by the `bdk-ffi` project which is included in the root of this repository.
+
+This project builds a .jar package for the JVM platform that provides Kotlin language bindings for the [BDK] libraries. The Kotlin language bindings are created by the `bdk-ffi` project which is included in the root of this repository.
 
 ## How to Use
-To use the Kotlin language bindings for [`bdk`] in your JVM project add the following to your gradle dependencies:
+To use the Kotlin language bindings for BDK in your JVM project add the following to your gradle dependencies:
 ```kotlin
 repositories {
     mavenCentral()
@@ -73,5 +74,5 @@ dependencies {
 }
 ```
 
-[`bdk`]: https://github.com/bitcoindevkit/bdk
+[BDK]: https://github.com/bitcoindevkit/
 [`bdk-ffi`]: https://github.com/bitcoindevkit/bdk-ffi

--- a/bdk-jvm/gradle.properties
+++ b/bdk-jvm/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.jvmargs=-Xmx1536m
 android.enableJetifier=true
 kotlin.code.style=official
-libraryVersion=1.0.0-beta.8-SNAPSHOT
+libraryVersion=1.2.0-SNAPSHOT
 org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 org.jetbrains.dokka.experimental.gradle.pluginMode.noWarn=true

--- a/bdk-jvm/gradle.properties
+++ b/bdk-jvm/gradle.properties
@@ -3,3 +3,4 @@ android.enableJetifier=true
 kotlin.code.style=official
 libraryVersion=1.0.0-beta.8-SNAPSHOT
 org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
+org.jetbrains.dokka.experimental.gradle.pluginMode.noWarn=true

--- a/bdk-jvm/lib/README.md
+++ b/bdk-jvm/lib/README.md
@@ -4,4 +4,4 @@ The [bitcoindevkit](https://bitcoindevkit.org/) language bindings library for Ko
 
 # Package org.bitcoindevkit
 
-The types coming from BDK directly. The functionality exposed in this package is in fact a combination of the [bdk_wallet](https://crates.io/crates/bdk_wallet), [bdk_core](https://crates.io/crates/bdk_core), [bdk_electrum](https://crates.io/crates/bdk_electrum), and [bdk_esplora](https://crates.io/crates/bdk_esplora) crates.
+The functionality exposed in this package is in fact a combination of the [bdk_wallet](https://crates.io/crates/bdk_wallet), [bdk_core](https://crates.io/crates/bdk_core), [bdk_electrum](https://crates.io/crates/bdk_electrum), [bdk_esplora](https://crates.io/crates/bdk_esplora), [bitcoin](https://crates.io/crates/bitcoin), and [miniscript](https://crates.io/crates/miniscript) crates.

--- a/bdk-jvm/lib/src/test/kotlin/org/bitcoindevkit/LiveElectrumClientTest.kt
+++ b/bdk-jvm/lib/src/test/kotlin/org/bitcoindevkit/LiveElectrumClientTest.kt
@@ -8,11 +8,11 @@ private const val SIGNET_ELECTRUM_URL = "ssl://mempool.space:60602"
 
 class LiveElectrumClientTest {
     private val descriptor: Descriptor = Descriptor(
-        "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/0/*)",
+        "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/1h/0/*)",
         Network.SIGNET
     )
     private val changeDescriptor: Descriptor = Descriptor(
-        "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/1/*)",
+        "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/1h/1/*)",
         Network.SIGNET
     )
 

--- a/bdk-jvm/lib/src/test/kotlin/org/bitcoindevkit/LiveKyotoTest.kt
+++ b/bdk-jvm/lib/src/test/kotlin/org/bitcoindevkit/LiveKyotoTest.kt
@@ -13,8 +13,8 @@ import kotlin.io.path.ExperimentalPathApi
 import kotlin.io.path.deleteRecursively
 
 class LiveKyotoTest {
-    private val descriptor: Descriptor = Descriptor("wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/0/*)", Network.SIGNET)
-    private val changeDescriptor: Descriptor = Descriptor("wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/1/*)", Network.SIGNET)
+    private val descriptor: Descriptor = Descriptor("wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/1h/0/*)", Network.SIGNET)
+    private val changeDescriptor: Descriptor = Descriptor("wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/1h/1/*)", Network.SIGNET)
     private val ip: IpAddress = IpAddress.fromIpv4(68u, 47u, 229u, 218u)
     private val peer: Peer = Peer(ip, null, false)
     private val currentPath = Paths.get(".").toAbsolutePath().normalize()

--- a/bdk-jvm/lib/src/test/kotlin/org/bitcoindevkit/LiveMemoryWalletTest.kt
+++ b/bdk-jvm/lib/src/test/kotlin/org/bitcoindevkit/LiveMemoryWalletTest.kt
@@ -7,18 +7,18 @@ private const val TESTNET_ESPLORA_URL = "https://esplora.testnet.kuutamo.cloud"
 
 class LiveMemoryWalletTest {
     private val descriptor: Descriptor = Descriptor(
-        "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/0/*)",
+        "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/1h/0/*)",
         Network.SIGNET
     )
     private val changeDescriptor: Descriptor = Descriptor(
-        "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/1/*)",
+        "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/1h/1/*)",
         Network.SIGNET
     )
 
     @Test
     fun testSyncedBalance() {
         val descriptor: Descriptor = Descriptor(
-            "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/0/*)",
+            "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/1h/0/*)",
             Network.SIGNET
         )
         var conn: Connection = Connection.newInMemory()

--- a/bdk-jvm/lib/src/test/kotlin/org/bitcoindevkit/LiveTransactionTest.kt
+++ b/bdk-jvm/lib/src/test/kotlin/org/bitcoindevkit/LiveTransactionTest.kt
@@ -7,11 +7,11 @@ private const val TESTNET_ESPLORA_URL = "https://esplora.testnet.kuutamo.cloud"
 
 class LiveTransactionTest {
     private val descriptor: Descriptor = Descriptor(
-        "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/0/*)",
+        "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/1h/0/*)",
         Network.SIGNET
     )
     private val changeDescriptor: Descriptor = Descriptor(
-        "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/1/*)",
+        "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/1h/1/*)",
         Network.SIGNET
     )
 

--- a/bdk-jvm/lib/src/test/kotlin/org/bitcoindevkit/LiveTxBuilderTest.kt
+++ b/bdk-jvm/lib/src/test/kotlin/org/bitcoindevkit/LiveTxBuilderTest.kt
@@ -14,11 +14,11 @@ class LiveTxBuilderTest {
         "$currentDirectory/bdk_persistence.sqlite"
     }
     private val descriptor: Descriptor = Descriptor(
-        "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/0/*)",
+        "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/1h/0/*)",
         Network.SIGNET
     )
     private val changeDescriptor: Descriptor = Descriptor(
-        "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/1/*)",
+        "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/1h/1/*)",
         Network.SIGNET
     )
 
@@ -33,7 +33,6 @@ class LiveTxBuilderTest {
     @Test
     fun testTxBuilder() {
         val connection: Connection = Connection(persistenceFilePath)
-        val descriptor = Descriptor("wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/0/*)", Network.TESTNET)
         val wallet = Wallet(descriptor, changeDescriptor, Network.SIGNET, connection)
         val esploraClient = EsploraClient(SIGNET_ESPLORA_URL)
         val fullScanRequest: FullScanRequest = wallet.startFullScan().build()

--- a/bdk-jvm/lib/src/test/kotlin/org/bitcoindevkit/LiveWalletTest.kt
+++ b/bdk-jvm/lib/src/test/kotlin/org/bitcoindevkit/LiveWalletTest.kt
@@ -14,11 +14,11 @@ class LiveWalletTest {
         "$currentDirectory/bdk_persistence.sqlite"
     }
     private val descriptor: Descriptor = Descriptor(
-        "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/0/*)",
+        "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/1h/0/*)",
         Network.SIGNET
     )
     private val changeDescriptor: Descriptor = Descriptor(
-        "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/1/*)",
+        "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/1h/1/*)",
         Network.SIGNET
     )
 
@@ -58,7 +58,6 @@ class LiveWalletTest {
     @Test
     fun testBroadcastTransaction() {
         val connection = Connection(persistenceFilePath)
-        val descriptor = Descriptor("wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/0/*)", Network.SIGNET)
         val wallet: Wallet = Wallet(descriptor, changeDescriptor, Network.SIGNET, connection)
         val esploraClient = EsploraClient(SIGNET_ESPLORA_URL)
         val fullScanRequest: FullScanRequest = wallet.startFullScan().build()

--- a/bdk-jvm/lib/src/test/kotlin/org/bitcoindevkit/OfflineWalletTest.kt
+++ b/bdk-jvm/lib/src/test/kotlin/org/bitcoindevkit/OfflineWalletTest.kt
@@ -9,11 +9,11 @@ import java.io.File
 
 class OfflineWalletTest {
     private val descriptor: Descriptor = Descriptor(
-        "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/0/*)",
+        "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/1h/0/*)",
         Network.TESTNET
     )
     private val changeDescriptor: Descriptor = Descriptor(
-        "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/1/*)",
+        "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/1h/1/*)",
         Network.TESTNET
     )
 
@@ -43,7 +43,7 @@ class OfflineWalletTest {
         assertFalse(addressInfo.address.isValidForNetwork(Network.BITCOIN), "Address is valid for bitcoin network, but it shouldn't be")
 
         assertEquals(
-            expected = "tb1qrnfslnrve9uncz9pzpvf83k3ukz22ljgees989",
+            expected = "tb1qhjys9wxlfykmte7ftryptx975uqgd6kcm6a7z4",
             actual = addressInfo.address.toString()
         )
     }

--- a/bdk-python/README.md
+++ b/bdk-python/README.md
@@ -1,15 +1,18 @@
 # bdk-python
+
 The Python language bindings for the [bitcoindevkit](https://github.com/bitcoindevkit).
 
 See the [package on PyPI](https://pypi.org/project/bdkpython/).  
 
 ## Install from PyPI
+
 Install the latest release using
 ```shell
 pip install bdkpython
 ```
 
 ## Run the tests
+
 ```shell
 pip install --requirement requirements.txt
 bash ./scripts/generate-linux.sh # here you should run the script appropriate for your platform
@@ -19,6 +22,7 @@ python -m unittest --verbose
 ```
 
 ## Build the package
+
 ```shell
 # Install dependencies
 pip install --requirement requirements.txt
@@ -31,6 +35,7 @@ python setup.py --verbose bdist_wheel
 ```
 
 ## Install locally
+
 ```shell
 pip install ./dist/bdkpython-<yourversion>.whl
 ```

--- a/bdk-python/setup.py
+++ b/bdk-python/setup.py
@@ -18,7 +18,7 @@ from bdkpython import Wallet
 
 setup(
     name="bdkpython",
-    version="1.0.0b8.dev",
+    version="1.2.0.dev0",
     description="The Python language bindings for the Bitcoin Development Kit",
     long_description=LONG_DESCRIPTION,
     long_description_content_type="text/markdown",

--- a/bdk-python/setup.py
+++ b/bdk-python/setup.py
@@ -12,7 +12,7 @@ pip install bdkpython
 
 ## Simple example
 ```python
-import bdkpython as bdk
+from bdkpython import Wallet
 ```
 """
 

--- a/bdk-python/tests/test_live_kyoto.py
+++ b/bdk-python/tests/test_live_kyoto.py
@@ -9,11 +9,11 @@ ip: IpAddress = IpAddress.from_ipv4(68, 47, 229, 218)
 peer: Peer = Peer(address=ip, port=None, v2_transport=False)
 
 descriptor: Descriptor = Descriptor(
-    "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/0/*)",
+    "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/1h/0/*)",
     network=network
 )
 change_descriptor: Descriptor = Descriptor(
-    "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/1/*)",
+    "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/1h/1/*)",
     network=network
 )
 

--- a/bdk-python/tests/test_live_tx_builder.py
+++ b/bdk-python/tests/test_live_tx_builder.py
@@ -19,11 +19,11 @@ SIGNET_ESPLORA_URL = "http://signet.bitcoindevkit.net"
 TESTNET_ESPLORA_URL = "https://esplora.testnet.kuutamo.cloud"
 
 descriptor: Descriptor = Descriptor(
-    "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/0/*)",
+    "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/1h/0/*)",
     Network.TESTNET
 )
 change_descriptor: Descriptor = Descriptor(
-    "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/1/*)",
+    "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/1h/1/*)",
     Network.TESTNET
 )
 
@@ -34,10 +34,6 @@ class LiveTxBuilderTest(unittest.TestCase):
             os.remove("./bdk_persistence.sqlite")
 
     def test_tx_builder(self):
-        descriptor: Descriptor = Descriptor(
-            "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/0/*)",
-            Network.SIGNET
-        )
         connection: Connection = Connection.new_in_memory()
         wallet: Wallet = Wallet(
             descriptor,

--- a/bdk-python/tests/test_live_wallet.py
+++ b/bdk-python/tests/test_live_wallet.py
@@ -18,11 +18,11 @@ SIGNET_ESPLORA_URL = "http://signet.bitcoindevkit.net"
 TESTNET_ESPLORA_URL = "https://esplora.testnet.kuutamo.cloud"
 
 descriptor: Descriptor = Descriptor(
-    "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/0/*)",
+    "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/1h/0/*)",
     Network.TESTNET
 )
 change_descriptor: Descriptor = Descriptor(
-    "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/1/*)",
+    "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/1h/1/*)",
     Network.TESTNET
 )
 

--- a/bdk-python/tests/test_offline_wallet.py
+++ b/bdk-python/tests/test_offline_wallet.py
@@ -9,11 +9,11 @@ import unittest
 import os
 
 descriptor: Descriptor = Descriptor(
-    "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/0/*)",
+    "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/1h/0/*)",
     Network.TESTNET
 )
 change_descriptor: Descriptor = Descriptor(
-    "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/1/*)",
+    "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/1h/1/*)",
     Network.TESTNET
 )
 
@@ -38,7 +38,7 @@ class OfflineWalletTest(unittest.TestCase):
         self.assertFalse(address_info.address.is_valid_for_network(Network.REGTEST), "Address is valid for regtest network, but it shouldn't be")
         self.assertFalse(address_info.address.is_valid_for_network(Network.BITCOIN), "Address is valid for bitcoin network, but it shouldn't be")
     
-        self.assertEqual("tb1qrnfslnrve9uncz9pzpvf83k3ukz22ljgees989", address_info.address.__str__())
+        self.assertEqual("tb1qhjys9wxlfykmte7ftryptx975uqgd6kcm6a7z4", address_info.address.__str__())
     
     def test_balance(self):
         connection: Connection = Connection.new_in_memory()

--- a/bdk-swift/README.md
+++ b/bdk-swift/README.md
@@ -1,7 +1,7 @@
 # bdk-swift
 
 This project builds a Swift package that provides [Swift] language bindings for the
-[`bdk`] library. The Swift language bindings are created by the [`bdk-ffi`] project which is included as a module of this repository.
+[BDK] libraries. The Swift language bindings are created by the [`bdk-ffi`] project which is included as a module of this repository.
 
 Supported target platforms are:
 
@@ -11,7 +11,7 @@ Supported target platforms are:
 
 ## How to Use
 
-To use the Swift language bindings for [`bdk`] in your [Xcode] iOS or macOS project add
+To use the Swift language bindings for [BDK] in your [Xcode] iOS or macOS project add
 the GitHub repository https://github.com/bitcoindevkit/bdk-swift and select one of the
 release versions. You may then import and use the `BitcoinDevKit` library in your Swift
 code. For example:
@@ -43,10 +43,10 @@ If you are a maintainer of this project or want to build and publish this projec
 own GitHub repository use the following steps:
 
 1. If it doesn't already exist, create a new `release/0.MINOR` branch from the `master` branch.
-2. Add a tag `v0.MINOR.PATCH`.
-3. Run the `publish-spm` workflow on GitHub from the `bdk-swift` repo for  version `0.MINOR.PATCH`.
+2. Add a tag `vMAJOR.MINOR.PATCH`.
+3. Run the `publish-spm` workflow on GitHub from the `bdk-swift` repo for version `MAJOR.MINOR.PATCH`.
 
 [Swift]: https://developer.apple.com/swift/
 [Xcode]: https://developer.apple.com/documentation/Xcode
-[`bdk`]: https://github.com/bitcoindevkit/bdk
+[`BDK`]: https://github.com/bitcoindevkit/
 [`bdk-ffi`]: https://github.com/bitcoindevkit/bdk-ffi

--- a/bdk-swift/Tests/BitcoinDevKitTests/LiveElectrumClientTests.swift
+++ b/bdk-swift/Tests/BitcoinDevKitTests/LiveElectrumClientTests.swift
@@ -5,11 +5,11 @@ private let SIGNET_ELECTRUM_URL = "ssl://mempool.space:60602"
 
 final class LiveElectrumClientTests: XCTestCase {
     private let descriptor = try! Descriptor(
-        descriptor: "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/0/*)", 
+        descriptor: "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/1h/0/*)", 
         network: Network.signet
     )
     private let changeDescriptor = try! Descriptor(
-        descriptor: "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/1/*)", 
+        descriptor: "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/1h/1/*)", 
         network: Network.signet
     )
 

--- a/bdk-swift/Tests/BitcoinDevKitTests/LiveKyotoTests.swift
+++ b/bdk-swift/Tests/BitcoinDevKitTests/LiveKyotoTests.swift
@@ -3,11 +3,11 @@ import XCTest
 
 final class LiveKyotoTests: XCTestCase {
     private let descriptor = try! Descriptor(
-        descriptor: "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/0/*)",
+        descriptor: "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/1h/0/*)",
         network: Network.signet
     )
     private let changeDescriptor = try! Descriptor(
-        descriptor: "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/1/*)",
+        descriptor: "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/1h/1/*)",
         network: Network.signet
     )
     private let peer = IpAddress.fromIpv4(q1: 68, q2: 47, q3: 229, q4: 218)

--- a/bdk-swift/Tests/BitcoinDevKitTests/LiveMemoryWalletTests.swift
+++ b/bdk-swift/Tests/BitcoinDevKitTests/LiveMemoryWalletTests.swift
@@ -6,11 +6,11 @@ private let TESTNET_ESPLORA_URL = "https://esplora.testnet.kuutamo.cloud"
 
 final class LiveMemoryWalletTests: XCTestCase {
     private let descriptor = try! Descriptor(
-        descriptor: "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/0/*)", 
+        descriptor: "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/1h/0/*)", 
         network: Network.signet
     )
     private let changeDescriptor = try! Descriptor(
-        descriptor: "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/1/*)", 
+        descriptor: "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/1h/1/*)", 
         network: Network.signet
     )
 

--- a/bdk-swift/Tests/BitcoinDevKitTests/LiveTransactionTests.swift
+++ b/bdk-swift/Tests/BitcoinDevKitTests/LiveTransactionTests.swift
@@ -7,11 +7,11 @@ private let TESTNET_ESPLORA_URL = "https://esplora.testnet.kuutamo.cloud"
 
 final class LiveTransactionTests: XCTestCase {
     private let descriptor = try! Descriptor(
-    descriptor: "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/0/*)", 
+    descriptor: "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/1h/0/*)", 
     network: Network.signet
     )
     private let changeDescriptor = try! Descriptor(
-        descriptor: "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/1/*)", 
+        descriptor: "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/1h/1/*)", 
         network: Network.signet
     )
 

--- a/bdk-swift/Tests/BitcoinDevKitTests/LiveTxBuilderTests.swift
+++ b/bdk-swift/Tests/BitcoinDevKitTests/LiveTxBuilderTests.swift
@@ -6,11 +6,11 @@ private let TESTNET_ESPLORA_URL = "https://esplora.testnet.kuutamo.cloud"
 
 final class LiveTxBuilderTests: XCTestCase {
     private let descriptor = try! Descriptor(
-    descriptor: "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/0/*)", 
+    descriptor: "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/1h/0/*)", 
     network: Network.signet
     )
     private let changeDescriptor = try! Descriptor(
-        descriptor: "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/1/*)", 
+        descriptor: "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/1h/1/*)", 
         network: Network.signet
     )
     var dbFilePath: URL!
@@ -69,14 +69,6 @@ final class LiveTxBuilderTests: XCTestCase {
     }
 
     func testComplexTxBuilder() throws {
-        let descriptor = try Descriptor(
-            descriptor: "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/0/*)",
-            network: Network.signet
-        )
-        let changeDescriptor = try Descriptor(
-            descriptor: "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/1/*)",
-            network: Network.signet
-        )
         let connection = try Connection.newInMemory()
         let wallet = try Wallet(
             descriptor: descriptor,

--- a/bdk-swift/Tests/BitcoinDevKitTests/LiveWalletTests.swift
+++ b/bdk-swift/Tests/BitcoinDevKitTests/LiveWalletTests.swift
@@ -6,11 +6,11 @@ private let TESTNET_ESPLORA_URL = "https://esplora.testnet.kuutamo.cloud"
 
 final class LiveWalletTests: XCTestCase {
     private let descriptor = try! Descriptor(
-    descriptor: "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/0/*)", 
+    descriptor: "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/1h/0/*)", 
     network: Network.signet
     )
     private let changeDescriptor = try! Descriptor(
-        descriptor: "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/1/*)", 
+        descriptor: "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/1h/1/*)", 
         network: Network.signet
     )
     var dbFilePath: URL!

--- a/bdk-swift/Tests/BitcoinDevKitTests/OfflineWalletTests.swift
+++ b/bdk-swift/Tests/BitcoinDevKitTests/OfflineWalletTests.swift
@@ -3,11 +3,11 @@ import XCTest
 
 final class OfflineWalletTests: XCTestCase {
     private let descriptor = try! Descriptor(
-    descriptor: "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/0/*)", 
+    descriptor: "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/1h/0/*)", 
     network: Network.signet
     )
     private let changeDescriptor = try! Descriptor(
-        descriptor: "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/1/*)", 
+        descriptor: "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/1h/1/*)", 
         network: Network.signet
     )
     
@@ -30,7 +30,7 @@ final class OfflineWalletTests: XCTestCase {
         XCTAssertFalse(addressInfo.address.isValidForNetwork(network: Network.bitcoin),
                       "Address is valid for bitcoin network, but it shouldn't be")
 
-        XCTAssertEqual(addressInfo.address.description, "tb1qrnfslnrve9uncz9pzpvf83k3ukz22ljgees989")
+        XCTAssertEqual(addressInfo.address.description, "tb1qhjys9wxlfykmte7ftryptx975uqgd6kcm6a7z4")
     }
     
     func testBalance() throws {


### PR DESCRIPTION
Our wallet was over 500 indices deep, which made tests slower to complete. 

Note that the descriptors associated with the persistence tests are not changed, as they would require creating and committing new sqlite files but the old ones are fine and the tests are not live anyway so don't require any sync.

Ok this is turning into a bundle of tiny fixes we just need and I don't feel like PRing individually.
- The first commit was something we addressed on the release/1.1 branch but I forgot to cherry pick back on master.
- The second commit bumps the descriptors used in tests.
- The third one adds the changelog entry for the 0.32.1 release.
- The fourth commit updates the readme files and API docs landing page for bdk-jvm and bdk-android
- The fifth commit updates the development version of the libraries. I'm using 1.2.0-dev for the Rust library, which is not a format recognized by Cargo but is recommended for these types of internal uses and when the library is not actually released on crates.io. This indicates it's an "in-development" version. Our other choices are to use `alpha.0`, but I found this odd because it's not an alpha at this point, it's literally just a development version, or to keep it at 1.1.0 until we release 1.2.0, and bump it then.
- The sixth commit adds the changelog entry.