### PR TITLE
Test Android library in CI

### DIFF
--- a/.github/workflows/test-android.yaml
+++ b/.github/workflows/test-android.yaml
@@ -10,30 +10,16 @@ on:
       - "bdk-ffi/**"
       - "bdk-android/**"
 
-# The default Android NDK on the ubuntu-24.04 image is 25.2.9519653
-
 permissions: {}
 
 jobs:
   build:
     runs-on: ubuntu-24.04
     steps:
-      - name: "Show default version of NDK"
-        run: echo $ANDROID_NDK_ROOT
-
       - name: "Check out PR branch"
         uses: actions/checkout@v4
         with:
           persist-credentials: false
-
-      - name: "Cache"
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            ./target
-          key: ${{ runner.os }}-${{ hashFiles('**/Cargo.toml','**/Cargo.lock') }}
 
       - name: "Set up JDK"
         uses: actions/setup-java@v4
@@ -41,15 +27,44 @@ jobs:
           distribution: temurin
           java-version: 17
 
+      - name: "Setup Android SDK"
+        uses: android-actions/setup-android@v3
+
+      - name: "Setup Android NDK"
+        uses: nttld/setup-ndk@v1
+        with:
+          ndk-version: r26c
+
+      - name: "Install Rust"
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.84.1
+
+      - name: "Cache Rust"
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            ./target
+          key: ${{ runner.os }}-rust-${{ hashFiles('**/Cargo.toml','**/Cargo.lock') }}
+
       - name: "Build Android library"
         run: |
           cd bdk-android
           bash ./scripts/build-linux-x86_64.sh
 
-# There are currently no unit tests for bdk-android (see the tests in bdk-jvm instead) and the 
-# integration tests require the macOS image which is not working with the older NDK version we
-# are using, so for now we just make sure that the library builds and omit the connectedTest
-#      - name: "Run Android connected tests"
-#        run: |
-#          cd bdk-android
-#          ./gradlew connectedAndroidTest --console=plain
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: "Run Android connected tests"
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 30
+          target: google_apis
+          arch: x86_64
+          profile: Nexus 6
+          script: cd bdk-android && ./gradlew connectedAndroidTest --console=plain

--- a/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/LiveTxBuilderTest.kt
+++ b/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/LiveTxBuilderTest.kt
@@ -8,75 +8,75 @@ import kotlin.test.AfterTest
 import kotlin.test.assertTrue
 import java.io.File
 
-private const val SIGNET_ESPLORA_URL = "http://signet.bitcoindevkit.net"
+private const val SIGNET_ESPLORA_URL = "https://blockstream.info/signet/api/"
 private const val TESTNET_ESPLORA_URL = "https://esplora.testnet.kuutamo.cloud"
 
