### PR TITLE
Bump `bdk_kyoto` patch release

### DIFF
--- a/bdk-ffi/Cargo.lock
+++ b/bdk-ffi/Cargo.lock
@@ -176,9 +176,9 @@ dependencies = [
 
 [[package]]
 name = "bdk_kyoto"
-version = "0.15.1"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91b430c5fc2d28073df2fe122b177e89f67fbcec47824587163ba96499e3d02c"
+checksum = "2d1148f84df0d8ad287677457f15b554f7cc300a05101b15e31d20af1710a996"
 dependencies = [
  "bdk_wallet",
  "bip157",
@@ -207,9 +207,9 @@ checksum = "d965446196e3b7decd44aa7ee49e31d630118f90ef12f97900f262eb915c951d"
 
 [[package]]
 name = "bip157"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d10c525b8dc2a9c0aae5d2de384336696023e5201c6bcc22c47ec0fb9d9947cb"
+checksum = "88df5c18baaea9be4219679afbd4fc26491606f89f6ecdaffcdcabd67635b07b"
 dependencies = [
  "bip324",
  "bitcoin",
@@ -262,9 +262,9 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-address-book"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16d55a2ccdaa0271ea60355a01fc82e37f33a340df80599d344f9d6e97d46e48"
+checksum = "060c05780195789a7b89bbfe7f57a1a8cd6ae0bb3daa9b96eeca4fbe0ba8014f"
 dependencies = [
  "bitcoin",
 ]

--- a/bdk-ffi/Cargo.toml
+++ b/bdk-ffi/Cargo.toml
@@ -18,7 +18,7 @@ path = "uniffi-bindgen.rs"
 bdk_wallet = { version = "2.2.0", features = ["all-keys", "keys-bip39", "rusqlite"] }
 bdk_esplora = { version = "0.22.1", default-features = false, features = ["std", "blocking", "blocking-https-rustls"] }
 bdk_electrum = { version = "0.23.2", default-features = false, features = ["use-rustls-ring"] }
-bdk_kyoto = { version = "0.15.1" }
+bdk_kyoto = { version = "0.15.2" }
 
 uniffi = { version = "=0.29.4", features = ["cli"]}
 thiserror = "2.0.17"


### PR DESCRIPTION
This should re-add support for 32 bit architectures. I recommend we keep #892 open to see if this is necessary in the future. @ItoroD can you verify this works on `armv7-linux-androideabi`?

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
* [ ] I've added a changelog in the next release tracking issue (see [example](https://github.com/bitcoindevkit/bdk-ffi/issues/875))

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
