### PR TITLE
Fix module.modulemap build conflict with other packages

### DIFF
--- a/bdk-swift/build-xcframework-dev.sh
+++ b/bdk-swift/build-xcframework-dev.sh
@@ -62,6 +62,10 @@ fi
 
 echo -e "\n" >> "${HEADER_OUT_DIR}/module.modulemap"
 
+# Keep Swift sources clean: only .swift files should stay in the package Sources dir
+rm -f "${SWIFT_OUT_DIR}/${HEADER_BASENAME}.h"
+rm -f "${SWIFT_OUT_DIR}/${HEADER_BASENAME}.modulemap"
+
 cd ../bdk-swift/ || exit
 
 rm -rf "${OUTDIR}/${NAME}.xcframework"

--- a/bdk-swift/build-xcframework.sh
+++ b/bdk-swift/build-xcframework.sh
@@ -54,6 +54,10 @@ fi
 
 echo -e "\n" >> "${HEADER_OUT_DIR}/module.modulemap"
 
+# Keep Swift sources clean: only .swift files should stay in the package Sources dir
+rm -f "${SWIFT_OUT_DIR}/${HEADER_BASENAME}.h"
+rm -f "${SWIFT_OUT_DIR}/${HEADER_BASENAME}.modulemap"
+
 # combine bdk-ffi static libs for aarch64 and x86_64 targets via lipo tool
 mkdir -p target/lipo-ios-sim/release-smaller
 lipo target/aarch64-apple-ios-sim/release-smaller/libbdkffi.a target/x86_64-apple-ios/release-smaller/libbdkffi.a -create -output target/lipo-ios-sim/release-smaller/libbdkffi.a


### PR DESCRIPTION
<!-- Erase any parts of this template not applicable to your Pull Request. -->

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->
**The issue:** using bdk-swift and any other sdk with `module.modulemap` file cause packages resolution error "Multiple commands produce ... module.modulemap". 

**Solution:** add new build script steps to store `module.modulemap` and header file in temporary folder called `BitcoinDevKitFFI`. It helps avoid conflicts (resolves build errors) with other packages that also use `module.modulemap` file in the same project.
The sdk builds and resolves fine and these changes doesn't affect any functionality. 

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Documentation

<!-- Paste the canonical docs/spec for anything this PR wraps or updates. -->

- [ ] [`bdk_wallet`](https://docs.rs/bdk_wallet/latest/bdk_wallet/)
  <!-- Add a link below with the docs.rs page. -->
- [ ] [`bitcoin`](https://docs.rs/bitcoin/latest/bitcoin/index.html)
  <!-- Add a link below with the docs.rs page. -->
- [ ] [`uniffi`](https://github.com/mozilla/uniffi-rs) <!-- Add a link below with the version changelog or any other docs. -->
- [x] Other: <!-- Add a link below with additional references -->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
* [ ] I've added a changelog in the next release tracking issue (see [example](https://github.com/bitcoindevkit/bdk-ffi/issues/875))
* [ ] I've linked the relevant upstream docs or specs above
