### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+/bdk-jvm/     @thunderbiscuit
+/bdk-android/ @thunderbiscuit
+/bdk-swift/   @reez


### PR DESCRIPTION
Let me know what you think @reez. This is just a start, basically making @reez an automatic reviewer of code changes in the `bdk-swift` directory, and me an automatic reviewer of code changes in the `bdk-jvm` and `bdk-android` directories.

This is a fairly small scope, since those directories are only affected by build scripts and tests, but I just wanted to get the codeowners file in there. We can adjust as we go, but it's good practice and outlines explicitly the devs invested and leading certain parts of the codebase.

Note that I have not added anyone for python or the Rust side yet.