### PR TITLE
feat: implement display for `Transaction`

### DIFF
--- a/bdk-ffi/src/bitcoin.rs
+++ b/bdk-ffi/src/bitcoin.rs
@@ -321,6 +321,7 @@ impl_into_core_type!(Address, BdkAddress);
 /// Bitcoin transaction.
 /// An authenticated movement of coins.
 #[derive(Debug, Clone, PartialEq, Eq, uniffi::Object)]
+#[uniffi::export(Eq, Display)]
 pub struct Transaction(BdkTransaction);
 
 #[uniffi::export]
@@ -461,6 +462,12 @@ impl From<&BdkTransaction> for Transaction {
 impl From<&Transaction> for BdkTransaction {
     fn from(tx: &Transaction) -> Self {
         tx.0.clone()
+    }
+}
+
+impl Display for Transaction {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self.0)
     }
 }
 


### PR DESCRIPTION
<!-- Erase any parts of this template not applicable to your Pull Request. -->

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->
I think we need to be able to see the details of a `Transaction`  when printed. In Kotlin, `Transaction` currently prints the memory address and not the display. @reez and I had noticed this and discussed briefly, see [here ](https://github.com/bitcoindevkit/bdk-ffi/pull/778#pullrequestreview-2920191449). I think we have manual implementations of display for struct like `Address`, so why not add it to `Transaction`  too. Its a bit of a hassle, developing and testing and not being able to see the printout for Tx. I understand that swift is ok having just `debug` trait and can printout with no issues. This will at least for now allow JVM users see the actual printouts.

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Changelog notice

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

### Checklists

#### All Submissions:

* [ ] I've signed all my commits
* [ ] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [ ] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
