### PR TITLE
Reduce stack allocation in CBF

### DIFF
--- a/bdk-ffi/Cargo.lock
+++ b/bdk-ffi/Cargo.lock
@@ -207,8 +207,7 @@ dependencies = [
 [[package]]
 name = "bdk_kyoto"
 version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a46b32f4f92e368fb5fd446f30c8c81126a63a78f90f63011bc7a6b787511a81"
+source = "git+https://github.com/rustaceanrob/bdk-kyoto.git?rev=1b61c9c53bc3cd9d2827e04994f7dc14d0f93f5c#1b61c9c53bc3cd9d2827e04994f7dc14d0f93f5c"
 dependencies = [
  "bdk_wallet",
  "bip157",
@@ -238,8 +237,7 @@ checksum = "d965446196e3b7decd44aa7ee49e31d630118f90ef12f97900f262eb915c951d"
 [[package]]
 name = "bip157"
 version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9af64ec611227ba3ea73bc8b09a97a8af835804d0202071e2465e9b1055e6cd1"
+source = "git+https://github.com/rustaceanrob/kyoto.git?rev=ef9f4aa4ef557f1f12f563d9f2760ae2e384594a#ef9f4aa4ef557f1f12f563d9f2760ae2e384594a"
 dependencies = [
  "bip324",
  "bitcoin",

--- a/bdk-ffi/Cargo.toml
+++ b/bdk-ffi/Cargo.toml
@@ -18,7 +18,7 @@ path = "uniffi-bindgen.rs"
 bdk_wallet = { version = "2.2.0", features = ["all-keys", "keys-bip39", "rusqlite"] }
 bdk_esplora = { version = "0.22.1", default-features = false, features = ["std", "blocking", "blocking-https-rustls"] }
 bdk_electrum = { version = "0.23.2", default-features = false, features = ["use-rustls-ring"] }
-bdk_kyoto = { version = "0.15.0" }
+bdk_kyoto = { version = "0.15.1" }
 
 uniffi = { version = "=0.29.4", features = ["cli"]}
 thiserror = "2.0.17"


### PR DESCRIPTION
Closes #877 

The `CbfNode` was attempting to allocate a large section of the stack memory, and Swift denied doing so. Reducing this allocation in Kyoto has resolved the issue locally for me.