-@RunWith(AndroidJUnit4::class)
-class LiveTxBuilderTest {
-    private val persistenceFilePath = InstrumentationRegistry.getInstrumentation().targetContext.filesDir.path + "/bdk_persistence3.sqlite"
-    private val descriptor = Descriptor("wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/1h/0/*)", Network.SIGNET)
-    private val changeDescriptor = Descriptor("wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/1h/1/*)", Network.SIGNET)
-
-    @AfterTest
-    fun cleanup() {
-        val file = File(persistenceFilePath)
-        if (file.exists()) {
-            file.delete()
-        }
-    }
-
-    @Test
-    fun testTxBuilder() {
-        var conn: Persister = Persister.newInMemory()
-        val wallet = Wallet(descriptor, changeDescriptor, Network.SIGNET, conn)
-        val esploraClient: EsploraClient = EsploraClient(SIGNET_ESPLORA_URL)
-        val fullScanRequest: FullScanRequest = wallet.startFullScan().build()
-        val update = esploraClient.fullScan(fullScanRequest, 10uL, 1uL)
-        wallet.applyUpdate(update)
-        println("Balance: ${wallet.balance().total.toSat()}")
-
-        assert(wallet.balance().total.toSat() > 0uL) {
-            "Wallet balance must be greater than 0! Please send funds to ${wallet.revealNextAddress(KeychainKind.EXTERNAL).address} and try again."
-        }
-
-        val recipient: Address = Address("tb1qrnfslnrve9uncz9pzpvf83k3ukz22ljgees989", Network.SIGNET)
-        val psbt: Psbt = TxBuilder()
-            .addRecipient(recipient.scriptPubkey(), Amount.fromSat(4200uL))
-            .feeRate(FeeRate.fromSatPerVb(2uL))
-            .finish(wallet)
-
-        println(psbt.serialize())
-        assertTrue(psbt.serialize().startsWith("cHNi"), "PSBT should start with 'cHNi'")
-    }
-
-    @Test
-    fun complexTxBuilder() {
-        var conn: Persister = Persister.newInMemory()
-        val wallet = Wallet(descriptor, changeDescriptor, Network.SIGNET, conn)
-        val esploraClient: EsploraClient = EsploraClient(SIGNET_ESPLORA_URL)
-        val fullScanRequest: FullScanRequest = wallet.startFullScan().build()
-        val update = esploraClient.fullScan(fullScanRequest, 10uL, 1uL)
-        wallet.applyUpdate(update)
-
-        println("Balance: ${wallet.balance().total.toSat()}")
-
-        assert(wallet.balance().total.toSat() > 0uL) {
-            "Wallet balance must be greater than 0! Please send funds to ${wallet.revealNextAddress(KeychainKind.EXTERNAL).address} and try again."
-        }
-
-        val recipient1: Address = Address("tb1qrnfslnrve9uncz9pzpvf83k3ukz22ljgees989", Network.SIGNET)
-        val recipient2: Address = Address("tb1qw2c3lxufxqe2x9s4rdzh65tpf4d7fssjgh8nv6", Network.SIGNET)
-        val allRecipients: List<ScriptAmount> = listOf(
-            ScriptAmount(recipient1.scriptPubkey(), Amount.fromSat(4200uL)),
-            ScriptAmount(recipient2.scriptPubkey(), Amount.fromSat(4200uL)),
-        )
-
-        val psbt: Psbt = TxBuilder()
-            .setRecipients(allRecipients)
-            .feeRate(FeeRate.fromSatPerVb(4uL))
-            .finish(wallet)
-
-        wallet.sign(psbt)
-        assertTrue(psbt.serialize().startsWith("cHNi"), "PSBT should start with 'cHNi'")
-    }
-}
+// @RunWith(AndroidJUnit4::class)
+// class LiveTxBuilderTest {
+//     private val persistenceFilePath = InstrumentationRegistry.getInstrumentation().targetContext.filesDir.path + "/bdk_persistence3.sqlite"
+//     private val descriptor = Descriptor("wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/1h/0/*)", Network.SIGNET)
+//     private val changeDescriptor = Descriptor("wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/1h/1/*)", Network.SIGNET)
+//
+//     @AfterTest
+//     fun cleanup() {
+//         val file = File(persistenceFilePath)
+//         if (file.exists()) {
+//             file.delete()
+//         }
+//     }
+//
+//     @Test
+//     fun testTxBuilder() {
+//         var conn: Persister = Persister.newInMemory()
+//         val wallet = Wallet(descriptor, changeDescriptor, Network.SIGNET, conn)
+//         val esploraClient: EsploraClient = EsploraClient(SIGNET_ESPLORA_URL)
+//         val fullScanRequest: FullScanRequest = wallet.startFullScan().build()
+//         val update = esploraClient.fullScan(fullScanRequest, 10uL, 1uL)
+//         wallet.applyUpdate(update)
+//         println("Balance: ${wallet.balance().total.toSat()}")
+//
+//         assert(wallet.balance().total.toSat() > 0uL) {
+//             "Wallet balance must be greater than 0! Please send funds to ${wallet.revealNextAddress(KeychainKind.EXTERNAL).address} and try again."
+//         }
+//
+//         val recipient: Address = Address("tb1qrnfslnrve9uncz9pzpvf83k3ukz22ljgees989", Network.SIGNET)
+//         val psbt: Psbt = TxBuilder()
+//             .addRecipient(recipient.scriptPubkey(), Amount.fromSat(4200uL))
+//             .feeRate(FeeRate.fromSatPerVb(2uL))
+//             .finish(wallet)
+//
+//         println(psbt.serialize())
+//         assertTrue(psbt.serialize().startsWith("cHNi"), "PSBT should start with 'cHNi'")
+//     }
+//
+//     @Test
+//     fun complexTxBuilder() {
+//         var conn: Persister = Persister.newInMemory()
+//         val wallet = Wallet(descriptor, changeDescriptor, Network.SIGNET, conn)
+//         val esploraClient: EsploraClient = EsploraClient(SIGNET_ESPLORA_URL)
+//         val fullScanRequest: FullScanRequest = wallet.startFullScan().build()
+//         val update = esploraClient.fullScan(fullScanRequest, 10uL, 1uL)
+//         wallet.applyUpdate(update)
+//
+//         println("Balance: ${wallet.balance().total.toSat()}")
+//
+//         assert(wallet.balance().total.toSat() > 25000uL) {
+//             "Wallet balance must be greater than 25000 satoshis! Please send funds to ${wallet.revealNextAddress(KeychainKind.EXTERNAL).address} and try again."
+//         }
+//
+//         val recipient1: Address = Address("tb1qrnfslnrve9uncz9pzpvf83k3ukz22ljgees989", Network.SIGNET)
+//         val recipient2: Address = Address("tb1qw2c3lxufxqe2x9s4rdzh65tpf4d7fssjgh8nv6", Network.SIGNET)
+//         val allRecipients: List<ScriptAmount> = listOf(
+//             ScriptAmount(recipient1.scriptPubkey(), Amount.fromSat(4200uL)),
+//             ScriptAmount(recipient2.scriptPubkey(), Amount.fromSat(4200uL)),
+//         )
+//
+//         val psbt: Psbt = TxBuilder()
+//             .setRecipients(allRecipients)
+//             .feeRate(FeeRate.fromSatPerVb(4uL))
+//             .finish(wallet)
+//
+//         wallet.sign(psbt)
+//         assertTrue(psbt.serialize().startsWith("cHNi"), "PSBT should start with 'cHNi'")
+//     }
+// }

