### PR TITLE
refactor: use macros for `WordCount`

### DIFF
--- a/bdk-ffi/src/bdk.udl
+++ b/bdk-ffi/src/bdk.udl
@@ -304,14 +304,6 @@ typedef record Condition;
 // bdk_wallet crate - bitcoin re-exports
 // ------------------------------------------------------------------------
 
-[Remote]
-enum WordCount {
-  "Words12",
-  "Words15",
-  "Words18",
-  "Words21",
-  "Words24",
-};
 
 typedef interface Script;
 

--- a/bdk-ffi/src/lib.rs
+++ b/bdk-ffi/src/lib.rs
@@ -35,6 +35,5 @@ use crate::types::LockTime;
 use crate::types::PkOrF;
 
 use bdk_wallet::bitcoin::Network;
-use bdk_wallet::keys::bip39::WordCount;
 
 uniffi::include_scaffolding!("bdk");

--- a/bdk-ffi/src/types.rs
+++ b/bdk-ffi/src/types.rs
@@ -48,6 +48,17 @@ pub enum KeychainKind {
     Internal = 1,
 }
 
+type WordCount = bdk_wallet::keys::bip39::WordCount;
+
+#[uniffi::remote(Enum)]
+pub enum WordCount {
+    Words12,
+    Words15,
+    Words18,
+    Words21,
+    Words24,
+}
+
 /// Represents the observed position of some chain data.
 #[derive(Debug, uniffi::Enum, Clone)]
 pub enum ChainPosition {


### PR DESCRIPTION
<!-- Erase any parts of this template not applicable to your Pull Request. -->

### Description

Migrate `WordCount` to use proc macro

### Notes to the reviewers

Unfortunately `lib.rs` required type alias thing, but this is the same pattern used for KeychainKind in `types.rs`. The type alias is necessary because we can't have both an import and an enum definition with the same name in the same scope.

### Changelog notice

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
