### PR TITLE
Use `Txid`, `BlockHash`, `DescriptorId`, and `TxMerkleNode` where applicable

### DIFF
--- a/bdk-ffi/src/descriptor.rs
+++ b/bdk-ffi/src/descriptor.rs
@@ -1,3 +1,4 @@
+use crate::bitcoin::DescriptorId;
 use crate::error::DescriptorError;
 use crate::keys::DescriptorPublicKey;
 use crate::keys::DescriptorSecretKey;
@@ -5,6 +6,7 @@ use crate::keys::DescriptorSecretKey;
 use bdk_wallet::bitcoin::bip32::Fingerprint;
 use bdk_wallet::bitcoin::key::Secp256k1;
 use bdk_wallet::bitcoin::Network;
+use bdk_wallet::chain::DescriptorExt;
 use bdk_wallet::descriptor::{ExtendedDescriptor, IntoWalletDescriptor};
 use bdk_wallet::keys::DescriptorPublicKey as BdkDescriptorPublicKey;
 use bdk_wallet::keys::{DescriptorSecretKey as BdkDescriptorSecretKey, KeyMap};
@@ -294,6 +296,12 @@ impl Descriptor {
     /// Does this descriptor contain paths: https://github.com/bitcoin/bips/blob/master/bip-0389.mediawiki
     pub fn is_multipath(&self) -> bool {
         self.extended_descriptor.is_multipath()
+    }
+
+    /// A unique identifier for the descriptor.
+    pub fn descriptor_id(&self) -> Arc<DescriptorId> {
+        let d_id = self.extended_descriptor.descriptor_id();
+        Arc::new(DescriptorId(d_id.0))
     }
 
     /// Return descriptors for all valid paths.

--- a/bdk-ffi/src/wallet.rs
+++ b/bdk-ffi/src/wallet.rs
@@ -1,4 +1,4 @@
-use crate::bitcoin::{Amount, FeeRate, OutPoint, Psbt, Script, Transaction};
+use crate::bitcoin::{Amount, FeeRate, OutPoint, Psbt, Script, Transaction, Txid};
 use crate::descriptor::Descriptor;
 use crate::error::{
     CalculateFeeError, CannotConnectError, CreateWithPersistError, DescriptorError,
@@ -11,13 +11,12 @@ use crate::types::{
     Update,
 };
 
-use bdk_wallet::bitcoin::{Network, Txid};
+use bdk_wallet::bitcoin::Network;
 use bdk_wallet::rusqlite::Connection as BdkConnection;
 use bdk_wallet::signer::SignOptions as BdkSignOptions;
 use bdk_wallet::{KeychainKind, PersistedWallet, Wallet as BdkWallet};
 
 use std::borrow::BorrowMut;
-use std::str::FromStr;
 use std::sync::{Arc, Mutex, MutexGuard};
 
 /// A Bitcoin wallet.
@@ -335,10 +334,8 @@ impl Wallet {
     ///   confirmed or unconfirmed. If the transaction is confirmed, the anchor which proves the
     ///   confirmation is provided. If the transaction is unconfirmed, the unix timestamp of when
     ///   the transaction was last seen in the mempool is provided.
-    pub fn get_tx(&self, txid: String) -> Result<Option<CanonicalTx>, TxidParseError> {
-        let txid =
-            Txid::from_str(txid.as_str()).map_err(|_| TxidParseError::InvalidTxid { txid })?;
-        Ok(self.get_wallet().get_tx(txid).map(|tx| tx.into()))
+    pub fn get_tx(&self, txid: Arc<Txid>) -> Result<Option<CanonicalTx>, TxidParseError> {
+        Ok(self.get_wallet().get_tx(txid.0).map(|tx| tx.into()))
     }
 
     /// Calculates the fee of a given transaction. Returns [`Amount::ZERO`] if `tx` is a coinbase transaction.

--- a/bdk-jvm/lib/src/test/kotlin/org/bitcoindevkit/LiveElectrumClientTest.kt
+++ b/bdk-jvm/lib/src/test/kotlin/org/bitcoindevkit/LiveElectrumClientTest.kt
@@ -48,7 +48,7 @@ class LiveElectrumClientTest {
 
         assertEquals(
             expected = "000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943",
-            actual = features.genesisHash
+            actual = features.genesisHash.toString()
         )
     }
 

--- a/bdk-swift/Tests/BitcoinDevKitTests/LiveElectrumClientTests.swift
+++ b/bdk-swift/Tests/BitcoinDevKitTests/LiveElectrumClientTests.swift
@@ -54,7 +54,7 @@ final class LiveElectrumClientTests: XCTestCase {
         print("Server Features:\n\(features)")
 
         XCTAssertEqual(
-            features.genesisHash,
+            features.genesisHash.description,
             "000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943"
         )
     }


### PR DESCRIPTION
Explicitly leaving out `BlockId` to avoid merge conflicts. The refactor here is moslty uneventful, however it removes a handful of `unwrap` when parsing transaction IDs.

### Changelog notice

- Use new hash types across public APIs

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
