### PR TITLE
CI: Add trigger event for bdk-python library

### DIFF
--- a/.github/workflows/trigger-external-bindings.yml
+++ b/.github/workflows/trigger-external-bindings.yml
@@ -39,3 +39,24 @@ jobs:
           else
             echo "(empty)"
           fi
+          
+      # Trigger trigger-bdk-python-test workflow in bdk-python repository
+      - name: Trigger tests in bdk-python repository
+        env:
+          BDK_PYTHON_ACCESS_TOKEN: ${{ secrets.BDK_PYTHON_ACCESS_TOKEN }}
+        run: |
+          curl --silent --show-error \
+            --output /tmp/resp_bdk-python.txt \
+            --write-out "HTTP Status: %{http_code}\n" \
+            --request POST \
+            --header "Accept: application/vnd.github+json" \
+            --header "Content-Type: application/json" \
+            --header "Authorization: Bearer $BDK_PYTHON_ACCESS_TOKEN" \
+            --data '{"event_type":"trigger-bdk-python-test"}' \
+            https://api.github.com/repos/bitcoindevkit/bdk-python/dispatches
+          echo "Response body:"
+          if [ -s /tmp/resp_bdk-python.txt ]; then
+            jq . /tmp/resp_bdk-python.txt || cat /tmp/resp_bdk-python.txt
+          else
+            echo "(empty)"
+          fi


### PR DESCRIPTION
### Description

This PR extends the trigger-external-binding workflow to allow bdk-python library to run tests when new commits are merged on bdk-ffi master branch.

### Notes to the reviewers

Repository owner

1. bdk-python repo owner: a new personal access token needs to be created (mandatory scopes: `workflow, repo/public_repo`).
2. bdk-ffi repo owner: a new repository secret (BDK_PYTHON_ACCESS_TOKEN) must be added, setting its value to the token gotten in the previous step.

### Checklists

#### All Submissions:

* [X] I've signed all my commits
* [X] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [ ] I ran `cargo fmt` and `cargo clippy` before committing
