### PR TITLE
Fix: export BumpFeeTxBuilder to uniffi

### DIFF
--- a/bdk-ffi/src/tx_builder.rs
+++ b/bdk-ffi/src/tx_builder.rs
@@ -421,6 +421,7 @@ pub(crate) struct BumpFeeTxBuilder {
     pub(crate) version: Option<i32>,
 }
 
+#[uniffi::export]
 impl BumpFeeTxBuilder {
     #[uniffi::constructor]
     pub(crate) fn new(txid: String, fee_rate: Arc<FeeRate>) -> Self {


### PR DESCRIPTION
This bug was introduced in #691. The `BumpFeeTxBuilder` was not exported through proc macros and was therefore not available in the bindings.

Note that this would not have happened when using the UDL, so it's a good thing to keep in mind! Everything compiled fine, but the type created in the glue code file was actually empty. Another good reason to keep a healthy test suite, and maybe adding the BumpFeeTxBuilder to one of the live the tests.