### PR TITLE
Bump Rust to 1.90.0

### DIFF
--- a/bdk-ffi/rust-toolchain.toml
+++ b/bdk-ffi/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.85.1"
+channel = "1.90.0"
 components = ["clippy", "rustfmt"]


### PR DESCRIPTION
This PR follows our policy (did we write this anywhere?) of following uniffi's Rust version for building the bindings.

[They are currently (and have been for a little while now) on 1.90.0](https://github.com/mozilla/uniffi-rs/blob/main/rust-toolchain.toml).

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
* [ ] I've added a changelog in the next release tracking issue (see [example](https://github.com/bitcoindevkit/bdk-ffi/issues/875))
* [ ] I've linked the relevant upstream docs or specs above
