### PR TITLE
Migrate descriptor types to proc macros

### DIFF
--- a/bdk-ffi/src/bdk.udl
+++ b/bdk-ffi/src/bdk.udl
@@ -462,44 +462,6 @@ interface DerivationPath {
   constructor(string path);
 };
 
-interface DescriptorSecretKey {
-  constructor(Network network, [ByRef] Mnemonic mnemonic, string? password);
-
-  [Name=from_string, Throws=DescriptorKeyError]
-  constructor(string secret_key);
-
-  [Throws=DescriptorKeyError]
-  DescriptorSecretKey derive([ByRef] DerivationPath path);
-
-  [Throws=DescriptorKeyError]
-  DescriptorSecretKey extend([ByRef] DerivationPath path);
-
-  DescriptorPublicKey as_public();
-
-  sequence<u8> secret_bytes();
-
-  string as_string();
-};
-
-interface DescriptorPublicKey {
-  [Name=from_string, Throws=DescriptorKeyError]
-  constructor(string public_key);
-
-  [Throws=DescriptorKeyError]
-  DescriptorPublicKey derive([ByRef] DerivationPath path);
-
-  [Throws=DescriptorKeyError]
-  DescriptorPublicKey extend([ByRef] DerivationPath path);
-
-  string as_string();
-
-  /// Whether or not this key has multiple derivation paths.
-  boolean is_multipath();
-
-  /// The fingerprint of the master key associated with this key, `0x00000000` if none.
-  string master_fingerprint();
-};
-
 // ------------------------------------------------------------------------
 // bdk-ffi-defined types
 // ------------------------------------------------------------------------

--- a/bdk-ffi/src/bdk.udl
+++ b/bdk-ffi/src/bdk.udl
@@ -500,48 +500,6 @@ interface DescriptorPublicKey {
   string master_fingerprint();
 };
 
-[Traits=(Display)]
-interface Descriptor {
-  [Throws=DescriptorError]
-  constructor(string descriptor, Network network);
-
-  [Name=new_bip44]
-  constructor([ByRef] DescriptorSecretKey secret_key, KeychainKind keychain, Network network);
-
-  [Name=new_bip44_public]
-  constructor([ByRef] DescriptorPublicKey public_key, string fingerprint, KeychainKind keychain, Network network);
-
-  [Name=new_bip49]
-  constructor([ByRef] DescriptorSecretKey secret_key, KeychainKind keychain, Network network);
-
-  [Name=new_bip49_public]
-  constructor([ByRef] DescriptorPublicKey public_key, string fingerprint, KeychainKind keychain, Network network);
-
-  [Name=new_bip84]
-  constructor([ByRef] DescriptorSecretKey secret_key, KeychainKind keychain, Network network);
-
-  [Name=new_bip84_public]
-  constructor([ByRef] DescriptorPublicKey public_key, string fingerprint, KeychainKind keychain, Network network);
-
-  [Name=new_bip86]
-  constructor([ByRef] DescriptorSecretKey secret_key, KeychainKind keychain, Network network);
-
-  [Name=new_bip86_public]
-  constructor([ByRef] DescriptorPublicKey public_key, string fingerprint, KeychainKind keychain, Network network);
-
-  string to_string_with_secret();
-
-  /// Whether or not this key has multiple derivation paths.
-  boolean is_multipath();
-
-  /// Get as many descriptors as different paths in this descriptor.
-  ///
-  /// For multipath descriptors it will return as many descriptors as there is
-  /// "parallel" paths. For regular descriptors it will just return itself.
-  [Throws=MiniscriptError]
-  sequence<Descriptor> to_single_descriptors();
-};
-
 // ------------------------------------------------------------------------
 // bdk-ffi-defined types
 // ------------------------------------------------------------------------

--- a/bdk-ffi/src/bdk.udl
+++ b/bdk-ffi/src/bdk.udl
@@ -443,26 +443,6 @@ dictionary Condition {
 };
 
 // ------------------------------------------------------------------------
-// bdk crate - descriptor module
-// ------------------------------------------------------------------------
-
-[Traits=(Display)]
-interface Mnemonic {
-  constructor(WordCount word_count);
-
-  [Name=from_string, Throws=Bip39Error]
-  constructor(string mnemonic);
-
-  [Name=from_entropy, Throws=Bip39Error]
-  constructor(sequence<u8> entropy);
-};
-
-interface DerivationPath {
-  [Throws=Bip32Error]
-  constructor(string path);
-};
-
-// ------------------------------------------------------------------------
 // bdk-ffi-defined types
 // ------------------------------------------------------------------------
 

