### PR TITLE
Migrate `Connection` type to procedural macros

### DIFF
--- a/bdk-ffi/src/bdk.udl
+++ b/bdk-ffi/src/bdk.udl
@@ -805,13 +805,7 @@ dictionary Condition {
 // bdk_sqlite crate
 // ------------------------------------------------------------------------
 
-interface Connection {
-  [Throws=SqliteError]
-  constructor(string path);
-
-  [Name=new_in_memory, Throws=SqliteError]
-  constructor();
-};
+typedef interface Connection;
 
 // ------------------------------------------------------------------------
 // bdk crate - descriptor module

--- a/bdk-ffi/src/store.rs
+++ b/bdk-ffi/src/store.rs
@@ -5,19 +5,29 @@ use bdk_wallet::rusqlite::Connection as BdkConnection;
 use std::sync::Mutex;
 use std::sync::MutexGuard;
 
+/// A connection to a SQLite database.
+#[derive(uniffi::Object)]
 pub struct Connection(Mutex<BdkConnection>);
 
+#[uniffi::export]
 impl Connection {
+    /// Open a new connection to a SQLite database. If a database does not exist at the path, one is
+    /// created.
+    #[uniffi::constructor]
     pub fn new(path: String) -> Result<Self, SqliteError> {
         let connection = BdkConnection::open(path)?;
         Ok(Self(Mutex::new(connection)))
     }
 
+    /// Open a new connection to an in-memory SQLite database.
+    #[uniffi::constructor]
     pub fn new_in_memory() -> Result<Self, SqliteError> {
         let connection = BdkConnection::open_in_memory()?;
         Ok(Self(Mutex::new(connection)))
     }
+}
 
+impl Connection {
     pub(crate) fn get_store(&self) -> MutexGuard<BdkConnection> {
         self.0.lock().expect("must lock")
     }


### PR DESCRIPTION
Migration of the `Connection` type.

Docs pulled directly from the rusqlite crate: https://docs.rs/rusqlite/0.31.0/rusqlite/struct.Connection.html#method.open

One thing to note is that with proc macros, all methods in an `impl` block will be exported if that block is marked with the `#uniffi::export` annotation, meaning that if we want to keep some methods private/out of the public API for the bindings (for example the `Connection::get_store()`), they simply need to be brought into a separate impl block.