### PR TITLE
Export `Display` for `Script`

### DIFF
--- a/bdk-ffi/src/bitcoin.rs
+++ b/bdk-ffi/src/bitcoin.rs
@@ -174,6 +174,7 @@ impl_into_core_type!(Amount, BdkAmount);
 
 /// A bitcoin script: https://en.bitcoin.it/wiki/Script
 #[derive(Clone, Debug, uniffi::Object)]
+#[uniffi::export(Display)]
 pub struct Script(pub BdkScriptBuf);
 
 #[uniffi::export]
@@ -193,6 +194,12 @@ impl Script {
 
 impl_from_core_type!(BdkScriptBuf, Script);
 impl_into_core_type!(Script, BdkScriptBuf);
+
+impl Display for Script {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt_asm(f)
+    }
+}
 
 /// Bitcoin block header.
 /// Contains all the block’s information except the actual transactions, but including a root of a merkle tree


### PR DESCRIPTION
The `rust-bitcoin` type has a nice feature where the human-readable OP-codes are printed when using the `Display` version of `ScriptBuf`. Some users might find this interesting, as this is a feature of the almighty Sparrow wallet.

To see for yourself:
```rust
let mut output = String::new();
addr.fmt_asm(&mut output).unwrap();
println!("{output}");
```
Which should have an output similar to this for a fully built out example:
```
OP_0 OP_PUSHBYTES_20 1cd30fcc6cc9793c08a1105893c6d1e584a57e48
```

### Changelog notice

- Added `Display` for `Script`

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing