### PR TITLE
Prepare libraries for 1.2 release: update readmes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Native language bindings for BDK
+# Language bindings for BDK
 
 <p>
     <a href="https://github.com/bitcoindevkit/bdk-ffi/blob/master/LICENSE"><img alt="MIT or Apache-2.0 Licensed" src="https://img.shields.io/badge/license-MIT%2FApache--2.0-blue.svg"/></a>
@@ -8,22 +8,25 @@
 </p>
 
 ## Readme
+
 The workspace in this repository creates the `libbdkffi` multi-language library for the Rust-based 
 [bdk] library from the [Bitcoin Dev Kit] project.
 
 Each supported language and the platform(s) it's packaged for has its own directory. The Rust code in this project is in the bdk-ffi directory and is a wrapper around the [bdk] library to expose its APIs in a uniform way using the [mozilla/uniffi-rs] bindings generator for each supported target language.
 
 ## Supported target languages and platforms
+
 The below directories (a separate repository in the case of bdk-swift) include instructions for using, building, and publishing the native language binding for [bdk] supported by this project.
 
 | Language | Platform              | Published Package | Building Documentation | API Docs              |
-| -------- |-----------------------|-------------|------------------------|-----------------------|
-| Kotlin   | JVM                   | [bdk-jvm]   | [Readme bdk-jvm]       | [Kotlin JVM API Docs] |
-| Kotlin   | Android               | [bdk-android] | [Readme bdk-android]   | [Android API Docs]    |
-| Swift    | iOS, macOS            | [bdk-swift] | [Readme bdk-swift]     |                       |
-| Python   | linux, macOS, Windows | [bdk-python] | [Readme bdk-python]    |                       |
+| -------- |-----------------------|-------------------|------------------------|-----------------------|
+| Kotlin   | JVM                   | [bdk-jvm]         | [Readme bdk-jvm]       | [Kotlin JVM API Docs] |
+| Kotlin   | Android               | [bdk-android]     | [Readme bdk-android]   | [Android API Docs]    |
+| Swift    | iOS, macOS            | [bdk-swift]       | [Readme bdk-swift]     |                       |
+| Python   | linux, macOS, Windows | [bdk-python]      | [Readme bdk-python]    |                       |
 
