### PR TITLE
Use `uniffi::Remote` where applicable in module Kyoto

### DIFF
--- a/bdk-ffi/src/bdk.udl
+++ b/bdk-ffi/src/bdk.udl
@@ -1120,29 +1120,6 @@ interface AddressData {
 };
 
 // ------------------------------------------------------------------------
-// bdk-kyoto crate
-// ------------------------------------------------------------------------
-
-/// The state of the node with respect to connected peers.
-[Remote]
-enum NodeState {
-  /// Behind on block headers according to our peers.
-  "Behind",
-
-  /// Downloading compact block filter headers.
-  "HeadersSynced",
-
-  /// Scanning compact block filters.
-  "FilterHeadersSynced",
-
-  /// Asking for blocks with matches.
-  "FiltersSynced",
-
-  /// Found all known transactions to the wallet.
-  "TransactionsSynced"
-};
-
-// ------------------------------------------------------------------------
 // bdk_wallet crate - bitcoin re-exports
 // ------------------------------------------------------------------------
 

--- a/bdk-ffi/src/lib.rs
+++ b/bdk-ffi/src/lib.rs
@@ -95,6 +95,4 @@ use bdk_wallet::tx_builder::ChangeSpendPolicy;
 use bdk_wallet::ChangeSet;
 use bdk_wallet::KeychainKind;
 
-use bdk_kyoto::NodeState;
-
 uniffi::include_scaffolding!("bdk");


### PR DESCRIPTION
### Description

Removing all Kyoto types from the UDL, and using the `uniffi::remote` macro wherever applicable in the module.

### Notes to the reviewers

I was not aware of `uniffi::Remote` until a recent PR, so this cleans up the Kyoto module significantly. Cheers.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [x] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
