### PR TITLE
Get `Wtxid` from a transaction

### DIFF
--- a/bdk-ffi/src/bitcoin.rs
+++ b/bdk-ffi/src/bitcoin.rs
@@ -308,6 +308,11 @@ impl Transaction {
         Arc::new(Txid(self.0.compute_txid()))
     }
 
+    /// Compute the Wtxid, which includes the witness in the transaction hash.
+    pub fn compute_wtxid(&self) -> Arc<Wtxid> {
+        Arc::new(Wtxid(self.0.compute_wtxid()))
+    }
+
     /// Returns the weight of this transaction, as defined by BIP-141.
     ///
     /// > Transaction weight is defined as Base transaction size * 3 + Total transaction size (ie.


### PR DESCRIPTION
Espcially when considering the peer-to-peer network, most transactions are managed by their `Wtxid`, which includes the witness data when preparing a hash.

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
