### PR TITLE
chore: add upstream doc links to pr template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,6 +9,17 @@
 <!-- In this section you can include notes directed to the reviewers, like explaining why some parts
 of the PR were done in a specific way -->
 
+### Documentation
+
+<!-- Paste the canonical docs/spec for anything this PR wraps or updates. -->
+
+- [ ] [`bdk_wallet`](https://docs.rs/bdk_wallet/latest/bdk_wallet/)
+  <!-- Add a link below with the docs.rs page. -->
+- [ ] [`bitcoin`](https://docs.rs/bitcoin/latest/bitcoin/index.html)
+  <!-- Add a link below with the docs.rs page. -->
+- [ ] [`uniffi`](https://github.com/mozilla/uniffi-rs) <!-- Add a link below with the version changelog or any other docs. -->
+- [ ] Other: <!-- Add a link below with additional references -->
+
 ### Checklists
 
 #### All Submissions:
@@ -17,6 +28,7 @@ of the PR were done in a specific way -->
 * [ ] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
 * [ ] I ran `cargo fmt` and `cargo clippy` before committing
 * [ ] I've added a changelog in the next release tracking issue (see [example](https://github.com/bitcoindevkit/bdk-ffi/issues/875))
+* [ ] I've linked the relevant upstream docs or specs above
 
 #### New Features:
 


### PR DESCRIPTION
<!-- Erase any parts of this template not applicable to your Pull Request. -->

### Description

I'd like to add a section in the PR template where upstream docs can be added.

Example: if im wrapping a bdk_wallet type in my PR then I link to the bdk_wallet docs.rs for it

I find it quite helpful when reviewing a PR if the associated upstream types/methods are already linked. I assume that's true for other people (which is why I try to do it but need to do it more consistently than I do though)

### Notes to the reviewers

Open to any thoughts or feedback.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [ ] I ran `cargo fmt` and `cargo clippy` before committing
* [ ] I've added a changelog in the next release tracking issue (see [example](https://github.com/bitcoindevkit/bdk-ffi/issues/875))

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
