### PR TITLE
Move some bitcoin related primitives to proc macros

### DIFF
--- a/bdk-ffi/src/bdk.udl
+++ b/bdk-ffi/src/bdk.udl
@@ -656,18 +656,6 @@ dictionary Tx {
     TxStatus status;
 };
 
-dictionary WitnessProgram {
-    u8 version;
-    sequence<u8> program;
-};
-
-[Enum]
-interface AddressData {
-    P2pkh(string pubkey_hash);
-    P2sh(string script_hash);
-    Segwit(WitnessProgram witness_program);
-};
-
 // ------------------------------------------------------------------------
 // bdk_wallet crate - bitcoin re-exports
 // ------------------------------------------------------------------------

--- a/bdk-ffi/src/bdk.udl
+++ b/bdk-ffi/src/bdk.udl
@@ -681,22 +681,7 @@ enum WordCount {
   "Words24",
 };
 
-[Traits=(Display)]
-interface Address {
-  [Throws=AddressParseError]
-  constructor(string address, Network network);
-
-  [Name=from_script, Throws=FromScriptError]
-  constructor(Script script, Network network);
-
-  Script script_pubkey();
-
-  string to_qr_uri();
-
-  boolean is_valid_for_network(Network network);
-
-  AddressData to_address_data();
-};
+typedef interface Address;
 
 /// Bitcoin block header.
 /// Contains all the block’s information except the actual transactions, but including a root of a merkle tree
@@ -732,11 +717,7 @@ dictionary TxIn {
   sequence<sequence<u8>> witness;
 };
 
-interface Script {
-  constructor(sequence<u8> raw_output_script);
-
-  sequence<u8> to_bytes();
-};
+typedef interface Script;
 
 [NonExhaustive, Remote]
 enum Network {

--- a/bdk-ffi/src/bdk.udl
+++ b/bdk-ffi/src/bdk.udl
@@ -337,20 +337,7 @@ dictionary LocalOutput {
   ChainPosition chain_position;
 };
 
-/// Bitcoin transaction output.
-///
-/// Defines new coins to be created as a result of the transaction,
-/// along with spending conditions ("script", aka "output script"),
-/// which an input spending it must satisfy.
-///
-/// An output that is not yet spent by an input is called Unspent Transaction Output ("UTXO").
-dictionary TxOut {
-  /// The value of the output, in satoshis.
-  u64 value;
-
-  /// The script which must be satisfied for the output to be spent.
-  Script script_pubkey;
-};
+typedef dictionary TxOut;
 
 /// Represents the observed position of some chain data.
 [Enum]

--- a/bdk-ffi/src/bitcoin.rs
+++ b/bdk-ffi/src/bitcoin.rs
@@ -533,9 +533,18 @@ impl From<&BdkTxIn> for TxIn {
     }
 }
 
-#[derive(Debug, Clone)]
+/// Bitcoin transaction output.
+///
+/// Defines new coins to be created as a result of the transaction,
+/// along with spending conditions ("script", aka "output script"),
+/// which an input spending it must satisfy.
+///
+/// An output that is not yet spent by an input is called Unspent Transaction Output ("UTXO").
+#[derive(Debug, Clone, uniffi::Record)]
 pub struct TxOut {
+    /// The value of the output, in satoshis.
     pub value: u64,
+    /// The script which must be satisfied for the output to be spent.
     pub script_pubkey: Arc<Script>,
 }
 

--- a/bdk-ffi/src/bitcoin.rs
+++ b/bdk-ffi/src/bitcoin.rs
@@ -172,16 +172,23 @@ impl From<BdkHeader> for Header {
     }
 }
 
-#[derive(Debug)]
+/// The type of address.
+#[derive(Debug, uniffi::Enum)]
 pub enum AddressData {
+    /// Legacy.
     P2pkh { pubkey_hash: String },
+    /// Wrapped Segwit
     P2sh { script_hash: String },
+    /// Segwit
     Segwit { witness_program: WitnessProgram },
 }
 
-#[derive(Debug)]
+/// The version and program of a Segwit address.
+#[derive(Debug, uniffi::Record)]
 pub struct WitnessProgram {
+    /// Version. For example 1 for Taproot.
     pub version: u8,
+    /// The witness program.
     pub program: Vec<u8>,
 }
 

--- a/bdk-ffi/src/lib.rs
+++ b/bdk-ffi/src/lib.rs
@@ -12,7 +12,6 @@ mod types;
 mod wallet;
 
 use crate::bitcoin::Address;
-use crate::bitcoin::AddressData;
 use crate::bitcoin::Amount;
 use crate::bitcoin::FeeRate;
 use crate::bitcoin::Header;
@@ -21,7 +20,6 @@ use crate::bitcoin::Script;
 use crate::bitcoin::Transaction;
 use crate::bitcoin::TxIn;
 use crate::bitcoin::TxOut;
-use crate::bitcoin::WitnessProgram;
 use crate::descriptor::Descriptor;
 use crate::error::AddressParseError;
 use crate::error::Bip32Error;


### PR DESCRIPTION
The crusade continues with `Script`, `Address`, `AddressData`, `WitnessProgram` and `TxOut`

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing