### PR TITLE
fix: make class final to conform to Sendable protocol

### DIFF
--- a/bdk-swift/Tests/BitcoinDevKitTests/LiveMemoryWalletTests.swift
+++ b/bdk-swift/Tests/BitcoinDevKitTests/LiveMemoryWalletTests.swift
@@ -77,7 +77,7 @@ final class LiveMemoryWalletTests: XCTestCase {
 
 }
 
-class FullScriptInspector: FullScanScriptInspector {
+final class FullScriptInspector: FullScanScriptInspector {
     func inspect(keychain: KeychainKind, index: UInt32, script: Script) {
         print("Inspecting index \(index) for keychain \(keychain)")
     }


### PR DESCRIPTION
<!-- Erase any parts of this template not applicable to your Pull Request. -->

### Description

This PR fix the issue [`Swift compiler warning #726`](https://github.com/bitcoindevkit/bdk-ffi/issues/726)

### Notes to the reviewers

Super easy! Just mark the class with the final modifier.
In Swift 6, for a class to conform to the Sendable protocol, it must be declared as final.

### Changelog notice

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

### Checklists

#### All Submissions:

* [X] I've signed all my commits
* [X] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [X] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
