### PR TITLE
Add reading and writing PSBT files

### DIFF
--- a/bdk-ffi/src/bitcoin.rs
+++ b/bdk-ffi/src/bitcoin.rs
@@ -32,6 +32,8 @@ use bdk_wallet::miniscript::psbt::PsbtExt;
 use bdk_wallet::serde_json;
 
 use std::fmt::Display;
+use std::fs::File;
+use std::io::{BufReader, BufWriter};
 use std::ops::Deref;
 use std::str::FromStr;
 use std::sync::{Arc, Mutex};
@@ -477,6 +479,15 @@ impl Psbt {
         Ok(Psbt(Mutex::new(psbt)))
     }
 
+    /// Create a new `Psbt` from a `.psbt` file.
+    #[uniffi::constructor]
+    pub(crate) fn from_file(path: String) -> Result<Self, PsbtError> {
+        let file = File::open(path)?;
+        let mut buf_read = BufReader::new(file);
+        let psbt: BdkPsbt = BdkPsbt::deserialize_from_reader(&mut buf_read)?;
+        Ok(Psbt(Mutex::new(psbt)))
+    }
+
     /// Serialize the PSBT into a base64-encoded string.
     pub(crate) fn serialize(&self) -> String {
         let psbt = self.0.lock().unwrap().clone();
@@ -546,6 +557,15 @@ impl Psbt {
                 }
             }
         }
+    }
+
+    /// Write the `Psbt` to a file. Note that the file must not yet exist.
+    pub(crate) fn write_to_file(&self, path: String) -> Result<(), PsbtError> {
+        let file = File::create(path)?;
+        let mut writer = BufWriter::new(file);
+        let psbt = self.0.lock().unwrap();
+        psbt.serialize_to_writer(&mut writer)?;
+        Ok(())
     }
 
     /// Serializes the PSBT into a JSON string representation.

--- a/bdk-ffi/src/error.rs
+++ b/bdk-ffi/src/error.rs
@@ -1438,6 +1438,22 @@ impl From<BdkPsbtParseError> for PsbtParseError {
     }
 }
 
+impl From<std::io::Error> for PsbtError {
+    fn from(error: std::io::Error) -> Self {
+        PsbtError::Io {
+            error_message: error.to_string(),
+        }
+    }
+}
+
+impl From<bdk_wallet::bitcoin::io::Error> for PsbtError {
+    fn from(error: bdk_wallet::bitcoin::io::Error) -> Self {
+        PsbtError::Io {
+            error_message: error.to_string(),
+        }
+    }
+}
+
 impl From<BdkPsbtFinalizeError> for PsbtFinalizeError {
     fn from(value: BdkPsbtFinalizeError) -> Self {
         match value {


### PR DESCRIPTION
The Rust API makes it trivially simple to read and write PSBT to and from files. Bindings users may make use of this in air-gapped signing flows. The `PsbtError` already includes an `Io` variant, so we may make use of that error.

### Notes to the reviewers

Discovered while working on a desktop app.

### Changelog notice

- Read and write PSBT to and from files

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [x] I've added docs for the new feature
