### PR TITLE
chore: Bump ext test lib to 1.3.0

### DIFF
--- a/bdk-android/lib/build.gradle.kts
+++ b/bdk-android/lib/build.gradle.kts
@@ -59,7 +59,7 @@ dependencies {
     api("org.slf4j:slf4j-api:1.7.30")
 
     androidTestImplementation("com.github.tony19:logback-android:2.0.0")
-    androidTestImplementation("androidx.test.ext:junit:1.1.3")
+    androidTestImplementation("androidx.test.ext:junit:1.3.0")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.4.0")
     androidTestImplementation("org.jetbrains.kotlin:kotlin-test:1.6.10")
     androidTestImplementation("org.jetbrains.kotlin:kotlin-test-junit:1.6.10")


### PR DESCRIPTION
<!-- Erase any parts of this template not applicable to your Pull Request. -->

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->
I’ve been dealing with recurring transient dependency issues that required local version update just to test FFI changes. It likely stems from a mismatch between the current Gradle and Kotlin versions. Rather than spending more time debugging the specific conflict, I’ve bumped the versions.

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Documentation

<!-- Paste the canonical docs/spec for anything this PR wraps or updates. -->

- [ ] [`bdk_wallet`](https://docs.rs/bdk_wallet/latest/bdk_wallet/)
  <!-- Add a link below with the docs.rs page. -->
- [ ] [`bitcoin`](https://docs.rs/bitcoin/latest/bitcoin/index.html)
  <!-- Add a link below with the docs.rs page. -->
- [ ] [`uniffi`](https://github.com/mozilla/uniffi-rs) <!-- Add a link below with the version changelog or any other docs. -->
- [x] Other: <!-- Add a link below with additional references -->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
* [ ] I've added a changelog in the next release tracking issue (see [example](https://github.com/bitcoindevkit/bdk-ffi/issues/875))
* [ ] I've linked the relevant upstream docs or specs above


