### PR TITLE
feat: expose `derived_address` helper on `Descriptor`

### DIFF
--- a/bdk-ffi/src/tests/descriptor.rs
+++ b/bdk-ffi/src/tests/descriptor.rs
@@ -161,3 +161,39 @@ fn test_max_weight_to_satisfy() {
     // Verify the method works and returns a positive weight
     assert!(weight > 0, "Weight must be positive");
 }
+
+#[test]
+fn test_descriptor_derive_address() {
+    let descriptor = Descriptor::new_bip84(
+        &get_descriptor_secret_key(),
+        KeychainKind::External,
+        Network::Testnet,
+    );
+
+    let derived = descriptor
+        .derive_address(0, Network::Testnet)
+        .expect("derive address");
+
+    let expected_descriptor = descriptor
+        .extended_descriptor
+        .at_derivation_index(0)
+        .expect("derive descriptor");
+    let expected_address = expected_descriptor
+        .address(Network::Testnet)
+        .expect("address from descriptor");
+
+    assert_eq!(derived.to_string(), expected_address.to_string());
+}
+
+#[test]
+fn test_descriptor_derive_address_multipath_error() {
+    let descriptor = Descriptor::new(
+        "wpkh([9a6a2580/84'/1'/0']tpubDDnGNapGEY6AZAdQbfRJgMg9fvz8pUBrLwvyvUqEgcUfgzM6zc2eVK4vY9x9L5FJWdX8WumXuLEDV5zDZnTfbn87vLe9XceCFwTu9so9Kks/<0;1>/*)".to_string(),
+        Network::Testnet,
+    )
+    .expect("multipath descriptor parses");
+
+    let error = descriptor.derive_address(0, Network::Testnet).unwrap_err();
+
+    assert_matches!(error, DescriptorError::MultiPath);
+}


### PR DESCRIPTION
<!-- Erase any parts of this template not applicable to your Pull Request. -->

### Description

exposing a helper to derive an address from a descriptor without building a wallet

follows miniscript’s recommended at_derivation_index → derived_descriptor flow to avoid panicy edge cases with unsupported descriptor https://docs.rs/miniscript/12.3.5/src/miniscript/descriptor/mod.rs.html#886

### Notes to the reviewers

tests covering both the happy path and multipath error mapping

### Documentation

The helper includes these

- [x] [`bdk_wallet`](https://docs.rs/bdk_wallet/latest/bdk_wallet/)

  https://docs.rs/bdk_wallet/latest/bdk_wallet/descriptor/enum.Descriptor.html#method.at_derivation_index
  https://docs.rs/bdk_wallet/latest/bdk_wallet/descriptor/enum.Descriptor.html#method.derived_descriptor-1
  
- [x] [`bitcoin`](https://docs.rs/bitcoin/latest/bitcoin/index.html)

  https://docs.rs/bitcoin/0.32.7/bitcoin/address/struct.Address.html#method.from_script

- [ ] [`uniffi`](https://github.com/mozilla/uniffi-rs) <!-- Add a link below with the version changelog or any other docs. -->
- [ ] Other: <!-- Add a link below with additional references -->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
* [ ] I've added a changelog in the next release tracking issue (see [example](https://github.com/bitcoindevkit/bdk-ffi/issues/875))
* [x] I've linked the relevant upstream docs or specs above

#### New Features:

* [x] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
