### PR TITLE
Express the wallet changeset over the FFI layer

### DIFF
--- a/bdk-ffi/src/bdk.udl
+++ b/bdk-ffi/src/bdk.udl
@@ -304,10 +304,6 @@ interface FullScanScriptInspector {
   void inspect(KeychainKind keychain, u32 index, Script script);
 };
 
-/// A changeset for [`Wallet`].
-[Remote]
-interface ChangeSet {};
-
 // ------------------------------------------------------------------------
 // bdk_wallet crate - wallet module
 // ------------------------------------------------------------------------

--- a/bdk-ffi/src/bitcoin.rs
+++ b/bdk-ffi/src/bitcoin.rs
@@ -72,13 +72,22 @@ impl From<OutPoint> for BdkOutPoint {
     }
 }
 
-/// An [`OutPoint`] suitable as a key in a hash map.
+/// An [`OutPoint`] used as a key in a hash map.
+///
+/// Due to limitations in generating the foreign language bindings, we cannot use [`OutPoint`] as a
+/// key for hash maps.
 #[derive(Debug, PartialEq, Eq, std::hash::Hash, uniffi::Object)]
 #[uniffi::export(Debug, Eq, Hash)]
 pub struct HashableOutPoint(pub(crate) OutPoint);
 
 #[uniffi::export]
 impl HashableOutPoint {
+    /// Create a key for a key-value store from an [`OutPoint`]
+    #[uniffi::constructor]
+    pub fn new(outpoint: OutPoint) -> Self {
+        Self(outpoint)
+    }
+
     /// Get the internal [`OutPoint`]
     pub fn outpoint(&self) -> OutPoint {
         self.0.clone()

--- a/bdk-ffi/src/lib.rs
+++ b/bdk-ffi/src/lib.rs
@@ -43,7 +43,6 @@ use crate::types::SyncScriptInspector;
 
 use bdk_wallet::bitcoin::Network;
 use bdk_wallet::keys::bip39::WordCount;
-use bdk_wallet::ChangeSet;
 use bdk_wallet::KeychainKind;
 
 uniffi::include_scaffolding!("bdk");

--- a/bdk-ffi/tests/bindings/test.kts
+++ b/bdk-ffi/tests/bindings/test.kts
@@ -4,7 +4,6 @@
  */
 
 import org.bitcoindevkit.bitcoin.Network
-import org.bitcoindevkit.Condition
 
 // A type from bitcoin-ffi
 val network = Network.TESTNET

--- a/bdk-ffi/tests/bindings/test.py
+++ b/bdk-ffi/tests/bindings/test.py
@@ -1,4 +1,3 @@
-from bdkpython import Condition
 from bdkpython.bitcoin import Network
 
 import unittest


### PR DESCRIPTION
<!-- Erase any parts of this template not applicable to your Pull Request. -->

### Description

Builds on #754 to create a fully expressive and serializable `ChangeSet` type. The goal is for this to enable arbitrary persistence backends across the FFI layer. Ultimately that would close #739 and any further database requests that are outside the immediately supported options.

For context: The iterators in the BDK changesets are `BTree` based to be `no_std` compatible and have deterministic ordering of duplicate data across all targets. UniFFI exposes only two iterators across the boundary, `Vec` and `HashMap`, but I can try to lay out why I think using these is acceptable. 

The goal here is to convert between `bdk_wallet::ChangeSet` and FFI `ChangeSet`, and the easiest way to go about that is to just make each field convertible. For the `LocalChain::ChangeSet`, I iterate over the `BTreeMap`, which will return the key-value pairs in order. That means the vector will be in order over the FFI layer. Everything else coming from BDK _could_ be ordered by key, but is not required in my opinion to implement the persistence. For instance any mapping from `DescriptorId` to last revealed index is okay, as the `DescirptorId` do not necessarily have to be in any particular order. Same goes for `Txid` or `Outpoint` mapping to some value. While it is nice to be reproducible, these keys are suitable for a `HashMap`.

Can elaborate on the next call

### Notes to the reviewers

In Swift, and key of a `HashMap` must implement `Equitable` and `Hashable`. We can export `Eq` and `Hash` from Rust for _Objects_, but not for _Records_ from what I can tell. As a result, I made a kind-of-gross wrapper called `HashableOutPoint` that is an `Object` so it can be used as a key, but it is convertible to the underlying `Record` if required. Open to ideas on that one.

Also, I cannot for the life of me figure out the best way to go from a `Descriptor<DescriptorPublicKey>` into `DescriptorPublicKey` and vise versa without introducing an `unwrap`. Feels like we can improve that.

### Changelog notice

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
