### PR TITLE
refactor: descriptor errors instead of panicking on invalid fingerprints

### DIFF
--- a/bdk-ffi/src/descriptor.rs
+++ b/bdk-ffi/src/descriptor.rs
@@ -78,8 +78,12 @@ impl Descriptor {
         fingerprint: String,
         keychain_kind: KeychainKind,
         network: Network,
-    ) -> Self {
-        let fingerprint = Fingerprint::from_str(fingerprint.as_str()).unwrap();
+    ) -> Result<Self, DescriptorError> {
+        let fingerprint = Fingerprint::from_str(fingerprint.as_str()).map_err(|error| {
+            DescriptorError::Bip32 {
+                error_message: error.to_string(),
+            }
+        })?;
         let derivable_key = &public_key.0;
 
         match derivable_key {
@@ -91,12 +95,12 @@ impl Descriptor {
                 let (extended_descriptor, key_map, _) =
                     Bip44Public(derivable_key, fingerprint, keychain_kind)
                         .build(network)
-                        .unwrap();
+                        .map_err(DescriptorError::from)?;
 
-                Self {
+                Ok(Self {
                     extended_descriptor,
                     key_map,
-                }
+                })
             }
             BdkDescriptorPublicKey::MultiXPub(_) => {
                 unreachable!()
@@ -139,8 +143,12 @@ impl Descriptor {
         fingerprint: String,
         keychain_kind: KeychainKind,
         network: Network,
-    ) -> Self {
-        let fingerprint = Fingerprint::from_str(fingerprint.as_str()).unwrap();
+    ) -> Result<Self, DescriptorError> {
+        let fingerprint = Fingerprint::from_str(fingerprint.as_str()).map_err(|error| {
+            DescriptorError::Bip32 {
+                error_message: error.to_string(),
+            }
+        })?;
         let derivable_key = &public_key.0;
 
         match derivable_key {
@@ -152,12 +160,12 @@ impl Descriptor {
                 let (extended_descriptor, key_map, _) =
                     Bip49Public(derivable_key, fingerprint, keychain_kind)
                         .build(network)
-                        .unwrap();
+                        .map_err(DescriptorError::from)?;
 
-                Self {
+                Ok(Self {
                     extended_descriptor,
                     key_map,
-                }
+                })
             }
             BdkDescriptorPublicKey::MultiXPub(_) => {
                 unreachable!()
@@ -200,8 +208,12 @@ impl Descriptor {
         fingerprint: String,
         keychain_kind: KeychainKind,
         network: Network,
-    ) -> Self {
-        let fingerprint = Fingerprint::from_str(fingerprint.as_str()).unwrap();
+    ) -> Result<Self, DescriptorError> {
+        let fingerprint = Fingerprint::from_str(fingerprint.as_str()).map_err(|error| {
+            DescriptorError::Bip32 {
+                error_message: error.to_string(),
+            }
+        })?;
         let derivable_key = &public_key.0;
 
         match derivable_key {
@@ -213,12 +225,12 @@ impl Descriptor {
                 let (extended_descriptor, key_map, _) =
                     Bip84Public(derivable_key, fingerprint, keychain_kind)
                         .build(network)
-                        .unwrap();
+                        .map_err(DescriptorError::from)?;
 
-                Self {
+                Ok(Self {
                     extended_descriptor,
                     key_map,
-                }
+                })
             }
             BdkDescriptorPublicKey::MultiXPub(_) => {
                 unreachable!()
@@ -261,8 +273,12 @@ impl Descriptor {
         fingerprint: String,
         keychain_kind: KeychainKind,
         network: Network,
-    ) -> Self {
-        let fingerprint = Fingerprint::from_str(fingerprint.as_str()).unwrap();
+    ) -> Result<Self, DescriptorError> {
+        let fingerprint = Fingerprint::from_str(fingerprint.as_str()).map_err(|error| {
+            DescriptorError::Bip32 {
+                error_message: error.to_string(),
+            }
+        })?;
         let derivable_key = &public_key.0;
 
         match derivable_key {
@@ -274,12 +290,12 @@ impl Descriptor {
                 let (extended_descriptor, key_map, _) =
                     Bip86Public(derivable_key, fingerprint, keychain_kind)
                         .build(network)
-                        .unwrap();
+                        .map_err(DescriptorError::from)?;
 
-                Self {
+                Ok(Self {
                     extended_descriptor,
                     key_map,
-                }
+                })
             }
             BdkDescriptorPublicKey::MultiXPub(_) => {
                 unreachable!()

--- a/bdk-ffi/src/tests/descriptor.rs
+++ b/bdk-ffi/src/tests/descriptor.rs
@@ -57,25 +57,29 @@ fn test_descriptor_templates() {
         "d1d04177".to_string(),
         KeychainKind::External,
         Network::Testnet,
-    );
+    )
+    .unwrap();
     let template_public_49 = Descriptor::new_bip49_public(
         &handmade_public_49,
         "d1d04177".to_string(),
         KeychainKind::External,
         Network::Testnet,
-    );
+    )
+    .unwrap();
     let template_public_84 = Descriptor::new_bip84_public(
         &handmade_public_84,
         "d1d04177".to_string(),
         KeychainKind::External,
         Network::Testnet,
-    );
+    )
+    .unwrap();
     let template_public_86 = Descriptor::new_bip86_public(
         &handmade_public_86,
         "d1d04177".to_string(),
         KeychainKind::External,
         Network::Testnet,
-    );
+    )
+    .unwrap();
     println!("Template public 49: {}", template_public_49);
     println!("Template public 44: {}", template_public_44);
     println!("Template public 84: {}", template_public_84);
@@ -122,6 +126,25 @@ fn test_descriptor_from_string() {
     // Creating a Descriptor using an extended key that doesn't match the network provided will throw a DescriptorError::Key with inner InvalidNetwork error
     assert!(descriptor1.is_ok());
     assert_matches!(descriptor2.unwrap_err(), DescriptorError::Key { .. });
+}
+
+#[test]
+fn test_new_bip84_public_invalid_fingerprint() {
+    let master: DescriptorSecretKey = get_descriptor_secret_key();
+    let public_84 = master
+        .derive(&DerivationPath::new("m/84h/1h/0h".to_string()).unwrap())
+        .unwrap()
+        .as_public();
+
+    let error = Descriptor::new_bip84_public(
+        &public_84,
+        "not-a-fingerprint".to_string(),
+        KeychainKind::External,
+        Network::Testnet,
+    )
+    .unwrap_err();
+
+    assert_matches!(error, DescriptorError::Bip32 { .. });
 }
 
 #[test]


### PR DESCRIPTION
<!-- Erase any parts of this template not applicable to your Pull Request. -->

### Description

Fixes the four descriptor constructors to return and map invalid fingerprints instead of unwrapping.

People using bindings will now get typed error they can handle instead of a possible panic.

Previously constructors handed back nothing on malformed input because they crashed so now they surface concrete error.

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Changelog notice

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [x] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
