### PR TITLE
Make a runtime environment for DNS for Kyoto

### DIFF
--- a/bdk-ffi/src/kyoto.rs
+++ b/bdk-ffi/src/kyoto.rs
@@ -368,7 +368,11 @@ impl CbfClient {
     /// for compact block filter nodes from the seeder. For example `dns.myseeder.com` will be queried
     /// as `x849.dns.myseeder.com`. This has no guarantee to return any `IpAddr`.
     pub async fn lookup_host(&self, hostname: String) -> Vec<Arc<IpAddress>> {
-        let nodes = lookup_host(hostname, self.dns_resolver).await;
+        let nodes = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(lookup_host(hostname, self.dns_resolver));
         nodes
             .into_iter()
             .map(|ip| Arc::new(IpAddress { inner: ip }))


### PR DESCRIPTION
The `lookup_host` function requires a `tokio` runtime to execute, but since it is outside of the `Node`, this function panics when called. Add a runtime, which is essentially an OS thread in this context, to complete the call.

### Notes to the reviewers

In the future I could potentially find a more elegant way to do this, but this call should be relatively short and only consume a single thread.

### Changelog notice

- Fix `lookup_host` on `CbfClient`

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
