### PR TITLE
fix: broken links for bdk-jvm bdk-android maven central

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,12 @@ Each supported language and the platform(s) it's packaged for has its own direct
 ## Supported target languages and platforms
 The below directories (a separate repository in the case of bdk-swift) include instructions for using, building, and publishing the native language binding for [bdk] supported by this project.
 
-| Language | Platform              | Published Package             | Building Documentation | API Docs              |
-| -------- |-----------------------|-------------------------------|------------------------|-----------------------|
-| Kotlin   | JVM                   | [bdk-jvm (Maven Central)]     | [Readme bdk-jvm]       | [Kotlin JVM API Docs] |
-| Kotlin   | Android               | [bdk-android (Maven Central)] | [Readme bdk-android]   | [Android API Docs]    |
-| Swift    | iOS, macOS            | [bdk-swift (GitHub)]          | [Readme bdk-swift]     |                       |
-| Python   | linux, macOS, Windows | [bdk-python (PyPI)]           | [Readme bdk-python]    |                       |
+| Language | Platform              | Published Package | Building Documentation | API Docs              |
+| -------- |-----------------------|-------------|------------------------|-----------------------|
+| Kotlin   | JVM                   | [bdk-jvm]   | [Readme bdk-jvm]       | [Kotlin JVM API Docs] |
+| Kotlin   | Android               | [bdk-android] | [Readme bdk-android]   | [Android API Docs]    |
+| Swift    | iOS, macOS            | [bdk-swift] | [Readme bdk-swift]     |                       |
+| Python   | linux, macOS, Windows | [bdk-python] | [Readme bdk-python]    |                       |
 
 ## Building and Testing the Libraries
 If you are familiar with the build tools for the specific languages you wish to build the libraries for, you can use their normal build/test workflows. We also include some [just](https://just.systems/) files to simplify the work across different languages. If you have the just tool installed on your system, you can simply call the commands defined in the `justfile`s, for example:
@@ -134,12 +134,10 @@ This project is made possible thanks to the wonderful work by the [mozilla/uniff
 [`bdk`]: https://github.com/bitcoindevkit/bdk
 [`bdk-ffi`]: https://github.com/bitcoindevkit/bdk-ffi
 ["Getting Started (Developer)"]: https://github.com/bitcoindevkit/bdk-ffi#getting-started-developer
-[bdk-jvm]: https://search.maven.org/artifact/org.bitcoindevkit/bdk-jvm/0.11.0/jar
-[bdk-android]: https://search.maven.org/artifact/org.bitcoindevkit/bdk-android/0.11.0/aar
-[bdk-jvm (Maven Central)]: https://central.sonatype.dev/artifact/org.bitcoindevkit/bdk-jvm/0.11.0
-[bdk-android (Maven Central)]: https://central.sonatype.dev/artifact/org.bitcoindevkit/bdk-android/0.11.0
-[bdk-swift (GitHub)]: https://github.com/bitcoindevkit/bdk-swift
-[bdk-python (PyPI)]: https://pypi.org/project/bdkpython/
+[bdk-jvm]: https://central.sonatype.com/artifact/org.bitcoindevkit/bdk-jvm/
+[bdk-android]: https://central.sonatype.com/artifact/org.bitcoindevkit/bdk-android/
+[bdk-swift]: https://github.com/bitcoindevkit/bdk-swift
+[bdk-python]: https://pypi.org/project/bdkpython/
 [mozilla/uniffi-rs]: https://github.com/mozilla/uniffi-rs
 [bdk]: https://github.com/bitcoindevkit/bdk
 [Bitcoin Dev Kit]: https://github.com/bitcoindevkit


### PR DESCRIPTION
<!-- Erase any parts of this template not applicable to your Pull Request. -->

### Description

<img width="1500" alt="Screenshot 2025-03-12 at 4 32 32 PM" src="https://github.com/user-attachments/assets/08046750-3296-4611-9dbd-59d4696a9edb" />

Was getting this when clicking on the Maven Central links in the README, I changed `dev` to `com`. I'm not sure if dev recently stopped working or anything, but wanted to make sure if people went to bdk-ffi for the 1.1 release and clicked on the links it would take them somewhere good.

Also while I was changing these I changed the versions from 0.11.0 to 1.1.0 so it would take them to newest version. Not sure if we want to add a step in our release to change these too or if we want to drop the version number from these links, but we can do that in a follow up PR whatever is best.

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Changelog notice

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
