### PR TITLE
feat: apply_unconfirmed_txs on wallet

### DIFF
--- a/bdk-ffi/Cargo.lock
+++ b/bdk-ffi/Cargo.lock
@@ -151,7 +151,7 @@ dependencies = [
 
 [[package]]
 name = "bdk-ffi"
-version = "1.0.0-beta.7"
+version = "1.2.0-dev"
 dependencies = [
  "assert_matches",
  "bdk_core",

--- a/bdk-ffi/src/bdk.udl
+++ b/bdk-ffi/src/bdk.udl
@@ -737,7 +737,13 @@ interface Wallet {
 
   [Throws=SqliteError]
   boolean persist(Connection connection);
+
+  /// Apply relevant unconfirmed transactions to the wallet.
+  /// Transactions that are not relevant are filtered out.
+  void apply_unconfirmed_txs(sequence<UnconfirmedTx> unconfirmed_txs);
 };
+
+typedef dictionary UnconfirmedTx;
 
 interface Update {};
 

--- a/bdk-ffi/src/lib.rs
+++ b/bdk-ffi/src/lib.rs
@@ -87,6 +87,7 @@ use crate::types::SyncRequestBuilder;
 use crate::types::SyncScriptInspector;
 use crate::types::Tx;
 use crate::types::TxStatus;
+use crate::types::UnconfirmedTx;
 use crate::types::Update;
 use crate::wallet::Wallet;
 

--- a/bdk-ffi/src/types.rs
+++ b/bdk-ffi/src/types.rs
@@ -592,3 +592,11 @@ impl From<BdkTx> for Tx {
         }
     }
 }
+
+/// This type replaces the Rust tuple `(tx, last_seen)` used in the Wallet::apply_unconfirmed_txs` method,
+/// where `last_seen` is the timestamp of when the transaction `tx` was last seen in the mempool.
+#[derive(uniffi::Record)]
+pub struct UnconfirmedTx {
+    pub tx: Arc<Transaction>,
+    pub last_seen: u64,
+}

--- a/bdk-ffi/src/wallet.rs
+++ b/bdk-ffi/src/wallet.rs
@@ -7,7 +7,7 @@ use crate::error::{
 use crate::store::Connection;
 use crate::types::{
     AddressInfo, Balance, CanonicalTx, FullScanRequestBuilder, KeychainAndIndex, LocalOutput,
-    Policy, SentAndReceivedValues, SignOptions, SyncRequestBuilder, Update,
+    Policy, SentAndReceivedValues, SignOptions, SyncRequestBuilder, UnconfirmedTx, Update,
 };
 
 use bdk_wallet::bitcoin::{Network, Txid};
@@ -128,6 +128,14 @@ impl Wallet {
         self.get_wallet()
             .apply_update(update.0.clone())
             .map_err(CannotConnectError::from)
+    }
+
+    pub fn apply_unconfirmed_txs(&self, unconfirmed_txs: Vec<UnconfirmedTx>) {
+        self.get_wallet().apply_unconfirmed_txs(
+            unconfirmed_txs
+                .into_iter()
+                .map(|utx| (Arc::new(utx.tx.as_ref().into()), utx.last_seen)),
+        )
     }
 
     pub(crate) fn derivation_index(&self, keychain: KeychainKind) -> Option<u32> {


### PR DESCRIPTION
<!-- Erase any parts of this template not applicable to your Pull Request. -->

### Description

Add [apply_unconfirmed_txs](https://docs.rs/bdk_wallet/latest/bdk_wallet/struct.Wallet.html#method.apply_unconfirmed_txs) to Wallet, resolving #636  potentially. 

### Notes to the reviewers

Created a `UnconfirmedTx` type, similar to how we needed to create a `SentAndReceivedValues` type instead of returning a tuple. Totally open to naming it something different, but just needed a type instead of a tuple.

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Changelog notice

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [x] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