--- a/bdk-ffi/src/descriptor.rs
+++ b/bdk-ffi/src/descriptor.rs
@@ -19,13 +19,18 @@ use std::fmt::Display;
 use std::str::FromStr;
 use std::sync::Arc;
 
-#[derive(Debug)]
+/// An expression of how to derive output scripts: https://github.com/bitcoin/bitcoin/blob/master/doc/descriptors.md
+#[derive(Debug, uniffi::Object)]
+#[uniffi::export(Debug, Display)]
 pub struct Descriptor {
     pub extended_descriptor: ExtendedDescriptor,
     pub key_map: KeyMap,
 }
 
+#[uniffi::export]
 impl Descriptor {
+    /// Parse a string as a descriptor for the given network.
+    #[uniffi::constructor]
     pub fn new(descriptor: String, network: Network) -> Result<Self, DescriptorError> {
         let secp = Secp256k1::new();
         let (extended_descriptor, key_map) = descriptor.into_wallet_descriptor(&secp, network)?;
@@ -35,6 +40,8 @@ impl Descriptor {
         })
     }
 
+    /// Multi-account hierarchy descriptor: https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki
+    #[uniffi::constructor]
     pub fn new_bip44(
         secret_key: &DescriptorSecretKey,
         keychain_kind: KeychainKind,
@@ -61,6 +68,8 @@ impl Descriptor {
         }
     }
 
+    /// Multi-account hierarchy descriptor: https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki
+    #[uniffi::constructor]
     pub fn new_bip44_public(
         public_key: &DescriptorPublicKey,
         fingerprint: String,
@@ -92,6 +101,8 @@ impl Descriptor {
         }
     }
 
+    /// P2SH nested P2WSH descriptor: https://github.com/bitcoin/bips/blob/master/bip-0049.mediawiki
+    #[uniffi::constructor]
     pub fn new_bip49(
         secret_key: &DescriptorSecretKey,
         keychain_kind: KeychainKind,
@@ -118,6 +129,8 @@ impl Descriptor {
         }
     }
 
+    /// P2SH nested P2WSH descriptor: https://github.com/bitcoin/bips/blob/master/bip-0049.mediawiki
+    #[uniffi::constructor]
     pub fn new_bip49_public(
         public_key: &DescriptorPublicKey,
         fingerprint: String,
@@ -149,6 +162,8 @@ impl Descriptor {
         }
     }
 
+    /// Pay to witness PKH descriptor: https://github.com/bitcoin/bips/blob/master/bip-0084.mediawiki
+    #[uniffi::constructor]
     pub fn new_bip84(
         secret_key: &DescriptorSecretKey,
         keychain_kind: KeychainKind,
@@ -175,6 +190,8 @@ impl Descriptor {
         }
     }
 
+    /// Pay to witness PKH descriptor: https://github.com/bitcoin/bips/blob/master/bip-0084.mediawiki
+    #[uniffi::constructor]
     pub fn new_bip84_public(
         public_key: &DescriptorPublicKey,
         fingerprint: String,
@@ -206,6 +223,8 @@ impl Descriptor {
         }
     }
 
+    /// Single key P2TR descriptor: https://github.com/bitcoin/bips/blob/master/bip-0086.mediawiki
+    #[uniffi::constructor]
     pub fn new_bip86(
         secret_key: &DescriptorSecretKey,
         keychain_kind: KeychainKind,
@@ -232,6 +251,8 @@ impl Descriptor {
         }
     }
 
+    /// Single key P2TR descriptor: https://github.com/bitcoin/bips/blob/master/bip-0086.mediawiki
+    #[uniffi::constructor]
     pub fn new_bip86_public(
         public_key: &DescriptorPublicKey,
         fingerprint: String,
@@ -263,16 +284,19 @@ impl Descriptor {
         }
     }
 
+    /// Dangerously convert the descriptor to a string.
     pub fn to_string_with_secret(&self) -> String {
         let descriptor = &self.extended_descriptor;
         let key_map = &self.key_map;
         descriptor.to_string_with_secret(key_map)
     }
 
+    /// Does this descriptor contain paths: https://github.com/bitcoin/bips/blob/master/bip-0389.mediawiki
     pub fn is_multipath(&self) -> bool {
         self.extended_descriptor.is_multipath()
     }
 
