### PR TITLE
Kyoto version bump and new methods

### DIFF
--- a/bdk-ffi/Cargo.lock
+++ b/bdk-ffi/Cargo.lock
@@ -164,9 +164,9 @@ dependencies = [
 
 [[package]]
 name = "bdk_kyoto"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adeefeb8b453b966761b2b965daeeed163b5ee6984f19daed969d7c90b3ead58"
+checksum = "1bb33172976f7fa26115ad6842f7903a2af325544eac6ddf5a17099e3cd9df3c"
 dependencies = [
  "bdk_wallet",
  "kyoto-cbf",
@@ -577,9 +577,9 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "kyoto-cbf"
-version = "0.13.0"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00ee7b57630516848fe664babc355b07e13a0dd026b8b5795db666908f37883a"
+checksum = "805f16bcf1d4738529f230404e7d0ab6e9ecf9e265920c212d446a291a93297e"
 dependencies = [
  "bip324",
  "bitcoin",

--- a/bdk-ffi/Cargo.toml
+++ b/bdk-ffi/Cargo.toml
@@ -21,7 +21,7 @@ default = ["uniffi/cli"]
 bdk_wallet = { version = "2.0.0", features = ["all-keys", "keys-bip39", "rusqlite"] }
 bdk_esplora = { version = "0.22.0", default-features = false, features = ["std", "blocking", "blocking-https-rustls"] }
 bdk_electrum = { version = "0.23.0", default-features = false, features = ["use-rustls-ring"] }
-bdk_kyoto = { version = "0.13.0" }
+bdk_kyoto = { version = "0.13.1" }
 
 uniffi = { version = "=0.29.1" }
 thiserror = "1.0.58"


### PR DESCRIPTION
The first commit adds a patch from `bdk_kyoto` to make DNS queries more robust and reliable

The second commit adds some nice-to-haves I discovered while working on a macOS app. `connect` is straightforward, where the user can request the light client connects to a specific node even while the light client is running. `average_fee_rate` is more of a niche case, but I realized would still be useful in the desktop/server case. The method requests a block to compute the average fee rate. Computing the fee rate is easily done, it is just a bandwidth-heavy method.

#### Changelog

- Add `connect` and `average_fee_rate` to Kyoto client methods

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

