### PR TITLE
Migrate `ElectrumClient` to proc macros

### DIFF
--- a/bdk-ffi/src/bdk.udl
+++ b/bdk-ffi/src/bdk.udl
@@ -466,8 +466,6 @@ dictionary SignOptions {
 // bdk_wallet crate - wallet module
 // ------------------------------------------------------------------------
 
-typedef interface Update;
-
 interface Policy {
   string id();
   
@@ -620,105 +618,6 @@ interface Descriptor {
   /// "parallel" paths. For regular descriptors it will just return itself.
   [Throws=MiniscriptError]
   sequence<Descriptor> to_single_descriptors();
-};
-
-// ------------------------------------------------------------------------
-// bdk_electrum crate
-// ------------------------------------------------------------------------
-
-/// Wrapper around an electrum_client::ElectrumApi which includes an internal in-memory transaction
-/// cache to avoid re-fetching already downloaded transactions.
-interface ElectrumClient {
-  /// Creates a new bdk client from a electrum_client::ElectrumApi
-  /// Optional: Set the proxy of the builder
-  [Throws=ElectrumError]
-  constructor(string url, optional string? socks5 = null);
-
-  /// Full scan the keychain scripts specified with the blockchain (via an Electrum client) and
-  /// returns updates for bdk_chain data structures.
-  ///
-  /// - `request`: struct with data required to perform a spk-based blockchain client
-  ///   full scan, see `FullScanRequest`.
-  /// - `stop_gap`: the full scan for each keychain stops after a gap of script pubkeys with no
-  ///   associated transactions.
-  /// - `batch_size`: specifies the max number of script pubkeys to request for in a single batch
-  ///   request.
-  /// - `fetch_prev_txouts`: specifies whether we want previous `TxOuts` for fee calculation. Note
-  ///   that this requires additional calls to the Electrum server, but is necessary for
-  ///   calculating the fee on a transaction if your wallet does not own the inputs. Methods like
-  ///   `Wallet.calculate_fee` and `Wallet.calculate_fee_rate` will return a
-  ///   `CalculateFeeError::MissingTxOut` error if those TxOuts are not present in the transaction
-  ///   graph.
-  [Throws=ElectrumError]
-  Update full_scan(FullScanRequest request, u64 stop_gap, u64 batch_size, boolean fetch_prev_txouts);
-
-  /// Sync a set of scripts with the blockchain (via an Electrum client) for the data specified and returns updates for bdk_chain data structures.
-  ///
-  /// - `request`: struct with data required to perform a spk-based blockchain client
-  ///   sync, see `SyncRequest`.
-  /// - `batch_size`: specifies the max number of script pubkeys to request for in a single batch
-  ///   request.
-  /// - `fetch_prev_txouts`: specifies whether we want previous `TxOuts` for fee calculation. Note
-  ///   that this requires additional calls to the Electrum server, but is necessary for
-  ///   calculating the fee on a transaction if your wallet does not own the inputs. Methods like
-  ///   `Wallet.calculate_fee` and `Wallet.calculate_fee_rate` will return a
-  ///   `CalculateFeeError::MissingTxOut` error if those TxOuts are not present in the transaction
-  ///   graph.
-  ///
-  /// If the scripts to sync are unknown, such as when restoring or importing a keychain that may
-  /// include scripts that have been used, use full_scan with the keychain.
-  [Throws=ElectrumError]
-  Update sync(SyncRequest request, u64 batch_size, boolean fetch_prev_txouts);
-
-  /// Broadcasts a transaction to the network.
-  [Throws=ElectrumError]
-  string transaction_broadcast([ByRef] Transaction tx);
-
-  /// Returns the capabilities of the server.
-  [Throws=ElectrumError]
-  ServerFeaturesRes server_features();
-
-  /// Estimates the fee required in bitcoin per kilobyte to confirm a transaction in `number` blocks.
-  [Throws=ElectrumError]
-  f64 estimate_fee(u64 number);
-
-  /// Subscribes to notifications for new block headers, by sending a blockchain.headers.subscribe call.
-  [Throws=ElectrumError]
-  HeaderNotification block_headers_subscribe();
-
-  /// Pings the server.
-  [Throws=ElectrumError]
-  void ping();
-};
-
-/// Response to an ElectrumClient.server_features request.
-dictionary ServerFeaturesRes {
-  /// Server version reported.
-  string server_version;
-
-  /// Hash of the genesis block.
-  string genesis_hash;
-
-  /// Minimum supported version of the protocol.
-  string protocol_min;
-
-  /// Maximum supported version of the protocol.
-  string protocol_max;
-
-  /// Hash function used to create the `ScriptHash`.
-  string? hash_function;
-
-  /// Pruned height of the server.
-  i64? pruning;
-};
-
-/// Notification of a new block header.
-dictionary HeaderNotification {
-  /// New block height.
-  u64 height;
-
-  /// Newly added header.
-  Header header;
 };
 
 // ------------------------------------------------------------------------

--- a/bdk-ffi/src/bdk.udl
+++ b/bdk-ffi/src/bdk.udl
@@ -466,7 +466,7 @@ dictionary SignOptions {
 // bdk_wallet crate - wallet module
 // ------------------------------------------------------------------------
 
-interface Update {};
+typedef interface Update;
 
 interface Policy {
   string id();

--- a/bdk-ffi/src/kyoto.rs
+++ b/bdk-ffi/src/kyoto.rs
@@ -23,9 +23,9 @@ use tokio::sync::Mutex;
 
 use crate::bitcoin::Transaction;
 use crate::error::{CbfBuilderError, CbfError};
+use crate::types::Update;
 use crate::wallet::Wallet;
 use crate::FeeRate;
-use crate::Update;
 
 type LogLevel = bdk_kyoto::kyoto::LogLevel;
 type NodeState = bdk_kyoto::NodeState;

--- a/bdk-ffi/src/lib.rs
+++ b/bdk-ffi/src/lib.rs
@@ -23,9 +23,6 @@ use crate::bitcoin::TxIn;
 use crate::bitcoin::TxOut;
 use crate::bitcoin::WitnessProgram;
 use crate::descriptor::Descriptor;
-use crate::electrum::ElectrumClient;
-use crate::electrum::HeaderNotification;
-use crate::electrum::ServerFeaturesRes;
 use crate::error::AddressParseError;
 use crate::error::Bip32Error;
 use crate::error::Bip39Error;
@@ -73,7 +70,6 @@ use crate::types::SyncRequestBuilder;
 use crate::types::SyncScriptInspector;
 use crate::types::Tx;
 use crate::types::TxStatus;
-use crate::types::Update;
 
 use bdk_wallet::bitcoin::Network;
 use bdk_wallet::keys::bip39::WordCount;

--- a/bdk-ffi/src/types.rs
+++ b/bdk-ffi/src/types.rs
@@ -250,6 +250,8 @@ impl FullScanRequestBuilder {
     }
 }
 
+/// An update for a wallet containing chain, descriptor index, and transaction data.
+#[derive(uniffi::Object)]
 pub struct Update(pub(crate) BdkUpdate);
 
 pub struct SentAndReceivedValues {


### PR DESCRIPTION
### Description

Joining in on the effort to migrate all the types to proc-marcos

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