+    /// Return descriptors for all valid paths.
     pub fn to_single_descriptors(&self) -> Result<Vec<Arc<Descriptor>>, MiniscriptError> {
         self.extended_descriptor
             .clone()
@@ -300,7 +324,8 @@ impl Display for Descriptor {
 
 #[cfg(test)]
 mod test {
-    use crate::*;
+    use super::*;
+    use crate::keys::{DerivationPath, Mnemonic};
     use assert_matches::assert_matches;
     use bdk_wallet::bitcoin::Network;
     use bdk_wallet::KeychainKind;

--- a/bdk-ffi/src/descriptor.rs
+++ b/bdk-ffi/src/descriptor.rs
@@ -338,31 +338,31 @@ mod test {
     #[test]
     fn test_descriptor_templates() {
         let master: DescriptorSecretKey = get_descriptor_secret_key();
-        println!("Master: {:?}", master.as_string());
+        println!("Master: {:?}", master.to_string());
         // tprv8ZgxMBicQKsPdWuqM1t1CDRvQtQuBPyfL6GbhQwtxDKgUAVPbxmj71pRA8raTqLrec5LyTs5TqCxdABcZr77bt2KyWA5bizJHnC4g4ysm4h
         let handmade_public_44 = master
             .derive(&DerivationPath::new("m/44h/1h/0h".to_string()).unwrap())
             .unwrap()
             .as_public();
-        println!("Public 44: {}", handmade_public_44.as_string());
+        println!("Public 44: {}", handmade_public_44);
         // Public 44: [d1d04177/44'/1'/0']tpubDCoPjomfTqh1e7o1WgGpQtARWtkueXQAepTeNpWiitS3Sdv8RKJ1yvTrGHcwjDXp2SKyMrTEca4LoN7gEUiGCWboyWe2rz99Kf4jK4m2Zmx/*
         let handmade_public_49 = master
             .derive(&DerivationPath::new("m/49h/1h/0h".to_string()).unwrap())
             .unwrap()
             .as_public();
-        println!("Public 49: {}", handmade_public_49.as_string());
+        println!("Public 49: {}", handmade_public_49);
         // Public 49: [d1d04177/49'/1'/0']tpubDC65ZRvk1NDddHrVAUAZrUPJ772QXzooNYmPywYF9tMyNLYKf5wpKE7ZJvK9kvfG3FV7rCsHBNXy1LVKW95jrmC7c7z4hq7a27aD2sRrAhR/*
         let handmade_public_84 = master
             .derive(&DerivationPath::new("m/84h/1h/0h".to_string()).unwrap())
             .unwrap()
             .as_public();
-        println!("Public 84: {}", handmade_public_84.as_string());
+        println!("Public 84: {}", handmade_public_84);
         // Public 84: [d1d04177/84'/1'/0']tpubDDNxbq17egjFk2edjv8oLnzxk52zny9aAYNv9CMqTzA4mQDiQq818sEkNe9Gzmd4QU8558zftqbfoVBDQorG3E4Wq26tB2JeE4KUoahLkx6/*
         let handmade_public_86 = master
             .derive(&DerivationPath::new("m/86h/1h/0h".to_string()).unwrap())
             .unwrap()
             .as_public();
-        println!("Public 86: {}", handmade_public_86.as_string());
+        println!("Public 86: {}", handmade_public_86);
         // Public 86: [d1d04177/86'/1'/0']tpubDCJzjbcGbdEfXMWaL6QmgVmuSfXkrue7m2YNoacWwyc7a2XjXaKojRqNEbo41CFL3PyYmKdhwg2fkGpLX4SQCbQjCGxAkWHJTw9WEeenrJb/*
         let template_private_44 =
             Descriptor::new_bip44(&master, KeychainKind::External, Network::Testnet);
@@ -405,7 +405,7 @@ mod test {
         println!("Template public 44: {}", template_public_44);
         println!("Template public 84: {}", template_public_84);
         println!("Template public 86: {}", template_public_86);
-        // when using a public key, both to_string and as_string_private return the same string
+        // when using a public key, both to_string and to_string_private return the same string
         assert_eq!(
             template_public_44.to_string_with_secret(),
             template_public_44.to_string()

--- a/bdk-ffi/src/keys.rs
+++ b/bdk-ffi/src/keys.rs
@@ -19,9 +19,15 @@ use std::ops::Deref;
 use std::str::FromStr;
 use std::sync::{Arc, Mutex};
 
+/// A mnemonic seed phrase to recover a BIP-32 wallet.
+#[derive(uniffi::Object)]
+#[uniffi::export(Display)]
 pub struct Mnemonic(BdkMnemonic);
 
+#[uniffi::export]
 impl Mnemonic {
+    /// Generate a mnemonic given a word count.
+    #[uniffi::constructor]
     pub fn new(word_count: WordCount) -> Self {
         // TODO 4: I DON'T KNOW IF THIS IS A DECENT WAY TO GENERATE ENTROPY PLEASE CONFIRM
         let mut rng = rand::thread_rng();
@@ -33,13 +39,18 @@ impl Mnemonic {
         let mnemonic = BdkMnemonic::parse_in(Language::English, generated_key.to_string()).unwrap();
         Mnemonic(mnemonic)
     }
-
+    /// Parse a string as a mnemonic seed phrase.
+    #[uniffi::constructor]
     pub fn from_string(mnemonic: String) -> Result<Self, Bip39Error> {
         BdkMnemonic::from_str(&mnemonic)
             .map(Mnemonic)
             .map_err(Bip39Error::from)
     }
 
+    /// Construct a mnemonic given an array of bytes. Note that using weak entropy will result in a loss
+    /// of funds. To ensure the entropy is generated properly, read about your operating
+    /// system specific ways to generate secure random numbers.
+    #[uniffi::constructor]
     pub fn from_entropy(entropy: Vec<u8>) -> Result<Self, Bip39Error> {
         BdkMnemonic::from_entropy(entropy.as_slice())
             .map(Mnemonic)
@@ -53,11 +64,16 @@ impl Display for Mnemonic {
     }
 }
 
+/// A BIP-32 derivation path.
+#[derive(uniffi::Object)]
 pub struct DerivationPath {
     inner_mutex: Mutex<BdkDerivationPath>,
 }
 
+#[uniffi::export]
 impl DerivationPath {
+    /// Parse a string as a BIP-32 derivation path.
+    #[uniffi::constructor]
     pub fn new(path: String) -> Result<Self, Bip32Error> {
         BdkDerivationPath::from_str(&path)
             .map(|x| DerivationPath {

--- a/bdk-ffi/src/lib.rs
+++ b/bdk-ffi/src/lib.rs
@@ -15,7 +15,6 @@ use crate::bitcoin::FeeRate;
 use crate::bitcoin::OutPoint;
 use crate::bitcoin::Script;
 use crate::bitcoin::TxOut;
-use crate::descriptor::Descriptor;
 use crate::error::AddressParseError;
 use crate::error::Bip32Error;
 use crate::error::Bip39Error;

--- a/bdk-ffi/src/lib.rs
+++ b/bdk-ffi/src/lib.rs
@@ -34,8 +34,6 @@ use crate::error::PsbtParseError;
 use crate::error::RequestBuilderError;
 use crate::error::TransactionError;
 use crate::keys::DerivationPath;
-use crate::keys::DescriptorPublicKey;
-use crate::keys::DescriptorSecretKey;
 use crate::keys::Mnemonic;
 use crate::types::ChainPosition;
 use crate::types::Condition;

--- a/bdk-ffi/src/lib.rs
+++ b/bdk-ffi/src/lib.rs
@@ -33,8 +33,6 @@ use crate::error::PsbtFinalizeError;
 use crate::error::PsbtParseError;
 use crate::error::RequestBuilderError;
 use crate::error::TransactionError;
-use crate::keys::DerivationPath;
-use crate::keys::Mnemonic;
 use crate::types::ChainPosition;
 use crate::types::Condition;
 use crate::types::FullScanRequest;

--- a/bdk-swift/Tests/BitcoinDevKitTests/OfflineDescriptorTests.swift
+++ b/bdk-swift/Tests/BitcoinDevKitTests/OfflineDescriptorTests.swift
@@ -11,7 +11,7 @@ final class OfflineDescriptorTests: XCTestCase {
         )
         let descriptor: Descriptor = Descriptor.newBip86(
             secretKey: descriptorSecretKey,
-            keychain: KeychainKind.external,
+            keychainKind: KeychainKind.external,
             network: Network.testnet
         )
 


### PR DESCRIPTION
### Description

Move `Descriptor`, `DescriptorPublicKey`, `DescriptorPrivateKey`, `DerivationPath`, and `Mnemonic` to proc macros. Adds documentation when appropriate, including links. Uses `uniffi::export(Display)` to derive `Display`, think that is the proper way to do it?

### Notes to the reviewers

There was a `TODO` questioning the use of `thread_rng` to create a mnemonic. Yes, `thread_rng` implements `CryptoRng`: https://docs.rs/rand/latest/rand/rngs/struct.ThreadRng.html#impl-CryptoRng-for-ThreadRng

### Changelog

Deprecated `as_string` for `DescriptorSecretKey`/`DescriptorPublicKey` in favor of `to_string` via `Display`

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
