### PR TITLE
Introduce hash-like types

### DIFF
--- a/bdk-ffi/src/error.rs
+++ b/bdk-ffi/src/error.rs
@@ -1507,6 +1507,12 @@ impl From<BdkEncodeError> for TransactionError {
     }
 }
 
+#[derive(Debug, thiserror::Error, uniffi::Error)]
+pub enum HashParseError {
+    #[error("invalid hash: expected length 32 bytes, got {len} bytes")]
+    InvalidHash { len: u32 },
+}
+
 impl From<BdkSqliteError> for SqliteError {
     fn from(error: BdkSqliteError) -> Self {
         SqliteError::Sqlite {

--- a/bdk-ffi/src/macros.rs
+++ b/bdk-ffi/src/macros.rs
@@ -19,3 +19,32 @@ macro_rules! impl_into_core_type {
         }
     };
 }
+
+#[macro_export]
+macro_rules! impl_hash_like {
+    ($ffi_type:ident, $core_type:ident) => {
+        #[uniffi::export]
+        impl $ffi_type {
+            /// Construct a hash-like type from 32 bytes.
+            #[uniffi::constructor]
+            pub fn from_bytes(bytes: Vec<u8>) -> Result<Self, HashParseError> {
+                let hash_like: $core_type = deserialize(&bytes).map_err(|_| {
+                    let len = bytes.len() as u32;
+                    HashParseError::InvalidHash { len }
+                })?;
+                Ok(Self(hash_like))
+            }
+
+            /// Serialize this type into a 32 byte array.
+            pub fn serialize(&self) -> Vec<u8> {
+                serialize(&self.0)
+            }
+        }
+
+        impl std::fmt::Display for $ffi_type {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                self.0.fmt(f)
+            }
+        }
+    };
+}


### PR DESCRIPTION
Types like "Txid", "BlockHash", "DescriptorId" are all just 32 byte arrays that represent hashes with different meanings. Currently they are represented as strings at the FFI layer, but they are also meaningful arrays of bytes. Particularly if a user wants to implement persistence over the FFI layer, they would want to efficiently serialize these types.

Here I am introducing a new group of types that all implement display, allow serialization to bytes, and may be constructed from an array of bytes. I went with a "rule of 3s" here, and also introduced a macro to do these implementations because there was a lot of boilerplate involved.

Note that all of these are included in the wallet changeset, which is required to represent in-full for FFI-layer custom persistence: https://docs.rs/bdk_wallet/latest/bdk_wallet/struct.ChangeSet.html

edit: Added `TxMerkleNode`, which may be interesting in the future if merkle inclusion proofs come to the bindings layer at some point for Electrum users.

edit: Added `Wtxid`, which is how transactions are identified over the p2p network as of SegWit. This is useful for Kyoto users.

### Notes to the reviewers

- I understand macros may not be the most legible, but this case in particular saves a lot of repeated logic.
- "DescriptorId" from `bdk_chain` is mostly an alias for `sha256::Hash`

### Changelog notice

- Introduce object types for `Txid`, `BlockHash`, `DescriptorId`, `Wtxid`, `TxMerkleNode`

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
