### PR TITLE
FinalizedPsbtResult : Change pro-macros to record

### DIFF
--- a/bdk-ffi/src/bitcoin.rs
+++ b/bdk-ffi/src/bitcoin.rs
@@ -483,7 +483,7 @@ impl From<BdkPsbt> for Psbt {
     }
 }
 
-#[derive(uniffi::Object)]
+#[derive(uniffi::Record)]
 pub struct FinalizedPsbtResult {
     pub psbt: Arc<Psbt>,
     pub could_finalize: bool,


### PR DESCRIPTION
The macro should have been #[derive(uniffi::Record)] instead of #[derive(uniffi::Object)] thanks for pointing this out @thunderbiscuit 

I see unused imports have been handled in #737. Thanks!