### PR TITLE
feat: Create trigger workflow trigger for bdk-jvm

### DIFF
--- a/.github/workflows/trigger-external-bindings.yml
+++ b/.github/workflows/trigger-external-bindings.yml
@@ -1,0 +1,27 @@
+name: Trigger External Bindings Workflow
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+    paths:
+      - 'bdk-ffi/**'
+
+permissions: {}
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    steps:    
+    #Trigger bdk-jvm-test in bdk-jvm repository
+      - name: Trigger bdk-jvm-test in bdk-jvm repository
+        if: ${{ github.ref_name == 'master' }}
+        run: |
+          response=$(curl -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: token ${{ secrets.BDK_JVM_ACCESS_TOKEN }}" \
+            https://api.github.com/repos/bitcoindevkit/bdk-jvm/dispatches \
+            -d '{"event_type":"trigger-bdk-jvm-tests"}')
+          echo "Response: $response"
+          echo "HTTP Status Code: $(echo $response | jq -r '.status')"
+          echo "Response Body: $(echo $response | jq -r '.body')"


### PR DESCRIPTION
<!-- Erase any parts of this template not applicable to your Pull Request. -->

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->
This would allow bdk-jvm workflow file to be triggered when a merge happens. 

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->
- A repo_access token needs to be created by someone with access to both bdk-ffi and bdk-jvm. I only have access (as collaborator) on bdk-ffi but not on bdk-jvm.
- In this pr we are only concerned about changes to the bdk-ffi directory. No need to run test of specific bindings if push was not done in this folder.
- The dispatcher requires url for the repo where i needed to add the repo name and owner I believe the below is correct?

`https://api.github.com/repos/{owner}/{repo}/dispatches \`

where name and owner are

`https://api.github.com/repos/bdk/bdk-jvm/dispatches \`



See docs
- [Here](https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#create-a-repository-dispatch-event)

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [ ] I ran `cargo fmt` and `cargo clippy` before committing

