### PR TITLE
Migrate FeeRate to procedural macros

### DIFF
--- a/bdk-ffi/src/bdk.udl
+++ b/bdk-ffi/src/bdk.udl
@@ -1475,19 +1475,7 @@ interface Amount {
   f64 to_btc();
 };
 
-interface FeeRate {
-  [Name=from_sat_per_vb, Throws=FeeRateError]
-  constructor(u64 sat_per_vb);
-
-  [Name=from_sat_per_kwu]
-  constructor(u64 sat_per_kwu);
-
-  u64 to_sat_per_vb_ceil();
-
-  u64 to_sat_per_vb_floor();
-
-  u64 to_sat_per_kwu();
-};
+typedef interface FeeRate;
 
 dictionary OutPoint {
   string txid;

--- a/bdk-ffi/src/bitcoin.rs
+++ b/bdk-ffi/src/bitcoin.rs
@@ -54,20 +54,27 @@ impl From<OutPoint> for BdkOutPoint {
     }
 }
 
-#[derive(Clone, Debug)]
+/// Represents fee rate.
+///
+/// This is an integer type representing fee rate in sat/kwu. It provides protection against mixing
+/// up the types as well as basic formatting features.
+#[derive(Clone, Debug, uniffi::Object)]
 pub struct FeeRate(pub BdkFeeRate);
 
+#[uniffi::export]
 impl FeeRate {
-    pub fn from_sat_per_vb(sat_per_vb: u64) -> Result<Self, FeeRateError> {
-        let fee_rate: Option<BdkFeeRate> = BdkFeeRate::from_sat_per_vb(sat_per_vb);
+    #[uniffi::constructor]
+    pub fn from_sat_per_vb(sat_vb: u64) -> Result<Self, FeeRateError> {
+        let fee_rate: Option<BdkFeeRate> = BdkFeeRate::from_sat_per_vb(sat_vb);
         match fee_rate {
             Some(fee_rate) => Ok(FeeRate(fee_rate)),
             None => Err(FeeRateError::ArithmeticOverflow),
         }
     }
 
-    pub fn from_sat_per_kwu(sat_per_kwu: u64) -> Self {
-        FeeRate(BdkFeeRate::from_sat_per_kwu(sat_per_kwu))
+    #[uniffi::constructor]
+    pub fn from_sat_per_kwu(sat_kwu: u64) -> Self {
+        FeeRate(BdkFeeRate::from_sat_per_kwu(sat_kwu))
     }
 
     pub fn to_sat_per_vb_ceil(&self) -> u64 {

--- a/bdk-swift/Tests/BitcoinDevKitTests/LiveTxBuilderTests.swift
+++ b/bdk-swift/Tests/BitcoinDevKitTests/LiveTxBuilderTests.swift
@@ -61,7 +61,7 @@ final class LiveTxBuilderTests: XCTestCase {
         let recipient: Address = try Address(address: "tb1qrnfslnrve9uncz9pzpvf83k3ukz22ljgees989", network: .signet)
         let psbt: Psbt = try TxBuilder()
             .addRecipient(script: recipient.scriptPubkey(), amount: Amount.fromSat(fromSat: 4200))
-            .feeRate(feeRate: FeeRate.fromSatPerVb(satPerVb: 2))
+            .feeRate(feeRate: FeeRate.fromSatPerVb(satVb: 2))
             .finish(wallet: wallet)
 
         print(psbt.serialize())
@@ -101,7 +101,7 @@ final class LiveTxBuilderTests: XCTestCase {
 
         let psbt: Psbt = try TxBuilder()
             .setRecipients(recipients: allRecipients)
-            .feeRate(feeRate: FeeRate.fromSatPerVb(satPerVb: 4))
+            .feeRate(feeRate: FeeRate.fromSatPerVb(satVb: 4))
             .finish(wallet: wallet)
 
         let _ = try! wallet.sign(psbt: psbt)

--- a/bdk-swift/Tests/BitcoinDevKitTests/LiveWalletTests.swift
+++ b/bdk-swift/Tests/BitcoinDevKitTests/LiveWalletTests.swift
@@ -98,7 +98,7 @@ final class LiveWalletTests: XCTestCase {
         let psbt: Psbt = try
             TxBuilder()
             .addRecipient(script: recipient.scriptPubkey(), amount: Amount.fromSat(fromSat: 4200))
-                .feeRate(feeRate: FeeRate.fromSatPerVb(satPerVb: 2))
+                .feeRate(feeRate: FeeRate.fromSatPerVb(satVb: 2))
                 .finish(wallet: wallet)
 
         print(psbt.serialize())


### PR DESCRIPTION
This PR simply migrates the FeeRate type to procedural macros. Notice that because it is used in the UDL more places than simply its definition, we must keep a single line indicating its definition in proc macros.

These lines can be removed once no reference to the FeeRate type are required in the UDL (for example once we migrate the `Wallet` type). 

I also fixed here the arguments to both constructors of the `FeeRate` type to [bring them in line with the Rust API](https://docs.rs/bitcoin/latest/bitcoin/struct.FeeRate.html).

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