--- a/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/LiveWalletTest.kt
+++ b/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/LiveWalletTest.kt
@@ -8,86 +8,86 @@ import kotlin.test.AfterTest
 import kotlin.test.assertTrue
 import java.io.File
 
-private const val SIGNET_ESPLORA_URL = "http://signet.bitcoindevkit.net"
+private const val SIGNET_ESPLORA_URL = "https://blockstream.info/signet/api/"
 private const val TESTNET_ESPLORA_URL = "https://esplora.testnet.kuutamo.cloud"
 
-@RunWith(AndroidJUnit4::class)
-class LiveWalletTest {
-    private val persistenceFilePath = InstrumentationRegistry
-        .getInstrumentation().targetContext.filesDir.path + "/bdk_persistence2.sqlite"
-    private val descriptor: Descriptor = Descriptor("wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/1h/0/*)", Network.SIGNET)
-    private val changeDescriptor: Descriptor = Descriptor("wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/1h/1/*)", Network.SIGNET)
-
-    @AfterTest
-    fun cleanup() {
-        val file = File(persistenceFilePath)
-        if (file.exists()) {
-            file.delete()
-        }
-    }
-
-    @Test
-    fun testSyncedBalance() {
-        var conn: Persister = Persister.newInMemory()
-        val wallet: Wallet = Wallet(descriptor, changeDescriptor, Network.SIGNET, conn)
-        val esploraClient: EsploraClient = EsploraClient(SIGNET_ESPLORA_URL)
-        val fullScanRequest: FullScanRequest = wallet.startFullScan().build()
-        val update = esploraClient.fullScan(fullScanRequest, 10uL, 1uL)
-        wallet.applyUpdate(update)
-        println("Balance: ${wallet.balance().total.toSat()}")
-        val balance: Balance = wallet.balance()
-        println("Balance: $balance")
-
-        assert(wallet.balance().total.toSat() > 0uL) {
-            "Wallet balance must be greater than 0! Please send funds to ${wallet.revealNextAddress(KeychainKind.EXTERNAL).address} and try again."
-        }
-
-        println("Transactions count: ${wallet.transactions().count()}")
-        val transactions = wallet.transactions().take(3)
-        for (tx in transactions) {
-            val sentAndReceived = wallet.sentAndReceived(tx.transaction)
-            println("Transaction: ${tx.transaction.computeTxid()}")
-            println("Sent ${sentAndReceived.sent.toSat()}")
-            println("Received ${sentAndReceived.received.toSat()}")
-        }
-    }
-
-    @Test
-    fun testBroadcastTransaction() {
-        var conn: Persister = Persister.newInMemory()
-        val wallet = Wallet(descriptor, changeDescriptor, Network.SIGNET, conn)
-        val esploraClient = EsploraClient(SIGNET_ESPLORA_URL)
-        val fullScanRequest: FullScanRequest = wallet.startFullScan().build()
-        val update = esploraClient.fullScan(fullScanRequest, 10uL, 1uL)
-        wallet.applyUpdate(update)
-        println("Balance: ${wallet.balance().total.toSat()}")
-
-        assert(wallet.balance().total.toSat() > 0uL) {
-            "Wallet balance must be greater than 0! Please send funds to ${wallet.revealNextAddress(KeychainKind.EXTERNAL).address} and try again."
-        }
-
-        val recipient: Address = Address("tb1qrnfslnrve9uncz9pzpvf83k3ukz22ljgees989", Network.SIGNET)
-
-        val psbt: Psbt = TxBuilder()
-            .addRecipient(recipient.scriptPubkey(), Amount.fromSat(4200uL))
-            .feeRate(FeeRate.fromSatPerVb(4uL))
-            .finish(wallet)
-
-        println(psbt.serialize())
-        assertTrue(psbt.serialize().startsWith("cHNi"), "PSBT should start with 'cHNi'")
-
-        val walletDidSign = wallet.sign(psbt)
-        assertTrue(walletDidSign)
-
-        val tx: Transaction = psbt.extractTx()
-        println("Txid is: ${tx.computeTxid()}")
-
-        val txFee: Amount = wallet.calculateFee(tx)
-        println("Tx fee is: ${txFee.toSat()}")
-
-        val feeRate: FeeRate = wallet.calculateFeeRate(tx)
-        println("Tx fee rate is: ${feeRate.toSatPerVbCeil()} sat/vB")
-
-        esploraClient.broadcast(tx)
-    }
-}
+// @RunWith(AndroidJUnit4::class)
+// class LiveWalletTest {
+//     private val persistenceFilePath = InstrumentationRegistry
+//         .getInstrumentation().targetContext.filesDir.path + "/bdk_persistence2.sqlite"
+//     private val descriptor: Descriptor = Descriptor("wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/1h/0/*)", Network.SIGNET)
+//     private val changeDescriptor: Descriptor = Descriptor("wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/1h/1/*)", Network.SIGNET)
+//
+//     @AfterTest
+//     fun cleanup() {
+//         val file = File(persistenceFilePath)
+//         if (file.exists()) {
+//             file.delete()
+//         }
+//     }
+//
+//     @Test
+//     fun testSyncedBalance() {
+//         var conn: Persister = Persister.newInMemory()
+//         val wallet: Wallet = Wallet(descriptor, changeDescriptor, Network.SIGNET, conn)
+//         val esploraClient: EsploraClient = EsploraClient(SIGNET_ESPLORA_URL)
+//         val fullScanRequest: FullScanRequest = wallet.startFullScan().build()
+//         val update = esploraClient.fullScan(fullScanRequest, 10uL, 1uL)
+//         wallet.applyUpdate(update)
+//         println("Balance: ${wallet.balance().total.toSat()}")
+//         val balance: Balance = wallet.balance()
+//         println("Balance: $balance")
+//
+//         assert(wallet.balance().total.toSat() > 0uL) {
+//             "Wallet balance must be greater than 0! Please send funds to ${wallet.revealNextAddress(KeychainKind.EXTERNAL).address} and try again."
+//         }
+//
+//         println("Transactions count: ${wallet.transactions().count()}")
+//         val transactions = wallet.transactions().take(3)
+//         for (tx in transactions) {
+//             val sentAndReceived = wallet.sentAndReceived(tx.transaction)
+//             println("Transaction: ${tx.transaction.computeTxid()}")
+//             println("Sent ${sentAndReceived.sent.toSat()}")
+//             println("Received ${sentAndReceived.received.toSat()}")
+//         }
+//     }
+//
+//     @Test
+//     fun testBroadcastTransaction() {
+//         var conn: Persister = Persister.newInMemory()
+//         val wallet = Wallet(descriptor, changeDescriptor, Network.SIGNET, conn)
+//         val esploraClient = EsploraClient(SIGNET_ESPLORA_URL)
+//         val fullScanRequest: FullScanRequest = wallet.startFullScan().build()
+//         val update = esploraClient.fullScan(fullScanRequest, 10uL, 1uL)
+//         wallet.applyUpdate(update)
+//         println("Balance: ${wallet.balance().total.toSat()}")
+//
+//         assert(wallet.balance().total.toSat() > 0uL) {
+//             "Wallet balance must be greater than 0! Please send funds to ${wallet.revealNextAddress(KeychainKind.EXTERNAL).address} and try again."
+//         }
+//
+//         val recipient: Address = Address("tb1qrnfslnrve9uncz9pzpvf83k3ukz22ljgees989", Network.SIGNET)
+//
+//         val psbt: Psbt = TxBuilder()
+//             .addRecipient(recipient.scriptPubkey(), Amount.fromSat(4200uL))
+//             .feeRate(FeeRate.fromSatPerVb(4uL))
+//             .finish(wallet)
+//
+//         println(psbt.serialize())
+//         assertTrue(psbt.serialize().startsWith("cHNi"), "PSBT should start with 'cHNi'")
+//
+//         val walletDidSign = wallet.sign(psbt)
+//         assertTrue(walletDidSign)
+//
+//         val tx: Transaction = psbt.extractTx()
+//         println("Txid is: ${tx.computeTxid()}")
+//
+//         val txFee: Amount = wallet.calculateFee(tx)
+//         println("Tx fee is: ${txFee.toSat()}")
+//
+//         val feeRate: FeeRate = wallet.calculateFeeRate(tx)
+//         println("Tx fee rate is: ${feeRate.toSatPerVbCeil()} sat/vB")
+//
+//         esploraClient.broadcast(tx)
+//     }
+// }


### PR DESCRIPTION
This is a really big achievement, because we have not been able to run the tests for the library in an Android emulator on CI for years!

Note that the live tests were failing because of:
1. The BDK signet Esplora instance has been down for a while. Once that was fixed, the mempool.space instance,
2. We ran into the low balance issue, where test had emptied the wallet over time. Once that was fixed, we ran into the mempool.space request max issue, where you can only make 700 requests per hour, but on big wallets you exceed that super quick.

So I JUST COMMENTED OUT ALL LIVE TESTS

As discussed over dev calls, we'll be focusing on unit tests here, and add an examples directory with more integration tests. In the long run we are also looking at adding a full regtest environment to the CI so we can run more of those tests that require syncing the wallet, without requiring Signet or Testnet 3 or 4.