### PR TITLE
Add `Cbf` prefix to public type names of Kyoto

### DIFF
--- a/bdk-ffi/src/error.rs
+++ b/bdk-ffi/src/error.rs
@@ -783,13 +783,13 @@ pub enum TxidParseError {
 }
 
 #[derive(Debug, thiserror::Error, uniffi::Error)]
-pub enum LightClientBuilderError {
+pub enum CbfBuilderError {
     #[error("the database could not be opened or created: {reason}")]
     DatabaseError { reason: String },
 }
 
 #[derive(Debug, thiserror::Error, uniffi::Error)]
-pub enum LightClientError {
+pub enum CbfError {
     #[error("the node is no longer running")]
     NodeStopped,
 }
@@ -1515,17 +1515,17 @@ impl From<BdkSqliteError> for SqliteError {
     }
 }
 
-impl From<bdk_kyoto::builder::SqlInitializationError> for LightClientBuilderError {
+impl From<bdk_kyoto::builder::SqlInitializationError> for CbfBuilderError {
     fn from(value: bdk_kyoto::builder::SqlInitializationError) -> Self {
-        LightClientBuilderError::DatabaseError {
+        CbfBuilderError::DatabaseError {
             reason: value.to_string(),
         }
     }
 }
 
-impl From<bdk_kyoto::kyoto::ClientError> for LightClientError {
+impl From<bdk_kyoto::kyoto::ClientError> for CbfError {
     fn from(_value: bdk_kyoto::kyoto::ClientError) -> Self {
-        LightClientError::NodeStopped
+        CbfError::NodeStopped
     }
 }
 

--- a/bdk-jvm/lib/src/test/kotlin/org/bitcoindevkit/LiveKyotoTest.kt
+++ b/bdk-jvm/lib/src/test/kotlin/org/bitcoindevkit/LiveKyotoTest.kt
@@ -32,7 +32,7 @@ class LiveKyotoTest {
         val wallet: Wallet = Wallet(descriptor, changeDescriptor, Network.SIGNET, conn)
         val peers = listOf(peer)
         runBlocking {
-            val lightClient = LightClientBuilder()
+            val lightClient = CbfBuilder()
                 .peers(peers)
                 .connections(1u)
                 .scanType(ScanType.New)

--- a/bdk-python/tests/test_live_kyoto.py
+++ b/bdk-python/tests/test_live_kyoto.py
@@ -1,4 +1,4 @@
-from bdkpython import Connection, Client, Network, Descriptor, KeychainKind, LightClientBuilder, LightClient, LightNode, IpAddress, ScanType, Peer, Update, Wallet
+from bdkpython import Connection, Client, Network, Descriptor, KeychainKind, CbfBuilder, CbfComponents, CbfClient, CbfNode, IpAddress, ScanType, Peer, Update, Wallet
 import unittest
 import os
 import asyncio
@@ -36,9 +36,9 @@ class LiveKyotoTest(unittest.IsolatedAsyncioTestCase):
             connection
         )
         peers = [peer]
-        light_client: LightClient = LightClientBuilder().scan_type(ScanType.NEW()).peers(peers).connections(1).build(wallet)
-        client: Client = light_client.client
-        node: LightNode = light_client.node
+        light_client: CbfComponents = CbfBuilder().scan_type(ScanType.NEW()).peers(peers).connections(1).build(wallet)
+        client: CbfClient = light_client.client
+        node: CbfNode = light_client.node
         async def log_loop(client: Client):
             while True:
                 log = await client.next_log()

--- a/bdk-swift/Tests/BitcoinDevKitTests/LiveKyotoTests.swift
+++ b/bdk-swift/Tests/BitcoinDevKitTests/LiveKyotoTests.swift
@@ -29,7 +29,7 @@ final class LiveKyotoTests: XCTestCase {
             connection: connection
         )
         let trustedPeer = Peer(address: peer, port: nil, v2Transport: false)
-        let lightClient = try LightClientBuilder()
+        let lightClient = try CbfBuilder()
             .peers(peers: [trustedPeer])
             .connections(connections: 1)
             .scanType(scanType: ScanType.new)


### PR DESCRIPTION
### Description

Closes #700 

Discussed in #700, technically _every_ client offered currently in the FFI is a "light client". Compact block filters are the underpinning of the system, so all of the types can indicate that in their names. This removes all notion of `LightClient` and replaces it with a `Cbf` prefix (`CBF` looked ugly imo)

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [x] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [x] I'm linking the issue being fixed by this PR
