### PR TITLE
Migrate Transaction to pro-macros

### DIFF
--- a/bdk-ffi/src/bdk.udl
+++ b/bdk-ffi/src/bdk.udl
@@ -900,34 +900,7 @@ dictionary Header {
   u32 nonce;
 };
 
-interface Transaction {
-  [Throws=TransactionError]
-  constructor(sequence<u8> transaction_bytes);
-
-  string compute_txid();
-
-  u64 total_size();
-
-  u64 vsize();
-
-  boolean is_coinbase();
-
-  boolean is_explicitly_rbf();
-
-  boolean is_lock_time_enabled();
-
-  i32 version();
-
-  sequence<u8> serialize();
-
-  u64 weight();
-
-  sequence<TxIn> input();
-
-  sequence<TxOut> output();
-
-  u32 lock_time();
-};
+typedef interface Transaction;
 
 typedef interface Psbt;
 

--- a/bdk-ffi/src/bitcoin.rs
+++ b/bdk-ffi/src/bitcoin.rs
@@ -245,10 +245,12 @@ impl Display for Address {
 impl_from_core_type!(BdkAddress, Address);
 impl_into_core_type!(Address, BdkAddress);
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, uniffi::Object)]
 pub struct Transaction(BdkTransaction);
 
+#[uniffi::export]
 impl Transaction {
+    #[uniffi::constructor]
     pub fn new(transaction_bytes: Vec<u8>) -> Result<Self, TransactionError> {
         let mut decoder = Cursor::new(transaction_bytes);
         let tx: BdkTransaction = BdkTransaction::consensus_decode(&mut decoder)?;


### PR DESCRIPTION
<!-- Erase any parts of this template not applicable to your Pull Request. -->

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->
This PR migrates `Transaction` to pro-macros 

### Notes to the reviewers
- Policy link is broken in `fn vsize(&self)` see main doc [here ]. So I took that part out of the doc here (https://docs.rs/bitcoin/latest/bitcoin/struct.Transaction.html#method.vsize)
- I am not sure if this is the right api docs for serialize(&self) [here ](https://docs.rs/serde/1.0.156/x86_64-unknown-linux-gnu/serde/ser/trait.Serialize.html#tymethod.serialize)
- I wondering if we need to put a doc for the default constructor.

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->


### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [x] I've added docs for the new feature