### PR TITLE
fix: Remove unwanted software in android test CI runner

### DIFF
--- a/.github/workflows/test-android.yaml
+++ b/.github/workflows/test-android.yaml
@@ -48,6 +48,15 @@ jobs:
           cd bdk-android
           bash ./scripts/release/build-release-linux-x86_64.sh
 
+      - name: "Free Disk Space (Ubuntu)"
+        uses: AdityaGarg8/remove-unwanted-software@v5
+        with:
+          remove-dotnet: true
+          remove-haskell: true
+          remove-codeql: true
+          remove-docker-images: true
+          remove-large-packages: true
+
       - name: "Enable KVM"
         run: |
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules


### PR DESCRIPTION
<!-- Erase any parts of this template not applicable to your Pull Request. -->

### Description
Test Android (test-android.yaml) workflow has been failing because of inadequate space on the ubuntu runner of the CI. Happens specifically when the emulator is being created. This PR removes applications that we do not need to run these test but exist by default on the ubuntu runner we are using for this workflow.

Thanks to @mikehardy I found the action that helps do this in his comment [here](https://github.com/ReactiveCircus/android-emulator-runner/issues/455#issuecomment-3577539155)

I have been able to run the workflow successfully in my fork [here](https://github.com/ItoroD/bdk-ffi/actions/runs/19820175733/job/56780502709)

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Documentation

<!-- Paste the canonical docs/spec for anything this PR wraps or updates. -->

- [ ] [`bdk_wallet`](https://docs.rs/bdk_wallet/latest/bdk_wallet/)
  <!-- Add a link below with the docs.rs page. -->
- [ ] [`bitcoin`](https://docs.rs/bitcoin/latest/bitcoin/index.html)
  <!-- Add a link below with the docs.rs page. -->
- [ ] [`uniffi`](https://github.com/mozilla/uniffi-rs) <!-- Add a link below with the version changelog or any other docs. -->
- [x] Other: <!-- Add a link below with additional references -->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
* [ ] I've added a changelog in the next release tracking issue (see [example](https://github.com/bitcoindevkit/bdk-ffi/issues/875))
* [ ] I've linked the relevant upstream docs or specs above

