### PR TITLE
Fix audit workflow

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -5,6 +5,7 @@ name: Rust Dependency Audit
 # Helps identify known security vulnerabilities in the dependency tree.
 
 on:
+  workflow_dispatch:
   push:
     paths:
       - '**/Cargo.toml'
@@ -28,5 +29,5 @@ jobs:
 
       - name: "Run audit"
         run: |
-          cargo install cargo-audit
+          cargo install cargo-audit --locked
           cargo-audit audit


### PR DESCRIPTION
This applies the recommendation from cargo in our failed audit CI run. The failure at the moment is not related to the audit itself, but rather the building of the cargo-audit tool with our current 1.85.1 version of Rust.

This should fix the build error. I also added a workflow dispatch for it in order to be able to test it on command.