### PR TITLE
chore: remove readme warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,6 @@
     <a href="https://discord.gg/d7NkDKm"><img alt="Chat on Discord" src="https://img.shields.io/discord/753336465005608961?logo=discord"></a>
 </p>
 
-## 🚨 Warning 🚨
-The `master` branch of this repository is being migrated to the [bdk 1.0 API](https://github.com/bitcoindevkit/bdk) and is incomplete. For production-ready libraries, use the [`0.31.X`](https://github.com/bitcoindevkit/bdk-ffi/tree/release/0.30) releases.
-
 ## Readme
 The workspace in this repository creates the `libbdkffi` multi-language library for the Rust-based 
 [bdk] library from the [Bitcoin Dev Kit] project.


### PR DESCRIPTION
<!-- Erase any parts of this template not applicable to your Pull Request. -->

### Description

<img width="868" alt="Screenshot 2025-03-12 at 4 38 13 PM" src="https://github.com/user-attachments/assets/840cc37b-abf9-4c08-86d2-94f9eea3f85c" />

Remove scary warning now that we are on 1.x. Didn't want to scare people when we announce bdk-ffi 1.x tomorrow and they land on our README and see the warning.

Thought about changing verbiage or saying we are on 1.x now, but that seems unnecessary (people will assume we are on 1.x and will know if they want 0.x they can find those too), so just removed the whole section.

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Changelog notice

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
