### PR TITLE
Export public types from `Script`

### DIFF
--- a/bdk-ffi/Cargo.lock
+++ b/bdk-ffi/Cargo.lock
@@ -107,7 +107,7 @@ dependencies = [
 
 [[package]]
 name = "bdk-ffi"
-version = "1.2.0-dev"
+version = "2.0.0-alpha.0"
 dependencies = [
  "assert_matches",
  "bdk_core",

--- a/bdk-ffi/src/bitcoin.rs
+++ b/bdk-ffi/src/bitcoin.rs
@@ -143,8 +143,10 @@ impl_into_core_type!(Amount, BdkAmount);
 #[derive(Clone, Debug, uniffi::Object)]
 pub struct Script(pub BdkScriptBuf);
 
+#[uniffi::export]
 impl Script {
     /// Interpret an array of bytes as a bitcoin script.
+    #[uniffi::constructor]
     pub fn new(raw_output_script: Vec<u8>) -> Self {
         let script: BdkScriptBuf = raw_output_script.into();
         Script(script)


### PR DESCRIPTION
### Description

I was developing on the latest commit in master and the script API was missing because it was not annotated with `uniffi::export`. I did a quick audit of the `impl` blocks but probably worth another pass by someone else to see if there are impl blocks missing exports

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
