### PR TITLE
Build the release-smaller profile when using just command

### DIFF
--- a/bdk-ffi/justfile
+++ b/bdk-ffi/justfile
@@ -2,7 +2,7 @@ default:
   just --list
 
 build:
-  cargo build
+  cargo build --profile release-smaller
 
 check:
    cargo fmt


### PR DESCRIPTION
The command currently builds both the `dev` and `release-smaller` profiles when calling `just build`, which is twice the work. This fix ensures we always attempt to build the release-smaller profile.