### PR TITLE
Update Kyoto to latest version

### DIFF
--- a/bdk-ffi/Cargo.lock
+++ b/bdk-ffi/Cargo.lock
@@ -164,9 +164,9 @@ dependencies = [
 
 [[package]]
 name = "bdk_kyoto"
-version = "0.11.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bdb5c2af2da8d0ddef7293835b31191a4ed77ca8fe89d66c442300c8c2c8551"
+checksum = "adeefeb8b453b966761b2b965daeeed163b5ee6984f19daed969d7c90b3ead58"
 dependencies = [
  "bdk_wallet",
  "kyoto-cbf",
@@ -577,9 +577,9 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "kyoto-cbf"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "360f3785e4f7514ed97e0acb94d0c5acb4281441ec1b6c01f2f941c618fe1049"
+checksum = "00ee7b57630516848fe664babc355b07e13a0dd026b8b5795db666908f37883a"
 dependencies = [
  "bip324",
  "bitcoin",

--- a/bdk-ffi/Cargo.toml
+++ b/bdk-ffi/Cargo.toml
@@ -21,7 +21,7 @@ default = ["uniffi/cli"]
 bdk_wallet = { version = "2.0.0", features = ["all-keys", "keys-bip39", "rusqlite"] }
 bdk_esplora = { version = "0.22.0", default-features = false, features = ["std", "blocking", "blocking-https-rustls"] }
 bdk_electrum = { version = "0.23.0", default-features = false, features = ["use-rustls-ring"] }
-bdk_kyoto = { version = "0.11.0" }
+bdk_kyoto = { version = "0.13.0" }
 
 uniffi = { version = "=0.29.1" }
 thiserror = "1.0.58"


### PR DESCRIPTION
A couple new `Info` variants are added in this release to give the user more context as to what is happening with the block header chain. There is also a new function, `lookup_host`, that allows the developer to query Bitcoin DNS seeders. Because the user may already configure a DNS resolver, this resolver is added to the `CbfClient` and used to resolve DNS queries.

There was also missing docs for adding a Socks5 proxy.

### Changelog notice

- `CbfClient` can query Bitcoin DNS seeders

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [x] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
