### PR TITLE
feat: Add wallet event

### DIFF
--- a/bdk-ffi/src/types.rs
+++ b/bdk-ffi/src/types.rs
@@ -23,6 +23,7 @@ use bdk_wallet::descriptor::policy::{
     Condition as BdkCondition, PkOrF as BdkPkOrF, Policy as BdkPolicy,
     Satisfaction as BdkSatisfaction, SatisfiableItem as BdkSatisfiableItem,
 };
+use bdk_wallet::event::WalletEvent as BdkWalletEvent;
 #[allow(deprecated)]
 use bdk_wallet::signer::{SignOptions as BdkSignOptions, TapLeavesOptions};
 use bdk_wallet::AddressInfo as BdkAddressInfo;
@@ -32,6 +33,7 @@ use bdk_wallet::Update as BdkUpdate;
 
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::convert::TryFrom;
+use std::fmt::Display;
 use std::sync::{Arc, Mutex};
 
 use crate::{impl_from_core_type, impl_into_core_type};
@@ -494,6 +496,157 @@ impl From<BdkSatisfiableItem> for SatisfiableItem {
                     .collect(),
                 threshold: threshold as u64,
             },
+        }
+    }
+}
+
+/// Events representing changes to wallet transactions.
+///
+/// Returned after calling
+/// [`Wallet::apply_update_events`](crate::wallet::Wallet::apply_update_events).
+#[derive(Debug, Clone, uniffi::Enum)]
+#[uniffi::export(Display)]
+#[non_exhaustive]
+pub enum WalletEvent {
+    /// The latest chain tip known to the wallet changed.
+    ChainTipChanged {
+        /// Previous chain tip.
+        old_tip: BlockId,
+        /// New chain tip.
+        new_tip: BlockId,
+    },
+    /// A transaction is now confirmed.
+    ///
+    /// If the transaction was previously unconfirmed `old_block_time` will be `None`.
+    ///
+    /// If a confirmed transaction is now re-confirmed in a new block `old_block_time` will contain
+    /// the block id and the time it was previously confirmed. This can happen after a chain
+    /// reorg.
+    TxConfirmed {
+        /// Transaction id.
+        txid: Arc<Txid>,
+        /// Transaction.
+        tx: Arc<Transaction>,
+        /// Confirmation block time.
+        block_time: ConfirmationBlockTime,
+        /// Old confirmation block and time if previously confirmed in a different block.
+        old_block_time: Option<ConfirmationBlockTime>,
+    },
+    /// A transaction is now unconfirmed.
+    ///
+    /// If the transaction is first seen in the mempool `old_block_time` will be `None`.
+    ///
+    /// If a previously confirmed transaction is now seen in the mempool `old_block_time` will
+    /// contain the block id and the time it was previously confirmed. This can happen after a
+    /// chain reorg.
+    TxUnconfirmed {
+        /// Transaction id.
+        txid: Arc<Txid>,
+        /// Transaction.
+        tx: Arc<Transaction>,
+        /// Old confirmation block and time, if previously confirmed.
+        old_block_time: Option<ConfirmationBlockTime>,
+    },
+    /// An unconfirmed transaction was replaced.
+    ///
+    /// This can happen after an RBF is broadcast or if a third party double spends an input of
+    /// a received payment transaction before it is confirmed.
+    ///
+    /// The conflicts field contains the txid and vin (in which it conflicts) of the conflicting
+    /// transactions.
+    TxReplaced {
+        /// Transaction id.
+        txid: Arc<Txid>,
+        /// Transaction.
+        tx: Arc<Transaction>,
+        /// Conflicting transactions.
+        conflicts: Vec<Conflict>,
+    },
+    /// Unconfirmed transaction dropped.
+    ///
+    /// The transaction was dropped from the local mempool. This is generally due to the fee rate
+    /// being too low. The transaction can still reappear in the mempool in the future resulting in
+    /// a [`WalletEvent::TxUnconfirmed`] event.
+    TxDropped {
+        /// Transaction id.
+        txid: Arc<Txid>,
+        /// Transaction.
+        tx: Arc<Transaction>,
+    },
+}
+
+impl Display for WalletEvent {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+/// Represent a conflict in a replacement transaction.
+#[uniffi::export(Display)]
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct Conflict {
+    /// The index of the conflicting input.
+    pub vin: u32,
+    /// Conflicting transaction id.
+    pub txid: Arc<Txid>,
+}
+
+impl Display for Conflict {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+impl From<BdkWalletEvent> for WalletEvent {
+    fn from(event: BdkWalletEvent) -> Self {
+        match event {
+            BdkWalletEvent::ChainTipChanged { old_tip, new_tip } => WalletEvent::ChainTipChanged {
+                old_tip: BlockId::from(old_tip),
+                new_tip: BlockId::from(new_tip),
+            },
+            BdkWalletEvent::TxConfirmed {
+                txid,
+                tx,
+                block_time,
+                old_block_time,
+            } => WalletEvent::TxConfirmed {
+                txid: Arc::new(Txid(txid)),
+                tx: Arc::new(tx.as_ref().clone().into()),
+                block_time: block_time.into(),
+                old_block_time: old_block_time.map(|v| v.into()),
+            },
+            BdkWalletEvent::TxUnconfirmed {
+                txid,
+                tx,
+                old_block_time,
+            } => WalletEvent::TxUnconfirmed {
+                txid: Arc::new(Txid(txid)),
+                tx: Arc::new(tx.as_ref().clone().into()),
+                old_block_time: old_block_time.map(|v| v.into()),
+            },
+            BdkWalletEvent::TxReplaced {
+                txid,
+                tx,
+                conflicts,
+            } => {
+                let conflict_list: Vec<Conflict> = conflicts
+                    .into_iter()
+                    .map(|(vin, conflict)| Conflict {
+                        vin: vin as u32,
+                        txid: Arc::new(Txid(conflict)),
+                    })
+                    .collect();
+                WalletEvent::TxReplaced {
+                    txid: Arc::new(Txid(txid)),
+                    tx: Arc::new(tx.as_ref().clone().into()),
+                    conflicts: conflict_list,
+                }
+            }
+            BdkWalletEvent::TxDropped { txid, tx } => WalletEvent::TxDropped {
+                txid: Arc::new(Txid(txid)),
+                tx: Arc::new(tx.as_ref().clone().into()),
+            },
+            _ => unreachable!("WalletEvent variant not covered in conversion"),
         }
     }
 }


### PR DESCRIPTION
<!-- Erase any parts of this template not applicable to your Pull Request. -->

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->
Adds wallet event to bdk-ffi types and exposes `apply_update_events`
### Notes to the reviewers
- Since [WalletEvent ](https://docs.rs/bdk_wallet/latest/bdk_wallet/event/enum.WalletEvent.html) is non-exhaustive I used wildcard with the unreachable! macro. I was thinking maybe there are better options (panic!() or unimplemented!). Not sure of most ideal for rust
- Event looks great too. I tried this out in our dev-kit wallet. See what it looks like here from 2 different even printout
[event-logs.txt](https://github.com/user-attachments/files/23547594/event-logs.txt)


<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Documentation

<!-- Paste the canonical docs/spec for anything this PR wraps or updates. -->
- [WalletEvent](https://docs.rs/bdk_wallet/latest/bdk_wallet/event/enum.WalletEvent.html)

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
* [ ] I've added a changelog in the next release tracking issue (see [example](https://github.com/bitcoindevkit/bdk-ffi/issues/875))
* [x] I've linked the relevant upstream docs or specs above

#### New Features:

* [ ] I've added tests for the new feature
* [x] I've added docs for the new feature