-## Building and Testing the Libraries
+## Building and testing the libraries
+
 If you are familiar with the build tools for the specific languages you wish to build the libraries for, you can use their normal build/test workflows. We also include some [just](https://just.systems/) files to simplify the work across different languages. If you have the just tool installed on your system, you can simply call the commands defined in the `justfile`s, for example:
 ```sh
 cd bdk-android
@@ -34,12 +37,15 @@ just publishlocal
 ```
 
 ## Minimum Supported Rust Version (MSRV)
+
 This library should compile with any combination of features with Rust 1.84.1.
 
 ## Contributing
+
 To add new structs and functions, see the [UniFFI User Guide](https://mozilla.github.io/uniffi-rs/) and the [uniffi-examples](https://thunderbiscuit.github.io/uniffi-examples/) repository.
 
 ## Goals
+
 1. Language bindings should feel idiomatic in target languages/platforms
 2. Adding new targets should be easy 
 3. Getting up and running should be easy 
@@ -47,7 +53,9 @@ To add new structs and functions, see the [UniFFI User Guide](https://mozilla.gi
 5. Get it right, then automate
 
 ## Using the libraries
+
 ### bdk-android
+
 ```kotlin
 // build.gradle.kts
 repositories {
@@ -59,6 +67,7 @@ dependencies {
 ```
 
 ### bdk-jvm
+
 ```kotlin
 // build.gradle.kts
 repositories {
@@ -71,18 +80,22 @@ dependencies {
 
 _Note:_ We also publish snapshot versions of bdk-jvm and bdk-android. See the specific readmes for instructions on how to use those.
 
-### bdk-python
+### bdkpython
+
 ```shell
 pip3 install bdkpython
 ```
 
-### bdk-swift
-Add bdk-swift to your dependencies in XCode.
+### BitcoinDevKit (Swift)
+
+Add `BitcoinDevKit` to your dependencies in XCode.
 
 ## Developing language bindings using uniffi-rs
+
 If you are interested in better understanding the base structure we use here in order to build your own Rust-to-Kotlin/Swift/Python language bindings, check out the [uniffi-bindings-template](https://github.com/thunderbiscuit/uniffi-bindings-template) repository. We maintain it as an example and starting point for other projects that wish to leverage the tech stack used in producing the BDK language bindings.
 
 ## Verifying Signatures
+
 Both libraries and all their corresponding artifacts are signed with a PGP key you can find in the
 root of this repository. To verify the signatures follow the below steps:
 
@@ -121,12 +134,14 @@ gpg: Good signature from "bitcoindevkit-bindings <bindings@bitcoindevkit.org>" [
 ```
 
 ### PGP Metadata
+
 Full key ID: `88AD 93AC 4589 FD09 0FF3 B8D1 2768 C43E 8803 C6A3`  
 Fingerprint: `2768C43E8803C6A3`  
 Name: `bitcoindevkit-bindings`  
 Email: `bindings@bitcoindevkit.org`
 
 ## Thanks
+
 This project is made possible thanks to the wonderful work by the [mozilla/uniffi-rs] team.
 
 [Kotlin]: https://kotlinlang.org/

--- a/bdk-android/README.md
+++ b/bdk-android/README.md
@@ -43,15 +43,15 @@ _Note that Kotlin version `2.1.10` or later is required to build the library._
 git clone https://github.com/bitcoindevkit/bdk-ffi
 ```
 2. Install Android SDK and Build-Tools for API level 30+
-3. Setup `ANDROID_SDK_ROOT` and `ANDROID_NDK_ROOT` path variables which are required by the build tool. Note that currently, NDK version 25.2.9519653 or above is required. For example:
+3. Setup `ANDROID_SDK_ROOT` and `ANDROID_NDK_ROOT` path variables which are required by the build tool. Note that currently, NDK version 27.2.12479018 or above is recommended. For example:
 ```shell
 # macOS
 export ANDROID_SDK_ROOT=~/Library/Android/sdk
-export ANDROID_NDK_ROOT=$ANDROID_SDK_ROOT/ndk/25.2.9519653
+export ANDROID_NDK_ROOT=$ANDROID_SDK_ROOT/ndk/27.2.12479018
 
 # Linux
 export ANDROID_SDK_ROOT=/usr/local/lib/android/sdk
-export ANDROID_NDK_ROOT=$ANDROID_SDK_ROOT/ndk/25.2.9519653
+export ANDROID_NDK_ROOT=$ANDROID_SDK_ROOT/ndk/27.2.12479018
 ```
 4. Build Kotlin bindings
 ```sh

--- a/bdk-jvm/README.md
+++ b/bdk-jvm/README.md
@@ -3,19 +3,23 @@
 This project builds a .jar package for the JVM platform that provides Kotlin language bindings for the [BDK] libraries. The Kotlin language bindings are created by the `bdk-ffi` project which is included in the root of this repository.
 
 ## How to Use
+
 To use the Kotlin language bindings for BDK in your JVM project add the following to your gradle dependencies:
+
 ```kotlin
 repositories {
     mavenCentral()
 }
 
 dependencies {
-  implementation("org.bitcoindevkit:bdk-jvm:<version>")
+    implementation("org.bitcoindevkit:bdk-jvm:<version>")
 }
 ```
 
 ### Snapshot releases
+
 To use a snapshot release, specify the snapshot repository url in the `repositories` block and use the snapshot version in the `dependencies` block:
+
 ```kotlin
 repositories {
     maven("https://s01.oss.sonatype.org/content/repositories/snapshots/")
@@ -27,9 +31,12 @@ dependencies {
 ```
 
 ## Example Projects
-* [Tatooine Faucet](https://github.com/thunderbiscuit/tatooine)
+
+- [Tatooine Faucet](https://github.com/thunderbiscuit/tatooine)
+- [Godzilla Wallet](https://github.com/thunderbiscuit/godzilla-wallet)
 
 ## How to build
+
 _Note that Kotlin version `1.9.23` or later is required to build the library._
 1. Install JDK 17. For example, with SDKMAN!:
 ```shell
@@ -43,24 +50,29 @@ bash ./scripts/build-<your-local-architecture>.sh
 ```
 
 ## How to publish to your local Maven repo
+
 ```shell
 cd bdk-jvm
 ./gradlew publishToMavenLocal -P localBuild
 ```
 
 Note that the commands assume you don't need the local libraries to be signed. If you do wish to sign them, simply set your `~/.gradle/gradle.properties` signing key values like so:
+
 ```properties
 signing.gnupg.keyName=<YOUR_GNUPG_ID>
 signing.gnupg.passphrase=<YOUR_GNUPG_PASSPHRASE>
 ```
 
 and use the `publishToMavenLocal` task without the `localBuild` flag:
+
 ```shell
 ./gradlew publishToMavenLocal
 ```
 
 ## Known issues
+
 ## JNA dependency
+
 Depending on the JVM version you use, you might not have the JNA dependency on your classpath. The exception thrown will be 
 ```shell
 class file for com.sun.jna.Pointer not found

--- a/bdk-python/README.md
+++ b/bdk-python/README.md
@@ -7,6 +7,7 @@ See the [package on PyPI](https://pypi.org/project/bdkpython/).
 ## Install from PyPI
 
 Install the latest release using
+
 ```shell
 pip install bdkpython
 ```

--- a/bdk-swift/README.md
+++ b/bdk-swift/README.md
@@ -35,7 +35,7 @@ swift test
 
 ### Example Projects
 
-* [BDKSwiftExampleWallet](https://github.com/bitcoindevkit/BDKSwiftExampleWallet), iOS
+- [BDKSwiftExampleWallet](https://github.com/bitcoindevkit/BDKSwiftExampleWallet), iOS
 
 ## How to Build and Publish
 


### PR DESCRIPTION
This PR updates the readme files. It's a step in our [release process](https://github.com/bitcoindevkit/bdk-ffi/issues/722) that just prevents documenation rot by doing a quick check on every release.

In this case most of the changes are related to formatting. I try to follow [Google's Markdown Style Guide](https://google.github.io/styleguide/docguide/style.html).
