### PR TITLE
Expose `Wallet::create_from_two_path_descriptor` constructor

### DIFF
--- a/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/CreatingWalletTest.kt
+++ b/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/CreatingWalletTest.kt
@@ -42,6 +42,32 @@ class CreatingWalletTest {
         )
     }
 
+    // Create a wallet with a public multipath descriptor.
+    @Test
+    fun createWalletWithMultipathDescriptor() {
+        val multipathDescriptor = Descriptor(
+            "wpkh([9a6a2580/84'/0'/0']xpub6DEzNop46vmxR49zYWFnMwmEfawSNmAMf6dLH5YKDY463twtvw1XD7ihwJRLPRGZJz799VPFzXHpZu6WdhT29WnaeuChS6aZHZPFmqczR5K/<0;1>/*)",
+            Network.BITCOIN
+        )
+
+        Wallet.createFromTwoPathDescriptor(
+            twoPathDescriptor = multipathDescriptor,
+            network = Network.BITCOIN,
+            persister = conn
+        )
+    }
+
+    // You cannot create a private multipath descriptor.
+    @Test
+    fun cannotCreatePrivateMultipathDescriptor() {
+        assertFails {
+            Descriptor(
+                descriptor = "tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/<0;1>/*)",
+                Network.TESTNET
+            )
+        }
+    }
+
     // Descriptors do not match provided network.
     @Test
     fun failsIfDescriptorsDontMatchNetwork() {


### PR DESCRIPTION
This was requested in #834. 
cc @reez.
See [Wallet::create_from_two_path_descriptor](https://docs.rs/bdk_wallet/2.1.0/bdk_wallet/struct.Wallet.html#method.create_from_two_path_descriptor).

### Note to Reviewers

One of the odd things about this API is that you cannot use private extended keys in your multipath descriptor to create wallets. In other words you can only use this API for with xpubs.

This looked so odd to me that I had to go down the rabbit hole and find out that indeed that's the case in Rust too. I will open a small documentation PR mentionning this in the API docs because that's not obvious at first glance.

In any case I added tests for both cases (pass and fail). Here I just took the descriptor used in the Rust tests, but I think we should add to our Constants file a number of recovery phrases with xpub and xprv keys that could then be used for this tests. I just didn't want to muddy the PR with new extra test fluff.

### Changelog notice

```md
Added
    - Add `Wallet::create_from_two_path_descriptor` constructor [#847]

[#847]: https://github.com/bitcoindevkit/bdk-ffi/pull/847
```

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [x] I've added tests for the new feature
* [x] I've added docs for the new feature
