### PR TITLE
Apply evicted transactions

### DIFF
--- a/bdk-ffi/src/types.rs
+++ b/bdk-ffi/src/types.rs
@@ -777,6 +777,15 @@ pub struct UnconfirmedTx {
     pub last_seen: u64,
 }
 
+/// This type replaces the Rust tuple `(txid, evicted_at)` used in the Wallet::apply_evicted_txs` method,
+/// where `evicted_at` is the timestamp of when the transaction `txid` was evicted from the mempool.
+/// Transactions may be evicted for paying a low fee rate or having invalid scripts.
+#[derive(uniffi::Record)]
+pub struct EvictedTx {
+    pub txid: Arc<Txid>,
+    pub evicted_at: u64,
+}
+
 /// Mapping of descriptors to their last revealed index.
 #[derive(Debug, Clone, uniffi::Record)]
 pub struct IndexerChangeSet {

--- a/bdk-ffi/src/wallet.rs
+++ b/bdk-ffi/src/wallet.rs
@@ -6,9 +6,9 @@ use crate::error::{
 };
 use crate::store::{PersistenceType, Persister};
 use crate::types::{
-    AddressInfo, Balance, BlockId, CanonicalTx, FullScanRequestBuilder, KeychainAndIndex,
-    LocalOutput, Policy, SentAndReceivedValues, SignOptions, SyncRequestBuilder, UnconfirmedTx,
-    Update,
+    AddressInfo, Balance, BlockId, CanonicalTx, EvictedTx, FullScanRequestBuilder,
+    KeychainAndIndex, LocalOutput, Policy, SentAndReceivedValues, SignOptions, SyncRequestBuilder,
+    UnconfirmedTx, Update,
 };
 
 use bdk_wallet::bitcoin::Network;
@@ -221,6 +221,19 @@ impl Wallet {
                 .into_iter()
                 .map(|utx| (Arc::new(utx.tx.as_ref().into()), utx.last_seen)),
         )
+    }
+
+    /// Apply transactions that have been evicted from the mempool.
+    /// Transactions may be evicted for paying too-low fee, or for being malformed.
+    /// Irrelevant transactions are ignored.
+    ///
+    /// For more information: https://docs.rs/bdk_wallet/latest/bdk_wallet/struct.Wallet.html#method.apply_evicted_txs
+    pub fn apply_evicted_txs(&self, evicted_txs: Vec<EvictedTx>) {
+        self.get_wallet().apply_evicted_txs(
+            evicted_txs
+                .into_iter()
+                .map(|etx| (etx.txid.0, etx.evicted_at)),
+        );
     }
 
     /// The derivation index of this wallet. It will return `None` if it has not derived any addresses.


### PR DESCRIPTION
We have an "apply unconfirmed" API, but no way to remove unconfirmed transactions when rejected or paying a too-low fee.

Closes #831 

### Changelog notice

- Add `apply_evicted_txs` to `Wallet`

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [x] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [x] I'm linking the issue being fixed by this PR
