### PR TITLE
Drop Python 3.8 and 3.9 support

### DIFF
--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -27,8 +27,6 @@ jobs:
     strategy:
       matrix:
         python:
-          - cp38-cp38
-          - cp39-cp39
           - cp310-cp310
           - cp311-cp311
           - cp312-cp312
@@ -73,8 +71,6 @@ jobs:
     strategy:
       matrix:
         python:
-          - "3.8"
-          - "3.9"
           - "3.10"
           - "3.11"
           - "3.12"
@@ -119,8 +115,6 @@ jobs:
     strategy:
       matrix:
         python:
-          - "3.8"
-          - "3.9"
           - "3.10"
           - "3.11"
           - "3.12"
@@ -164,8 +158,6 @@ jobs:
     strategy:
       matrix:
         python:
-          - "3.8"
-          - "3.9"
           - "3.10"
           - "3.11"
           - "3.12"


### PR DESCRIPTION
Python 3.9 is 5 years old. The CI builds the Python binary for every platform and every version from 3.8-latest, but hasn't caught a significant issue.

Motivated by #769 

### Changelog notice

- CI no longer builds for Python 3.8 and 3.9

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [x] I'm linking the issue being fixed by this PR
