### PR TITLE
Remove unused dependencies on JVM and Android

### DIFF
--- a/bdk-android/lib/build.gradle.kts
+++ b/bdk-android/lib/build.gradle.kts
@@ -53,7 +53,6 @@ java {
 
 dependencies {
     implementation("net.java.dev.jna:jna:5.14.0@aar")
-    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk7")
     implementation("androidx.appcompat:appcompat:1.4.0")
     implementation("androidx.core:core-ktx:1.7.0")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.1")

--- a/bdk-jvm/lib/build.gradle.kts
+++ b/bdk-jvm/lib/build.gradle.kts
@@ -62,17 +62,8 @@ tasks.withType<Test> {
 }
 
 dependencies {
-    implementation(platform("org.jetbrains.kotlin:kotlin-bom"))
-    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk7")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.1")
     implementation("net.java.dev.jna:jna:5.14.0")
-    api("org.slf4j:slf4j-api:1.7.30")
-
-    // testImplementation("org.junit.jupiter:junit-jupiter-api:5.10.1")
-    // testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.10.1")
-    // testRuntimeOnly("org.junit.vintage:junit-vintage-engine:5.8.2")
-    testImplementation("ch.qos.logback:logback-classic:1.2.3")
-    testImplementation("ch.qos.logback:logback-core:1.2.3")
 }
 
 afterEvaluate {


### PR DESCRIPTION
The JVM and Android libraries had unnecessary dependencies. 

This didn't create any problems on Android, but for some reason the `kotlin-bom` dependency on JVM started created [malformed POM files](https://repo.maven.apache.org/maven2/org/bitcoindevkit/bdk-jvm/1.1.0/bdk-jvm-1.1.0.pom) starting with version `1.1.0-rc.1`.

This removes those dependencies and solves the problem at the same time.
