### PR TITLE
Bump bdk_wallet dependency to 2.3.0

### DIFF
--- a/bdk-ffi/Cargo.lock
+++ b/bdk-ffi/Cargo.lock
@@ -186,9 +186,9 @@ dependencies = [
 
 [[package]]
 name = "bdk_wallet"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b172f2caa6311b8172cf99559cd7f7a61cb58834e35e4ca208b3299e7be8bec"
+checksum = "b03f1e31ccc562f600981f747d2262b84428cbff52c9c9cdf14d15fb15bd2286"
 dependencies = [
  "bdk_chain",
  "bip39",

--- a/bdk-ffi/Cargo.toml
+++ b/bdk-ffi/Cargo.toml
@@ -15,7 +15,7 @@ name = "uniffi-bindgen"
 path = "uniffi-bindgen.rs"
 
 [dependencies]
-bdk_wallet = { version = "2.2.0", features = ["all-keys", "keys-bip39", "rusqlite"] }
+bdk_wallet = { version = "2.3.0", features = ["all-keys", "keys-bip39", "rusqlite"] }
 bdk_esplora = { version = "0.22.1", default-features = false, features = ["std", "blocking", "blocking-https-rustls"] }
 bdk_electrum = { version = "0.23.2", default-features = false, features = ["use-rustls-ring"] }
 bdk_kyoto = { version = "0.15.3" }


### PR DESCRIPTION
This PR bumps bdk_wallet to 2.3.0.

I might also wait to merge client version bumps if any of them can be bumped as part of this PR.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
* [x] I've added a changelog in the next release tracking issue (see [example](https://github.com/bitcoindevkit/bdk-ffi/issues/875))
