### PR TITLE
add lib crate-type to bdk-ffi to be able to reuse it for other bindings like bdk-dart

### DIFF
--- a/bdk-ffi/Cargo.toml
+++ b/bdk-ffi/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 license = "MIT OR Apache-2.0"
 
 [lib]
-crate-type = ["cdylib", "staticlib"]
+crate-type = ["lib", "cdylib", "staticlib"]
 name = "bdkffi"
 
 [[bin]]


### PR DESCRIPTION
### Description

This PR just adds "lib" as a crate-type besides "cdylib" and "staticlib". In this way bdk-ffi can be more easily wrapped and reused for other bindings like the dart bindings in bdk-dart. Without it, more code from bdk-ffi has to be duplicated to bdk-dart and the process becomes more complex and hacky.

### Notes to the reviewers

I tested this PR in the following bdk-dart PR already: https://github.com/bitcoindevkit/bdk-dart/pull/12
It would be good to get this merged here first to be able to remove the patch to my fork of bdk-ffi there.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
* [ ] I've added a changelog in the next release tracking issue (see [example](https://github.com/bitcoindevkit/bdk-ffi/issues/875))
* [ ] I've linked the relevant upstream docs or specs above
