### PR TITLE
Use macros for `block::Header`

### DIFF
--- a/bdk-ffi/src/bdk.udl
+++ b/bdk-ffi/src/bdk.udl
@@ -605,28 +605,7 @@ enum WordCount {
 
 typedef interface Address;
 
-/// Bitcoin block header.
-/// Contains all the block’s information except the actual transactions, but including a root of a merkle tree
-/// committing to all transactions in the block.
-dictionary Header {
-  /// Block version, now repurposed for soft fork signalling.
-  i32 version;
-
-  /// Reference to the previous block in the chain.
-  string prev_blockhash;
-
-  /// The root hash of the merkle tree of transactions in the block.
-  string merkle_root;
-
-  /// The timestamp of the block, as claimed by the miner.
-  u32 time;
-
-  /// The target value below which the blockhash must lie.
-  u32 bits;
-
-  /// The nonce, selected to obtain a low enough blockhash.
-  u32 nonce;
-};
+typedef dictionary Header;
 
 typedef interface Transaction;
 

--- a/bdk-ffi/src/bitcoin.rs
+++ b/bdk-ffi/src/bitcoin.rs
@@ -150,12 +150,22 @@ impl Script {
 impl_from_core_type!(BdkScriptBuf, Script);
 impl_into_core_type!(Script, BdkScriptBuf);
 
+/// Bitcoin block header.
+/// Contains all the block’s information except the actual transactions, but including a root of a merkle tree
+/// committing to all transactions in the block.
+#[derive(uniffi::Record)]
 pub struct Header {
+    /// Block version, now repurposed for soft fork signalling.
     pub version: i32,
+    /// Reference to the previous block in the chain.
     pub prev_blockhash: String,
+    /// The root hash of the merkle tree of transactions in the block.
     pub merkle_root: String,
+    /// The timestamp of the block, as claimed by the miner.
     pub time: u32,
+    /// The target value below which the blockhash must lie.
     pub bits: u32,
+    /// The nonce, selected to obtain a low enough blockhash.
     pub nonce: u32,
 }
 

--- a/bdk-ffi/src/lib.rs
+++ b/bdk-ffi/src/lib.rs
@@ -14,7 +14,6 @@ mod wallet;
 use crate::bitcoin::Address;
 use crate::bitcoin::Amount;
 use crate::bitcoin::FeeRate;
-use crate::bitcoin::Header;
 use crate::bitcoin::OutPoint;
 use crate::bitcoin::Script;
 use crate::bitcoin::Transaction;


### PR DESCRIPTION
Somehow the `Transaction` is not being using from the crate, but this didn't seem to get caught by CI

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing