### PR TITLE
Add public_descriptor to wallet implementation

### DIFF
--- a/bdk-ffi/src/wallet.rs
+++ b/bdk-ffi/src/wallet.rs
@@ -433,6 +433,15 @@ impl Wallet {
             .tx_details(txid.0)
             .map(|details| details.into())
     }
+
+    /// Returns the descriptor used to create addresses for a particular `keychain`.
+    ///
+    /// It's the "public" version of the wallet's descriptor, meaning a new descriptor that has
+    /// the same structure but with the all secret keys replaced by their corresponding public key.
+    /// This can be used to build a watch-only version of a wallet.
+    pub fn public_descriptor(&self, keychain: KeychainKind) -> String {
+        self.get_wallet().public_descriptor(keychain).to_string()
+    }
 }
 
 impl Wallet {


### PR DESCRIPTION
<!-- Erase any parts of this template not applicable to your Pull Request. -->

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->
I have been working with wallet and our descriptor type for my work on Psbt and multisig. I noticed that we cannot get the descriptor used to create the wallet directly from the `Wallet` type. Hence exposing [public_descriptor](https://docs.rs/bdk_wallet/latest/bdk_wallet/struct.Wallet.html#method.public_descriptor) will allow us get this directly. A good use case is if you want to create a watch only wallet you could just call `public_descriptor`.

At the moment I am returning the descriptor as a string instead of a [ExtendedDescriptor](https://docs.rs/bdk_wallet/latest/bdk_wallet/descriptor/type.ExtendedDescriptor.html). The downside to this is we loose all the functionality `ExtendedDescriptor` provides. We do not have a ExtendedDescriptor type which is just an alias for `Descriptor<DescriptorPublicKey>`. 

We could create and implement the type if necessary instead of using a string.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [x] I've added docs for the new feature