### PR TITLE
feat: add from_string constructor for hash-like types

### DIFF
--- a/bdk-ffi/src/error.rs
+++ b/bdk-ffi/src/error.rs
@@ -1516,6 +1516,9 @@ impl From<BdkEncodeError> for TransactionError {
 pub enum HashParseError {
     #[error("invalid hash: expected length 32 bytes, got {len} bytes")]
     InvalidHash { len: u32 },
+
+    #[error("invalid hex string: {hex}")]
+    InvalidHexString { hex: String },
 }
 
 impl From<bdk_kyoto::builder::SqlInitializationError> for CbfBuilderError {

--- a/bdk-ffi/src/macros.rs
+++ b/bdk-ffi/src/macros.rs
@@ -35,6 +35,14 @@ macro_rules! impl_hash_like {
                 Ok(Self(hash_like))
             }
 
+            /// Construct a hash-like type from a hex string.
+            #[uniffi::constructor]
+            pub fn from_string(hex: String) -> Result<Self, HashParseError> {
+                hex.parse::<$core_type>()
+                    .map(Self)
+                    .map_err(|_| HashParseError::InvalidHexString { hex })
+            }
+
             /// Serialize this type into a 32 byte array.
             pub fn serialize(&self) -> Vec<u8> {
                 serialize(&self.0)


### PR DESCRIPTION
<!-- Erase any parts of this template not applicable to your Pull Request. -->

### Description

This PR adds a `from_string` constructor to all hash-like types to enable creating these types from hex strings. This restores the convenience of string-based construction.

### Notes to the reviewers

Tested locally built swift bindings with iOS app, and then was able to use `fromString`(swift) to address some lines of code mentioned in https://github.com/bitcoindevkit/BDKSwiftExampleWallet/pull/297/files

_Example:_ 

Pass a string into `BlockHash.fromString` to construct a `BlockHash` instead of pass bytes into `BlockHash.fromBytes`

### Changelog notice

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
