### PR TITLE
Require explicit wildcard derivation for descriptor key types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,22 +6,31 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased](https://github.com/bitcoindevkit/bdk-ffi/compare/v2.3.0...HEAD)
 
+## Breaking
+
+- The `DescriptorSecretKey::new` constructor does not produce an extended key with an automatic wildcard anymore [#853]
+- `Descriptor` and `DescriptorSecretKey` constructors now require a `NetworkKind` [#986]
+
 ### Added
 
-- Expose miniscript `has_wildcard` and `sanity_check` methods on `Descriptor` type #945
-- Expose `new_wsh_sortedmulti` and `new_pk` methods on `Descriptor` type #949
-- Expose `new_sh_sortedmulti`, `new_sh_wsh_sortedmulti`, `new_pkh`, `new_wpkh`, `new_sh_wpkh` methods on `Descriptor` type #973
-- Expose wallet event helpers `Wallet::apply_unconfirmed_txs_events` and `Wallet::apply_evicted_txs_events` #971
-- Expose wallet scan/sync helpers `Wallet::start_full_scan_at`, `Wallet::start_sync_with_revealed_spks_at`, and `Wallet::checkpoints` #971
-- Expose locked outpoint wallet APIs and locked outpoint persistence in `ChangeSet` #971
-- Expose transaction builder controls for sighash, transaction ordering, and adding foreign UTXOs with explicit sequence values #971
-- Expose `Persister::get_pre_v1_wallet_keychains` for pre-v1 SQLite wallet migration support #971
-- Expose `NetworkKind` type #986
+- Expose miniscript `has_wildcard` and `sanity_check` methods on `Descriptor` type [#945]
+- Expose `new_wsh_sortedmulti` and `new_pk` methods on `Descriptor` type [#949]
+- Expose `new_sh_sortedmulti`, `new_sh_wsh_sortedmulti`, `new_pkh`, `new_wpkh`, `new_sh_wpkh` methods on `Descriptor` type [#973]
+- Expose wallet event helpers `Wallet::apply_unconfirmed_txs_events` and `Wallet::apply_evicted_txs_events` [#971]
+- Expose wallet scan/sync helpers `Wallet::start_full_scan_at`, `Wallet::start_sync_with_revealed_spks_at`, and `Wallet::checkpoints` [#971]
+- Expose locked outpoint wallet APIs and locked outpoint persistence in `ChangeSet` [#971]
+- Expose transaction builder controls for sighash, transaction ordering, and adding foreign UTXOs with explicit sequence values [#971]
+- Expose `Persister::get_pre_v1_wallet_keychains` for pre-v1 SQLite wallet migration support [#971]
+- Expose `NetworkKind` type [#986]
+- New `WildcardType` enum [#853]
+- New `DescriptorPublicKey::add_wildcard` method, which adds an unhardened wildcard to the derivation path of the descriptor [#853]
+- New `DescriptorSecretKey::add_wildcard(wildcard_type: WildcardType)` method, which adds a wildcard to the derivation path of the descriptor [#853]
 
-### Breaking
-
-- `Descriptor` and `DescriptorSecretKey` constructors now require a `NetworkKind` #986
-
+[#853]: https://github.com/bitcoindevkit/bdk-ffi/pull/853
+[#853]: https://github.com/bitcoindevkit/bdk-ffi/pull/945
+[#853]: https://github.com/bitcoindevkit/bdk-ffi/pull/949
+[#986]: https://github.com/bitcoindevkit/bdk-ffi/pull/971
+[#986]: https://github.com/bitcoindevkit/bdk-ffi/pull/973
 [#986]: https://github.com/bitcoindevkit/bdk-ffi/pull/986
 
 ## [v2.3.0]

--- a/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/MnemonicTest.kt
+++ b/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/MnemonicTest.kt
@@ -4,6 +4,8 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.runner.RunWith
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
 
 @RunWith(AndroidJUnit4::class)
 class MnemonicTest {
@@ -18,5 +20,54 @@ class MnemonicTest {
             expected = "tr([be1eec8f/86'/1'/0']tpubDCTtszwSxPx3tATqDrsSyqScPNnUChwQAVAkanuDUCJQESGBbkt68nXXKRDifYSDbeMa2Xg2euKbXaU3YphvGWftDE7ozRKPriT6vAo3xsc/0/*)#m7puekcx",
             actual = descriptor.toString()
         )
+    }
+
+    @Test
+    fun descriptorSecretKeyAddUnhardenedWildcard() {
+        val mnemonic = Mnemonic.fromString("awesome awesome awesome awesome awesome awesome awesome awesome awesome awesome awesome awesome")
+        val secretKey = DescriptorSecretKey(NetworkKind.TEST, mnemonic, null)
+        val derived = secretKey.derive(DerivationPath("m/86'/1'/0'"))
+        val withWildcard = derived.addWildcard(WildcardType.UNHARDENED)
+        assertTrue(withWildcard.toString().endsWith("/*"))
+    }
+
+    @Test
+    fun descriptorSecretKeyAddHardenedWildcard() {
+        val mnemonic = Mnemonic.fromString("awesome awesome awesome awesome awesome awesome awesome awesome awesome awesome awesome awesome")
+        val secretKey = DescriptorSecretKey(NetworkKind.TEST, mnemonic, null)
+        val derived = secretKey.derive(DerivationPath("m/86'/1'/0'"))
+        val withWildcard = derived.addWildcard(WildcardType.HARDENED)
+        assertTrue(withWildcard.toString().endsWith("/*h"))
+    }
+
+    @Test
+    fun descriptorSecretKeyAddWildcardIsIdempotent() {
+        val mnemonic = Mnemonic.fromString("awesome awesome awesome awesome awesome awesome awesome awesome awesome awesome awesome awesome")
+        val secretKey = DescriptorSecretKey(NetworkKind.TEST, mnemonic, null)
+        val derived = secretKey.derive(DerivationPath("m/86'/1'/0'"))
+        val withWildcard = derived.addWildcard(WildcardType.UNHARDENED)
+        val withWildcardAgain = withWildcard.addWildcard(WildcardType.UNHARDENED)
+        assertEquals(withWildcard.toString(), withWildcardAgain.toString())
+    }
+
+    @Test
+    fun descriptorSecretKeyCannotChangeWildcardType() {
+        val mnemonic = Mnemonic.fromString("awesome awesome awesome awesome awesome awesome awesome awesome awesome awesome awesome awesome")
+        val secretKey = DescriptorSecretKey(NetworkKind.TEST, mnemonic, null)
+        val derived = secretKey.derive(DerivationPath("m/86'/1'/0'"))
+        val withWildcard = derived.addWildcard(WildcardType.UNHARDENED)
+        assertFailsWith<DescriptorKeyException> {
+            withWildcard.addWildcard(WildcardType.HARDENED)
+        }
+    }
+
+    @Test
+    fun descriptorPublicKeyAddWildcard() {
+        val mnemonic = Mnemonic.fromString("awesome awesome awesome awesome awesome awesome awesome awesome awesome awesome awesome awesome")
+        val secretKey = DescriptorSecretKey(NetworkKind.TEST, mnemonic, null)
+        val derived = secretKey.derive(DerivationPath("m/86'/1'/0'"))
+        val publicKey = derived.asPublic()
+        val withWildcard = publicKey.addWildcard()
+        assertTrue(withWildcard.toString().endsWith("/*"))
     }
 }

--- a/bdk-ffi/src/error.rs
+++ b/bdk-ffi/src/error.rs
@@ -287,6 +287,9 @@ pub enum DescriptorKeyError {
 
     #[error("error bip 32 related: {error_message}")]
     Bip32 { error_message: String },
+
+    #[error("you cannot change a wildcard from hardened to unhardened or the opposite")]
+    CannotChangeWildcardType,
 }
 
 #[derive(Debug, thiserror::Error, uniffi::Error)]

--- a/bdk-ffi/src/keys.rs
+++ b/bdk-ffi/src/keys.rs
@@ -16,6 +16,7 @@ use bdk_wallet::keys::{
 use bdk_wallet::miniscript::descriptor::{DescriptorXKey, Wildcard};
 use bdk_wallet::miniscript::BareCtx;
 
+use crate::types::WildcardType;
 use std::convert::TryFrom;
 use std::fmt::Display;
 use std::str::FromStr;
@@ -132,14 +133,14 @@ impl Display for DerivationPath {
 impl_from_core_type!(BdkDerivationPath, DerivationPath);
 impl_into_core_type!(DerivationPath, BdkDerivationPath);
 
-/// A descriptor containing secret data.
+/// The descriptor secret key, either a single private key or an xprv.
 #[derive(Debug, uniffi::Object)]
 #[uniffi::export(Debug, Display)]
 pub struct DescriptorSecretKey(pub(crate) BdkDescriptorSecretKey);
 
 #[uniffi::export]
 impl DescriptorSecretKey {
-    /// Construct a secret descriptor using a mnemonic.
+    /// Construct a secret descriptor key using a mnemonic.
     #[uniffi::constructor]
     pub fn new(network_kind: NetworkKind, mnemonic: &Mnemonic, password: Option<String>) -> Self {
         let mnemonic = mnemonic.0.clone();
@@ -148,7 +149,7 @@ impl DescriptorSecretKey {
             origin: None,
             xkey: xkey.into_xprv(network_kind).unwrap(),
             derivation_path: BdkDerivationPath::master(),
-            wildcard: Wildcard::Unhardened,
+            wildcard: Wildcard::None,
         });
         Self(descriptor_secret_key)
     }
@@ -202,6 +203,53 @@ impl DescriptorSecretKey {
                     wildcard: descriptor_x_key.wildcard,
                 });
                 Ok(Arc::new(Self(extended_descriptor_secret_key)))
+            }
+            BdkDescriptorSecretKey::MultiXPrv(_) => Err(DescriptorKeyError::InvalidKeyType),
+        }
+    }
+
+    /// Add a wildcard derivation step (unhardened `*` or hardened `*h`) to this extended private key.
+    ///
+    /// If the key already has the same wildcard type, it is returned unchanged. Returns an error
+    /// if the key is not a single xprv, or if the key already has a wildcard of a different type.
+    pub fn add_wildcard(
+        &self,
+        wildcard_type: WildcardType,
+    ) -> Result<Arc<Self>, DescriptorKeyError> {
+        let descriptor_secret_key = &self.0;
+        match descriptor_secret_key {
+            BdkDescriptorSecretKey::Single(_) => Err(DescriptorKeyError::InvalidKeyType),
+            BdkDescriptorSecretKey::XPrv(descriptor_x_key) => {
+                let same_wildcard = (descriptor_x_key.wildcard == Wildcard::Unhardened
+                    && wildcard_type == WildcardType::Unhardened)
+                    || (descriptor_x_key.wildcard == Wildcard::Hardened
+                        && wildcard_type == WildcardType::Hardened);
+
+                // If there is a wildcard already present and it's of the same type as the one requested,
+                // return the same DescriptorSecretKey
+                if same_wildcard {
+                    let descriptor_secret_key_with_wildcard =
+                        BdkDescriptorSecretKey::XPrv(DescriptorXKey {
+                            origin: descriptor_x_key.origin.clone(),
+                            xkey: descriptor_x_key.xkey,
+                            derivation_path: descriptor_x_key.derivation_path.clone(),
+                            wildcard: descriptor_x_key.wildcard,
+                        });
+                    Ok(Arc::new(Self(descriptor_secret_key_with_wildcard)))
+                } else if descriptor_x_key.wildcard == Wildcard::None {
+                    // If the descriptor doesn't have a wildcard, add the requested wildcard
+                    let descriptor_secret_key_with_wildcard =
+                        BdkDescriptorSecretKey::XPrv(DescriptorXKey {
+                            origin: descriptor_x_key.origin.clone(),
+                            xkey: descriptor_x_key.xkey,
+                            derivation_path: descriptor_x_key.derivation_path.clone(),
+                            wildcard: wildcard_type.into(),
+                        });
+                    Ok(Arc::new(Self(descriptor_secret_key_with_wildcard)))
+                } else {
+                    // If the descriptor already has a wildcard of a different type, return an error
+                    Err(DescriptorKeyError::CannotChangeWildcardType)
+                }
             }
             BdkDescriptorSecretKey::MultiXPrv(_) => Err(DescriptorKeyError::InvalidKeyType),
         }
@@ -295,6 +343,46 @@ impl DescriptorPublicKey {
                     wildcard: descriptor_x_key.wildcard,
                 });
                 Ok(Arc::new(Self(extended_descriptor_public_key)))
+            }
+            BdkDescriptorPublicKey::MultiXPub(_) => Err(DescriptorKeyError::InvalidKeyType),
+        }
+    }
+
+    /// Add an unhardened wildcard derivation step (`*`) to this extended public key.
+    ///
+    /// Public keys only support unhardened wildcards since xpubs cannot derive hardened children.
+    /// If the key already has an unhardened wildcard, it is returned unchanged. Returns an error
+    /// if the key is not a single xpub, or if the key already has a hardened wildcard.
+    pub fn add_wildcard(&self) -> Result<Arc<Self>, DescriptorKeyError> {
+        let descriptor_public_key = &self.0;
+        match descriptor_public_key {
+            BdkDescriptorPublicKey::Single(_) => Err(DescriptorKeyError::InvalidKeyType),
+            BdkDescriptorPublicKey::XPub(descriptor_x_key) => {
+                // If there is a wildcard already present and it's unhardened,
+                // return the same DescriptorPublicKey
+                if descriptor_x_key.wildcard == Wildcard::Unhardened {
+                    let descriptor_public_key_with_wildcard =
+                        BdkDescriptorPublicKey::XPub(DescriptorXKey {
+                            origin: descriptor_x_key.origin.clone(),
+                            xkey: descriptor_x_key.xkey,
+                            derivation_path: descriptor_x_key.derivation_path.clone(),
+                            wildcard: Wildcard::Unhardened,
+                        });
+                    Ok(Arc::new(Self(descriptor_public_key_with_wildcard)))
+                } else if descriptor_x_key.wildcard == Wildcard::None {
+                    // If the descriptor doesn't have a wildcard, add an Unhardened wildcard
+                    let descriptor_public_key_with_wildcard =
+                        BdkDescriptorPublicKey::XPub(DescriptorXKey {
+                            origin: descriptor_x_key.origin.clone(),
+                            xkey: descriptor_x_key.xkey,
+                            derivation_path: descriptor_x_key.derivation_path.clone(),
+                            wildcard: Wildcard::Unhardened,
+                        });
+                    Ok(Arc::new(Self(descriptor_public_key_with_wildcard)))
+                } else {
+                    // If the descriptor already has a wildcard and it's hardened, return an error, because (1) we don't want to allow changing the wildcard, and (2) extended public keys cannot derived hardened children
+                    Err(DescriptorKeyError::CannotChangeWildcardType)
+                }
             }
             BdkDescriptorPublicKey::MultiXPub(_) => Err(DescriptorKeyError::InvalidKeyType),
         }

--- a/bdk-ffi/src/tests/keys.rs
+++ b/bdk-ffi/src/tests/keys.rs
@@ -1,6 +1,7 @@
 use crate::bitcoin::NetworkKind;
 use crate::error::DescriptorKeyError;
 use crate::keys::{DerivationPath, DescriptorPublicKey, DescriptorSecretKey, Mnemonic};
+use crate::types::WildcardType;
 use std::sync::Arc;
 
 fn get_inner() -> DescriptorSecretKey {
@@ -43,38 +44,38 @@ fn extend_dpk(
 #[test]
 fn test_generate_descriptor_secret_key() {
     let master_dsk = get_inner();
-    assert_eq!(master_dsk.to_string(), "tprv8ZgxMBicQKsPdWuqM1t1CDRvQtQuBPyfL6GbhQwtxDKgUAVPbxmj71pRA8raTqLrec5LyTs5TqCxdABcZr77bt2KyWA5bizJHnC4g4ysm4h/*");
-    assert_eq!(master_dsk.as_public().to_string(), "tpubD6NzVbkrYhZ4WywdEfYbbd62yuvqLjAZuPsNyvzCNV85JekAEMbKHWSHLF9h3j45SxewXDcLv328B1SEZrxg4iwGfmdt1pDFjZiTkGiFqGa/*");
+    assert_eq!(master_dsk.to_string(), "tprv8ZgxMBicQKsPdWuqM1t1CDRvQtQuBPyfL6GbhQwtxDKgUAVPbxmj71pRA8raTqLrec5LyTs5TqCxdABcZr77bt2KyWA5bizJHnC4g4ysm4h");
+    assert_eq!(master_dsk.as_public().to_string(), "tpubD6NzVbkrYhZ4WywdEfYbbd62yuvqLjAZuPsNyvzCNV85JekAEMbKHWSHLF9h3j45SxewXDcLv328B1SEZrxg4iwGfmdt1pDFjZiTkGiFqGa");
 }
 
 #[test]
 fn test_derive_self() {
     let master_dsk = get_inner();
     let derived_dsk: &DescriptorSecretKey = &derive_dsk(&master_dsk, "m").unwrap();
-    assert_eq!(derived_dsk.to_string(), "[d1d04177]tprv8ZgxMBicQKsPdWuqM1t1CDRvQtQuBPyfL6GbhQwtxDKgUAVPbxmj71pRA8raTqLrec5LyTs5TqCxdABcZr77bt2KyWA5bizJHnC4g4ysm4h/*");
+    assert_eq!(derived_dsk.to_string(), "[d1d04177]tprv8ZgxMBicQKsPdWuqM1t1CDRvQtQuBPyfL6GbhQwtxDKgUAVPbxmj71pRA8raTqLrec5LyTs5TqCxdABcZr77bt2KyWA5bizJHnC4g4ysm4h");
     let master_dpk: &DescriptorPublicKey = &master_dsk.as_public();
     let derived_dpk: &DescriptorPublicKey = &derive_dpk(master_dpk, "m").unwrap();
-    assert_eq!(derived_dpk.to_string(), "[d1d04177]tpubD6NzVbkrYhZ4WywdEfYbbd62yuvqLjAZuPsNyvzCNV85JekAEMbKHWSHLF9h3j45SxewXDcLv328B1SEZrxg4iwGfmdt1pDFjZiTkGiFqGa/*");
+    assert_eq!(derived_dpk.to_string(), "[d1d04177]tpubD6NzVbkrYhZ4WywdEfYbbd62yuvqLjAZuPsNyvzCNV85JekAEMbKHWSHLF9h3j45SxewXDcLv328B1SEZrxg4iwGfmdt1pDFjZiTkGiFqGa");
 }
 
 #[test]
 fn test_derive_descriptors_keys() {
     let master_dsk = get_inner();
     let derived_dsk: &DescriptorSecretKey = &derive_dsk(&master_dsk, "m/0").unwrap();
-    assert_eq!(derived_dsk.to_string(), "[d1d04177/0]tprv8d7Y4JLmD25jkKbyDZXcdoPHu1YtMHuH21qeN7mFpjfumtSU7eZimFYUCSa3MYzkEYfSNRBV34GEr2QXwZCMYRZ7M1g6PUtiLhbJhBZEGYJ/*");
+    assert_eq!(derived_dsk.to_string(), "[d1d04177/0]tprv8d7Y4JLmD25jkKbyDZXcdoPHu1YtMHuH21qeN7mFpjfumtSU7eZimFYUCSa3MYzkEYfSNRBV34GEr2QXwZCMYRZ7M1g6PUtiLhbJhBZEGYJ");
     let master_dpk: &DescriptorPublicKey = &master_dsk.as_public();
     let derived_dpk: &DescriptorPublicKey = &derive_dpk(master_dpk, "m/0").unwrap();
-    assert_eq!(derived_dpk.to_string(), "[d1d04177/0]tpubD9oaCiP1MPmQdndm7DCD3D3QU34pWd6BbKSRedoZF1UJcNhEk3PJwkALNYkhxeTKL29oGNR7psqvT1KZydCGqUDEKXN6dVQJY2R8ooLPy8m/*");
+    assert_eq!(derived_dpk.to_string(), "[d1d04177/0]tpubD9oaCiP1MPmQdndm7DCD3D3QU34pWd6BbKSRedoZF1UJcNhEk3PJwkALNYkhxeTKL29oGNR7psqvT1KZydCGqUDEKXN6dVQJY2R8ooLPy8m");
 }
 
 #[test]
 fn test_extend_descriptor_keys() {
     let master_dsk = get_inner();
     let extended_dsk: &DescriptorSecretKey = &extend_dsk(&master_dsk, "m/0").unwrap();
-    assert_eq!(extended_dsk.to_string(), "tprv8ZgxMBicQKsPdWuqM1t1CDRvQtQuBPyfL6GbhQwtxDKgUAVPbxmj71pRA8raTqLrec5LyTs5TqCxdABcZr77bt2KyWA5bizJHnC4g4ysm4h/0/*");
+    assert_eq!(extended_dsk.to_string(), "tprv8ZgxMBicQKsPdWuqM1t1CDRvQtQuBPyfL6GbhQwtxDKgUAVPbxmj71pRA8raTqLrec5LyTs5TqCxdABcZr77bt2KyWA5bizJHnC4g4ysm4h/0");
     let master_dpk: &DescriptorPublicKey = &master_dsk.as_public();
     let extended_dpk: &DescriptorPublicKey = &extend_dpk(master_dpk, "m/0").unwrap();
-    assert_eq!(extended_dpk.to_string(), "tpubD6NzVbkrYhZ4WywdEfYbbd62yuvqLjAZuPsNyvzCNV85JekAEMbKHWSHLF9h3j45SxewXDcLv328B1SEZrxg4iwGfmdt1pDFjZiTkGiFqGa/0/*");
+    assert_eq!(extended_dpk.to_string(), "tpubD6NzVbkrYhZ4WywdEfYbbd62yuvqLjAZuPsNyvzCNV85JekAEMbKHWSHLF9h3j45SxewXDcLv328B1SEZrxg4iwGfmdt1pDFjZiTkGiFqGa/0");
     let wif = "L2wTu6hQrnDMiFNWA5na6jB12ErGQqtXwqpSL7aWquJaZG8Ai3ch";
     let extended_key = DescriptorSecretKey::from_string(wif.to_string()).unwrap();
     let result = extended_key.derive(&DerivationPath::new("m/0".to_string()).unwrap());
@@ -97,10 +98,10 @@ fn test_derive_and_extend_inner() {
     let master_dsk = get_inner();
     // derive DescriptorSecretKey with path "m/0" from master
     let derived_dsk: &DescriptorSecretKey = &derive_dsk(&master_dsk, "m/0").unwrap();
-    assert_eq!(derived_dsk.to_string(), "[d1d04177/0]tprv8d7Y4JLmD25jkKbyDZXcdoPHu1YtMHuH21qeN7mFpjfumtSU7eZimFYUCSa3MYzkEYfSNRBV34GEr2QXwZCMYRZ7M1g6PUtiLhbJhBZEGYJ/*");
+    assert_eq!(derived_dsk.to_string(), "[d1d04177/0]tprv8d7Y4JLmD25jkKbyDZXcdoPHu1YtMHuH21qeN7mFpjfumtSU7eZimFYUCSa3MYzkEYfSNRBV34GEr2QXwZCMYRZ7M1g6PUtiLhbJhBZEGYJ");
     // extend derived_dsk with path "m/0"
     let extended_dsk: &DescriptorSecretKey = &extend_dsk(derived_dsk, "m/0").unwrap();
-    assert_eq!(extended_dsk.to_string(), "[d1d04177/0]tprv8d7Y4JLmD25jkKbyDZXcdoPHu1YtMHuH21qeN7mFpjfumtSU7eZimFYUCSa3MYzkEYfSNRBV34GEr2QXwZCMYRZ7M1g6PUtiLhbJhBZEGYJ/0/*");
+    assert_eq!(extended_dsk.to_string(), "[d1d04177/0]tprv8d7Y4JLmD25jkKbyDZXcdoPHu1YtMHuH21qeN7mFpjfumtSU7eZimFYUCSa3MYzkEYfSNRBV34GEr2QXwZCMYRZ7M1g6PUtiLhbJhBZEGYJ/0");
 }
 
 #[test]
@@ -133,4 +134,66 @@ fn test_invalid_derivation_path() {
     let invalid_path_str = "m/44x/0h/0h/0/0";
     let result = DerivationPath::new(invalid_path_str.to_string());
     assert!(result.is_err());
+}
+
+#[test]
+fn test_add_wildcard() {
+    let mnemonic = Mnemonic::from_string("awesome awesome awesome awesome awesome awesome awesome awesome awesome awesome awesome awesome".to_string()).unwrap();
+    let key = DescriptorSecretKey::new(NetworkKind::Test, &mnemonic, None);
+
+    let derivation_path = DerivationPath::new("84/2h/1".to_string()).unwrap();
+    let extended_key = key.extend(&derivation_path).unwrap();
+    assert_eq!(extended_key.to_string(), "tprv8ZgxMBicQKsPdWAHbugK2tjtVtRjKGixYVZUdL7xLHMgXZS6BFbFi1UDb1CHT25Z5PU1F9j7wGxwUiRhqz9E3nZRztikGUV6HoRDYcqPhM4/84/2'/1");
+
+    // Add an unhardened wildcard
+    let dsk_unhardened = extended_key.add_wildcard(WildcardType::Unhardened).unwrap();
+    assert_eq!(dsk_unhardened.to_string(), "tprv8ZgxMBicQKsPdWAHbugK2tjtVtRjKGixYVZUdL7xLHMgXZS6BFbFi1UDb1CHT25Z5PU1F9j7wGxwUiRhqz9E3nZRztikGUV6HoRDYcqPhM4/84/2'/1/*");
+
+    // Add a hardened wildcard
+    let dsk_hardened = extended_key.add_wildcard(WildcardType::Hardened).unwrap();
+    assert_eq!(dsk_hardened.to_string(), "tprv8ZgxMBicQKsPdWAHbugK2tjtVtRjKGixYVZUdL7xLHMgXZS6BFbFi1UDb1CHT25Z5PU1F9j7wGxwUiRhqz9E3nZRztikGUV6HoRDYcqPhM4/84/2'/1/*h");
+
+    // Calling add_wildcard with the same type returns the same key
+    assert_eq!(
+        dsk_unhardened
+            .add_wildcard(WildcardType::Unhardened)
+            .unwrap()
+            .to_string(),
+        dsk_unhardened.to_string()
+    );
+    assert_eq!(
+        dsk_hardened
+            .add_wildcard(WildcardType::Hardened)
+            .unwrap()
+            .to_string(),
+        dsk_hardened.to_string()
+    );
+
+    // Attempting to change the wildcard type returns an error
+    assert!(matches!(
+        dsk_unhardened.add_wildcard(WildcardType::Hardened),
+        Err(DescriptorKeyError::CannotChangeWildcardType)
+    ));
+    assert!(matches!(
+        dsk_hardened.add_wildcard(WildcardType::Unhardened),
+        Err(DescriptorKeyError::CannotChangeWildcardType)
+    ));
+
+    // DescriptorPublicKey: add_wildcard() always adds an unhardened wildcard
+    let dpk = extended_key.as_public();
+    let dpk_with_wildcard = dpk.add_wildcard().unwrap();
+    assert_eq!(dpk_with_wildcard.to_string(), "[5bc5d243/84/2']tpubDAFG7XHSgRo927vaVKhcJAjuYW6AXJPunmS8So9ipV1xUyAUzEoBoiS5xSgPNBmjPMSnSXKjsJnTHWieJzUVxz8TUdWm8BUqgy4wL9yz5hp/1/*");
+
+    // Calling add_wildcard on a DPK that already has an unhardened wildcard returns the same DPK
+    assert_eq!(
+        dpk_with_wildcard.add_wildcard().unwrap().to_string(),
+        dpk_with_wildcard.to_string()
+    );
+
+    // Calling add_wildcard on a DPK converted from a DSK with a hardened wildcard returns an error
+    let dpk_hardened = dsk_hardened.as_public();
+    assert!(matches!(
+        dpk_hardened.add_wildcard(),
+        Err(DescriptorKeyError::CannotChangeWildcardType)
+    ));
 }

--- a/bdk-ffi/src/types.rs
+++ b/bdk-ffi/src/types.rs
@@ -25,6 +25,7 @@ use bdk_wallet::descriptor::policy::{
 };
 use bdk_wallet::locked_outpoints::ChangeSet as BdkLockedOutpointsChangeSet;
 #[allow(deprecated)]
+use bdk_wallet::miniscript::descriptor::Wildcard;
 use bdk_wallet::signer::{SignOptions as BdkSignOptions, TapLeavesOptions};
 use bdk_wallet::AddressInfo as BdkAddressInfo;
 use bdk_wallet::Balance as BdkBalance;
@@ -1459,6 +1460,24 @@ impl From<bdk_wallet::TxDetails> for TxDetails {
             balance_delta: details.balance_delta.to_sat(),
             chain_position: details.chain_position.into(),
             tx: Arc::new(Transaction::from(details.tx.as_ref().clone())),
+        }
+    }
+}
+
+/// Wildcard types for descriptors
+#[derive(uniffi::Enum, PartialEq)]
+pub enum WildcardType {
+    /// Unhardened wildcard, e.g. *
+    Unhardened,
+    /// Hardened wildcard, e.g. *h
+    Hardened,
+}
+
+impl From<WildcardType> for Wildcard {
+    fn from(wildcard_type: WildcardType) -> Self {
+        match wildcard_type {
+            WildcardType::Unhardened => Wildcard::Unhardened,
+            WildcardType::Hardened => Wildcard::Hardened,
         }
     }
 }

--- a/bdk-swift/Tests/BitcoinDevKitTests/OfflineDescriptorTests.swift
+++ b/bdk-swift/Tests/BitcoinDevKitTests/OfflineDescriptorTests.swift
@@ -17,4 +17,46 @@ final class OfflineDescriptorTests: XCTestCase {
 
         XCTAssertEqual(descriptor.description, "tr([be1eec8f/86'/1'/0']tpubDCTtszwSxPx3tATqDrsSyqScPNnUChwQAVAkanuDUCJQESGBbkt68nXXKRDifYSDbeMa2Xg2euKbXaU3YphvGWftDE7ozRKPriT6vAo3xsc/0/*)#m7puekcx")
     }
+
+    func testDescriptorSecretKeyAddUnhardenedWildcard() throws {
+        let mnemonic = try Mnemonic.fromString(mnemonic: "awesome awesome awesome awesome awesome awesome awesome awesome awesome awesome awesome awesome")
+        let secretKey = DescriptorSecretKey(networkKind: NetworkKind.test, mnemonic: mnemonic, password: nil)
+        let derived = try secretKey.derive(path: DerivationPath(path: "m/86'/1'/0'"))
+        let withWildcard = try derived.addWildcard(wildcardType: WildcardType.unhardened)
+        XCTAssertTrue(withWildcard.description.hasSuffix("/*"))
+    }
+
+    func testDescriptorSecretKeyAddHardenedWildcard() throws {
+        let mnemonic = try Mnemonic.fromString(mnemonic: "awesome awesome awesome awesome awesome awesome awesome awesome awesome awesome awesome awesome")
+        let secretKey = DescriptorSecretKey(networkKind: NetworkKind.test, mnemonic: mnemonic, password: nil)
+        let derived = try secretKey.derive(path: DerivationPath(path: "m/86'/1'/0'"))
+        let withWildcard = try derived.addWildcard(wildcardType: WildcardType.hardened)
+        XCTAssertTrue(withWildcard.description.hasSuffix("/*h"))
+    }
+
+    func testDescriptorSecretKeyAddWildcardIsIdempotent() throws {
+        let mnemonic = try Mnemonic.fromString(mnemonic: "awesome awesome awesome awesome awesome awesome awesome awesome awesome awesome awesome awesome")
+        let secretKey = DescriptorSecretKey(networkKind: NetworkKind.test, mnemonic: mnemonic, password: nil)
+        let derived = try secretKey.derive(path: DerivationPath(path: "m/86'/1'/0'"))
+        let withWildcard = try derived.addWildcard(wildcardType: WildcardType.unhardened)
+        let withWildcardAgain = try withWildcard.addWildcard(wildcardType: WildcardType.unhardened)
+        XCTAssertEqual(withWildcard.description, withWildcardAgain.description)
+    }
+
+    func testDescriptorSecretKeyCannotChangeWildcardType() throws {
+        let mnemonic = try Mnemonic.fromString(mnemonic: "awesome awesome awesome awesome awesome awesome awesome awesome awesome awesome awesome awesome")
+        let secretKey = DescriptorSecretKey(networkKind: NetworkKind.test, mnemonic: mnemonic, password: nil)
+        let derived = try secretKey.derive(path: DerivationPath(path: "m/86'/1'/0'"))
+        let withWildcard = try derived.addWildcard(wildcardType: WildcardType.unhardened)
+        XCTAssertThrowsError(try withWildcard.addWildcard(wildcardType: WildcardType.hardened))
+    }
+
+    func testDescriptorPublicKeyAddWildcard() throws {
+        let mnemonic = try Mnemonic.fromString(mnemonic: "awesome awesome awesome awesome awesome awesome awesome awesome awesome awesome awesome awesome")
+        let secretKey = DescriptorSecretKey(networkKind: NetworkKind.test, mnemonic: mnemonic, password: nil)
+        let derived = try secretKey.derive(path: DerivationPath(path: "m/86'/1'/0'"))
+        let publicKey = derived.asPublic()
+        let withWildcard = try publicKey.addWildcard()
+        XCTAssertTrue(withWildcard.description.hasSuffix("/*"))
+    }
 }


### PR DESCRIPTION
This is a small issue that's been on my mind for a very long time. Fixes #324.

Our `DescriptorSecretKey` and `DescriptorPublicKey` types, upon creation, build extended keys that have a wildcard added by default. For example, creating a DescriptorSecretKey currently gives you something like this:

```rust
tprv8ZgxMBicQKsPdWuqM1t1CDRvQtQuBPyfL6GbhQwtxDKgUAVPbxmj71pRA8raTqLrec5LyTs5TqCxdABcZr77bt2KyWA5bizJHnC4g4ysm4h/*
```

This is a bit weird because... well you wouldn't often add a wildcard right there as your first derivation step. None of the bips do this. Rather, you often add wildcards once you've fully derived your key at the index you want it at. Moreover, you could not use our API as is to create _unwildcarded_ DescriptorSecretKeys or DescriptorPublicKeys. This is an odd limitation of the code as it stands, because in reality those are totally possible; we just didn't allow it with the current code. I suspect we didn't get a lot of feedback on this simply because it's not a part of the API that is used much.

This PR addresses that, and creates extended keys the way you'd expect them:

```rust
let mnemonic = Mnemonic::from_string("awesome awesome awesome awesome awesome awesome awesome awesome awesome awesome awesome awesome".to_string()).unwrap();
let key = DescriptorSecretKey::new(Network::Testnet, &mnemonic, None);
// key = "tprv8ZgxMBicQKsPdWAHbugK2tjtVtRjKGixYVZUdL7xLHMgXZS6BFbFi1UDb1CHT25Z5PU1F9j7wGxwUiRhqz9E3nZRztikGUV6HoRDYcqPhM4"
```

From there you can extend them however you want, including adding a wildcard to it if you'd like, using a new method on the type, `add_wildcard()`.

### Changelog notice

```md
## Changed
    - The `DescriptorSecretKey::new` constructor does not produce an extended key with an automatic wildcard anymore [#853]

## Added
    - The `DescriptorPublicKey::new` constructor [#853]
    - New `DescriptorPublicKey::add_wildcard` method, which adds a wildcard to the derivation path of the descriptor [#853]
    - New `DescriptorSecretKey::add_wildcard` method, which adds a wildcard to the derivation path of the descriptor [#853]

[#853]: https://github.com/bitcoindevkit/bdk-ffi/pull/853
```

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [x] I've added tests for the new feature
* [x] I've added docs for the new feature
