### PR TITLE
Remove jvm weekly tests

### DIFF
--- a/.github/workflows/live-tests.yaml
+++ b/.github/workflows/live-tests.yaml
@@ -7,39 +7,6 @@ on:
 permissions: {}
 
 jobs:
-  jvm-tests:
-    name: "Build and test JVM library on Linux"
-    runs-on: ubuntu-24.04
-    steps:
-      - name: "Checkout publishing branch"
-        uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-
-      - name: "Cache"
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            ./target
-          key: ${{ runner.os }}-${{ hashFiles('**/Cargo.toml','**/Cargo.lock') }}
-
-      - name: "Set up JDK"
-        uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: 11
-
-      - name: "Set default Rust version to 1.84.1"
-        run: rustup default 1.84.1
-
-      - name: "Build library and run tests"
-        run: |
-          cd bdk-jvm
-          bash ./scripts/build-linux-x86_64.sh
-          ./gradlew test
-
   swift-tests:
     name: "Build and test iOS library on macOS"
     runs-on: macos-14


### PR DESCRIPTION
This PR removes the JVM tests. I noticed the weekly tests failed (again!) this week. This should fix that. Note that we're really just removing almost all tests at this point, so we should really continue pushing for bringing back the Android tests (#826).