### PR TITLE
Remove nexus-publishing plugin

### DIFF
--- a/bdk-android/build.gradle.kts
+++ b/bdk-android/build.gradle.kts
@@ -3,31 +3,11 @@ plugins {
     id("org.jetbrains.kotlin.android").version("2.1.10").apply(false)
     id("org.gradle.maven-publish")
     id("org.gradle.signing")
-    id("io.github.gradle-nexus.publish-plugin").version("1.1.0").apply(true)
     id("org.jetbrains.dokka").version("2.0.0").apply(false)
     id("org.jetbrains.dokka-javadoc").version("2.0.0").apply(false)
 }
 
 // library version is defined in gradle.properties
 val libraryVersion: String by project
-
-// These properties are required here so that the nexus publish-plugin
-// finds a staging profile with the correct group (group is otherwise set as "")
-// and knows whether to publish to a SNAPSHOT repository or not
-// https://github.com/gradle-nexus/publish-plugin#applying-the-plugin
 group = "org.bitcoindevkit"
 version = libraryVersion
-
-nexusPublishing {
-    repositories {
-        create("sonatype") {
-            nexusUrl.set(uri("https://s01.oss.sonatype.org/service/local/"))
-            snapshotRepositoryUrl.set(uri("https://s01.oss.sonatype.org/content/repositories/snapshots/"))
-
-            val ossrhUsername: String? by project
-            val ossrhPassword: String? by project
-            username.set(ossrhUsername)
-            password.set(ossrhPassword)
-        }
-    }
-}

--- a/bdk-android/lib/build.gradle.kts
+++ b/bdk-android/lib/build.gradle.kts
@@ -110,11 +110,6 @@ signing {
     if (project.hasProperty("localBuild")) {
         isRequired = false
     }
-
-    val signingKeyId: String? by project
-    val signingKey: String? by project
-    val signingPassword: String? by project
-    useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword)
     sign(publishing.publications)
 }
 


### PR DESCRIPTION
This is a cherry-pick of a commit I had to make on the `release/2.0.0` branch. It removes the old Gradle plugin that allowed us to publish on Maven Central. This is a good thing! That plugin was old and had weird quirks. Expect the build file to slightly change for the better now.

Note that we are now not using any plugin to release and have to upload manually. This should be fixed once the Maven Portal releases a plugin for releasing on their platform.