### PR TITLE
Update Python setuptools build dependency

### DIFF
--- a/bdk-python/requirements.txt
+++ b/bdk-python/requirements.txt
@@ -1,4 +1,4 @@
 semantic-version==2.9.0
 typing_extensions==4.0.1
-setuptools==67.4.0
+setuptools==75.3.2
 wheel==0.38.4


### PR DESCRIPTION
This PR fixes a dependabot vulnerability present in `setuptools < 70.1.0`.

I simply updated setuptools to the latest version available for CI runs.

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
