### PR TITLE
feat: add `spend_utxo` to Psbt

### DIFF
--- a/bdk-ffi/src/bitcoin.rs
+++ b/bdk-ffi/src/bitcoin.rs
@@ -560,6 +560,13 @@ impl Psbt {
         let psbt = self.0.lock().unwrap();
         serde_json::to_string(psbt.deref()).unwrap()
     }
+
+    /// Returns the spending utxo for this PSBT's input at `input_index`.
+    pub(crate) fn spend_utxo(&self, input_index: u64) -> String {
+        let psbt = self.0.lock().unwrap();
+        let utxo = psbt.spend_utxo(input_index as usize).unwrap();
+        serde_json::to_string(&utxo).unwrap()
+    }
 }
 
 impl From<BdkPsbt> for Psbt {
@@ -684,6 +691,7 @@ impl_hash_like!(TxMerkleNode, BitcoinDoubleSha256Hash);
 mod tests {
     use crate::bitcoin::Address;
     use crate::bitcoin::Network;
+    use crate::bitcoin::Psbt;
 
     #[test]
     fn test_is_valid_for_network() {
@@ -1038,5 +1046,20 @@ mod tests {
         .unwrap();
         let segwit_data = segwit.to_address_data();
         println!("Segwit data: {:#?}", segwit_data);
+    }
+
+    #[test]
+    fn test_psbt_spend_utxo() {
+        let psbt = Psbt::new("cHNidP8BAH0CAAAAAXHl8cCbj84lm1v42e54IGI6CQru/nBXwrPE3q2fiGO4AAAAAAD9////Ar4DAAAAAAAAIgAgYw/rnGd4Bifj8s7TaMgR2tal/lq+L1jVv2Sqd1mxMbJEEQAAAAAAABYAFNVpt8vHYUPZNSF6Hu07uP1YeHts4QsAAAABALUCAAAAAAEBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD/////BAJ+CwD/////AkAlAAAAAAAAIgAgQyrnn86L9D3vDiH959KJbPudDHc/bp6nI9E5EBLQD1YAAAAAAAAAACZqJKohqe3i9hw/cdHe/T+pmd+jaVN1XGkGiXmZYrSL69g2l06M+QEgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQErQCUAAAAAAAAiACBDKuefzov0Pe8OIf3n0ols+50Mdz9unqcj0TkQEtAPViICAy4V+d/Qff71zzPXxK4FWG5x+wL/Ku93y/LG5p+0rI2xSDBFAiEA9b0OdASAs0P2uhQinjN7QGP5jX/b32LcShBmny8U0RUCIBebxvCDbpchCjqLAhOMjydT80DAzokaalGzV7XVTsbiASICA1tMY+46EgxIHU18bgHnUvAAlAkMq5LfwkpOGZ97sDKRRzBEAiBpmlZwJocNEiKLxexEX0Par6UgG8a89AklTG3/z9AHlAIgQH/ybCvfKJzr2dq0+IyueDebm7FamKIJdzBYWMXRr/wBIgID+aCzK9nclwhbbN7KbIVGUQGLWZsjcaqWPxk9gFeG+FxIMEUCIQDRPBzb0i9vaUmxCcs1yz8uq4tq1mdDAYvvYn3isKEhFAIgfmeTLLzMo0mmQ23ooMnyx6iPceE8xV5CvARuJsd88tEBAQVpUiEDW0xj7joSDEgdTXxuAedS8ACUCQyrkt/CSk4Zn3uwMpEhAy4V+d/Qff71zzPXxK4FWG5x+wL/Ku93y/LG5p+0rI2xIQP5oLMr2dyXCFts3spshUZRAYtZmyNxqpY/GT2AV4b4XFOuIgYDLhX539B9/vXPM9fErgVYbnH7Av8q73fL8sbmn7SsjbEYCapBE1QAAIABAACAAAAAgAAAAAAAAAAAIgYDW0xj7joSDEgdTXxuAedS8ACUCQyrkt/CSk4Zn3uwMpEY2bvrelQAAIABAACAAAAAgAAAAAAAAAAAIgYD+aCzK9nclwhbbN7KbIVGUQGLWZsjcaqWPxk9gFeG+FwYAKVFVFQAAIABAACAAAAAgAAAAAAAAAAAAAEBaVIhA7cr8fTHOPtE+t0zM3iWJvpfPvsNaVyQ0Sar6nIe9tQXIQMm7k7OY+q+Lsge3bVACuSa9r19Js+lNuTtEhehWkpe1iECelHmzmhzDsQTDnApIcnWRz3oFR68UX1ag8jfk/SKuopTriICAnpR5s5ocw7EEw5wKSHJ1kc96BUevFF9WoPI35P0irqKGAClRVRUAACAAQAAgAAAAIABAAAAAAAAACICAybuTs5j6r4uyB7dtUAK5Jr2vX0mz6U25O0SF6FaSl7WGAmqQRNUAACAAQAAgAAAAIABAAAAAAAAACICA7cr8fTHOPtE+t0zM3iWJvpfPvsNaVyQ0Sar6nIe9tQXGNm763pUAACAAQAAgAAAAIABAAAAAAAAAAAA".to_string())
+        .unwrap();
+        let psbt_utxo = psbt.spend_utxo(0);
+
+        println!("Psbt utxo: {:?}", psbt_utxo);
+
+        assert_eq!(
+            psbt_utxo,
+            r#"{"value":9536,"script_pubkey":"0020432ae79fce8bf43def0e21fde7d2896cfb9d0c773f6e9ea723d1391012d00f56"}"#,
+            "Psbt utxo does not match the expected value"
+        );
     }
 }


### PR DESCRIPTION
<!-- Erase any parts of this template not applicable to your Pull Request. -->

### Description
 Exposing `spend_utxo`  will be helpful when trying to validate signatures or sign transaction inputs. This will allows signers of a psbt to verify and confirm the amount being spent and ensure it is what they expect before they approve/sign the transaction.

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

### Notes to the reviewers
`spend_utxo` returns a [SignError](https://docs.rs/bitcoin/0.32.6/bitcoin/psbt/enum.SignError.html) as part of result in case of any errors. We do not have this error type so I skipped this. After testing we still get a fairly descriptive error message when an error occurs. At least for passing an out of bounds index.


<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Changelog notice

- Check Psbt utxo at given index

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [x] I've added tests for the new feature
* [x] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
