### PR TITLE
Fix live test for Kyoto in python

### DIFF
--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -192,3 +192,21 @@ jobs:
 
       - name: "Run tests"
         run: python -m unittest discover --start "./tests/" --pattern "test_offline_*.py" --verbose
+
+  ruff:
+    name: "Lint tests"
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: bdk-python
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: "Install Ruff"
+        run: curl -LsSf https://astral.sh/ruff/install.sh | sh
+
+      - name: "Lint test targets"
+        run: ruff check ./tests/


### PR DESCRIPTION
### Description

I recently installed `mypy` and `ruff` for python linting and got a bunch of lints on the live Kyoto test:
1. Named imports are preferred over `*` 
2. The `update` method returns an optional
3. I never actually defined the `log_task` variable somehow, which is a log loop that prints to the console.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
