### PR TITLE
Update Kyoto to latest version

### DIFF
--- a/bdk-ffi/Cargo.lock
+++ b/bdk-ffi/Cargo.lock
@@ -166,9 +166,9 @@ dependencies = [
 
 [[package]]
 name = "bdk_kyoto"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "510abdf0efa06d5bc83a48af90ca43718ea8adf1cf660c663ca313ca0846144a"
+checksum = "fd5219ed3dc0c614aa9539b5005a63b596ec7391949c79117f3b83a490d75a46"
 dependencies = [
  "bdk_wallet",
  "kyoto-cbf",
@@ -221,9 +221,9 @@ dependencies = [
 
 [[package]]
 name = "bitcoin"
-version = "0.32.5"
+version = "0.32.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce6bc65742dea50536e35ad42492b234c27904a27f0abdcbce605015cb4ea026"
+checksum = "ad8929a18b8e33ea6b3c09297b687baaa71fb1b97353243a3f1029fad5c59c5b"
 dependencies = [
  "base58ck",
  "base64 0.21.7",
@@ -579,9 +579,9 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "kyoto-cbf"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a71eba746c4c4936a1b75336560b40ebe1145aa5b87cc90bc0ccfeacf4c49e79"
+checksum = "360f3785e4f7514ed97e0acb94d0c5acb4281441ec1b6c01f2f941c618fe1049"
 dependencies = [
  "bip324",
  "bitcoin",

--- a/bdk-ffi/Cargo.toml
+++ b/bdk-ffi/Cargo.toml
@@ -22,7 +22,7 @@ bdk_wallet = { version = "1.2.0", features = ["all-keys", "keys-bip39", "rusqlit
 bdk_core = { version = "0.4.1" }
 bdk_esplora = { version = "0.20.1", default-features = false, features = ["std", "blocking", "blocking-https-rustls"] }
 bdk_electrum = { version = "0.21.0", default-features = false, features = ["use-rustls-ring"] }
-bdk_kyoto = { version = "0.9.0" }
+bdk_kyoto = { version = "0.10.0" }
 
 uniffi = { version = "=0.29.1" }
 thiserror = "1.0.58"

--- a/bdk-python/tests/test_live_kyoto.py
+++ b/bdk-python/tests/test_live_kyoto.py
@@ -1,4 +1,4 @@
-from bdkpython import Connection, Network, Descriptor, KeychainKind, CbfBuilder, CbfComponents, CbfClient, CbfNode, IpAddress, ScanType, Peer, Update, Wallet
+from bdkpython import Connection, Network, Descriptor, KeychainKind, CbfBuilder, CbfComponents, CbfClient, CbfNode, CbfError, IpAddress, ScanType, Peer, Update, Wallet
 import unittest
 import os
 import asyncio
@@ -45,15 +45,18 @@ class LiveKyotoTest(unittest.IsolatedAsyncioTestCase):
                 print(log)
         log_task = asyncio.create_task(log_loop(client))
         node.run()
-        update: Update = await client.update()
-        wallet.apply_update(update)
-        self.assertGreater(
-            wallet.balance().total.to_sat(),
-            0,
-            f"Wallet balance must be greater than 0! Please send funds to {wallet.reveal_next_address(KeychainKind.EXTERNAL).address} and try again."
-        )
-        log_task.cancel()
-        await client.shutdown()
+        try:
+            update: Update = await client.update()
+            wallet.apply_update(update)
+            self.assertGreater(
+                wallet.balance().total.to_sat(),
+                0,
+                f"Wallet balance must be greater than 0! Please send funds to {wallet.reveal_next_address(KeychainKind.EXTERNAL).address} and try again."
+            )
+            log_task.cancel()
+            client.shutdown()
+        except CbfError as e:
+            raise e
 
 if __name__ == "__main__":
     unittest.main()

--- a/bdk-swift/Tests/BitcoinDevKitTests/LiveKyotoTests.swift
+++ b/bdk-swift/Tests/BitcoinDevKitTests/LiveKyotoTests.swift
@@ -45,7 +45,7 @@ final class LiveKyotoTests: XCTestCase {
                 }
             }
         }
-        let update = await client.update()
+        let update = try await client.update()
         try wallet.applyUpdate(update: update)
         let address = wallet.revealNextAddress(keychain: KeychainKind.external).address.description
         XCTAssertGreaterThan(


### PR DESCRIPTION
Some minor changes to Kyoto:

We know internally if the node has stopped within the `update` method now, so we can return that error. There is also a new informational message. We also refer to all transactions with `Wtxid`, consistent with the p2p network.

### Changelog notice

- Update `bdk_kyoto` to `0.10.0`

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing.
