### PR TITLE
Increase page sizes on Android platforms to 16KB

### DIFF
--- a/bdk-ffi/.cargo/config.toml
+++ b/bdk-ffi/.cargo/config.toml
@@ -1,0 +1,8 @@
+[target.'cfg(target_os = "android")']
+rustflags = [
+    "-C", "link-arg=-z",
+    "-C", "link-arg=max-page-size=16384",
+    "-C", "link-arg=-z",
+    "-C", "link-arg=common-page-size=16384",
+]
+


### PR DESCRIPTION
### Description
Add compiler flags to the Android platform targets that increase the page size to 16KB. This will be required by the Google Play Store starting in October.
This change only affects the android platform artifacts.

Fixes #819

### Notes to the reviewers

Google's page size requirements found here:
https://developer.android.com/guide/practices/page-sizes#test

### Changelog notice

 - Updates Android native libraries to use 16KB page sizes

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [x] I'm linking the issue being fixed by this PR
