### PR TITLE
feat: export xpub, tpub or vpub from Descriptor

### DIFF
--- a/bdk-ffi/Cargo.lock
+++ b/bdk-ffi/Cargo.lock
@@ -30,6 +30,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anstyle"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -115,6 +124,7 @@ dependencies = [
  "bdk_esplora",
  "bdk_kyoto",
  "bdk_wallet",
+ "regex",
  "thiserror",
  "uniffi",
 ]
@@ -801,6 +811,35 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
 ]
+
+[[package]]
+name = "regex"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "ring"

--- a/bdk-ffi/Cargo.toml
+++ b/bdk-ffi/Cargo.toml
@@ -23,6 +23,7 @@ bdk_core = { version = "0.4.1" }
 bdk_esplora = { version = "0.20.1", default-features = false, features = ["std", "blocking", "blocking-https-rustls"] }
 bdk_electrum = { version = "0.21.0", default-features = false, features = ["use-rustls-ring"] }
 bdk_kyoto = { version = "0.8.0" }
+regex = "1"
 
 uniffi = { version = "=0.29.1" }
 thiserror = "1.0.58"

--- a/bdk-ffi/src/bdk.udl
+++ b/bdk-ffi/src/bdk.udl
@@ -531,6 +531,9 @@ interface Descriptor {
 
   string to_string_with_secret();
 
+  // Get a xPub from the descriptor
+  string to_x_pub();
+
   /// Whether or not this key has multiple derivation paths.
   boolean is_multipath();
 

--- a/bdk-ffi/src/bdk.udl
+++ b/bdk-ffi/src/bdk.udl
@@ -531,7 +531,7 @@ interface Descriptor {
 
   string to_string_with_secret();
 
-  // Get a xPub from the descriptor
+  /// Get a xPub from the descriptor
   string to_x_pub();
 
   /// Whether or not this key has multiple derivation paths.

--- a/bdk-swift/Tests/BitcoinDevKitTests/OfflineDescriptorTests.swift
+++ b/bdk-swift/Tests/BitcoinDevKitTests/OfflineDescriptorTests.swift
@@ -14,7 +14,7 @@ final class OfflineDescriptorTests: XCTestCase {
             keychain: KeychainKind.external,
             network: Network.testnet
         )
-
+        
         XCTAssertEqual(descriptor.description, "tr([be1eec8f/86'/1'/0']tpubDCTtszwSxPx3tATqDrsSyqScPNnUChwQAVAkanuDUCJQESGBbkt68nXXKRDifYSDbeMa2Xg2euKbXaU3YphvGWftDE7ozRKPriT6vAo3xsc/0/*)#m7puekcx")
     }
 }

--- a/bdk-swift/Tests/BitcoinDevKitTests/OfflineWalletTests.swift
+++ b/bdk-swift/Tests/BitcoinDevKitTests/OfflineWalletTests.swift
@@ -3,8 +3,8 @@ import XCTest
 
 final class OfflineWalletTests: XCTestCase {
     private let descriptor = try! Descriptor(
-    descriptor: "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/1h/0/*)", 
-    network: Network.signet
+        descriptor: "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/1h/0/*)",
+        network: Network.signet
     )
     private let changeDescriptor = try! Descriptor(
         descriptor: "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/1h/1/*)", 
@@ -43,5 +43,10 @@ final class OfflineWalletTests: XCTestCase {
         )
 
         XCTAssertEqual(wallet.balance().total.toSat(), 0)
+    }
+    
+    func testXPub() throws {
+        print(descriptor.toXPub())
+        print(changeDescriptor.toXPub())
     }
 }


### PR DESCRIPTION
### Description

Created a convenient method to extract xpub from descriptors

### Notes to the reviewers

• Added new dependency: regex
• Created a new function to_x_pub in the Descriptor class to expose the xpub
• Added a test to validate `Descriptor::to_x_pub()`


### Changelog notice

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

### Checklists

#### All Submissions:

* [X] I've signed all my commits
* [X] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [X] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [x] I've added tests for the new feature
* [X] I've added docs for the new feature


