### PR TITLE
feat: Add `new_wsh_sortedmulti` and `new_pk`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 - Expose miniscript `has_wildcard` and `sanity_check` methods on `Descriptor` type #945
+- Expose `new_wsh_sortedmulti` and `new_pk` methods on `Descriptor` type #949
 
 ## [v2.3.0]
 

--- a/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/DescriptorTest.kt
+++ b/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/DescriptorTest.kt
@@ -41,6 +41,37 @@ class DescriptorTest {
         Descriptor("tr($MAINNET_EXTENDED_PRIVKEY/$BIP86_MAINNET_RECEIVE_PATH/0)", Network.BITCOIN)
     }
 
+    // Create a multisig descriptor.
+    @Test
+    fun createMultisigDescriptor() {
+        val pkList = listOf(
+            "xpub661MyMwAqRbcFW31YEwpkMuc5THy2PSt5bDMsktWQcFF8syAmRUapSCGu8ED9W6oDMSgv6Zz8idoc4a6mr8BDzTJY47LJhkJ8UB7WEGuduB",
+            "xpub661MyMwAqRbcFW31YEwpkMuc5THy2PSt5bDMsktWQcFF8syAmRUapSCGu8ED9W6oDMSgv6Zz8idoc4a6mr8BDzTJY47LJhkJ8UB7WEGuduB",
+            "xpub661MyMwAqRbcFW31YEwpkMuc5THy2PSt5bDMsktWQcFF8syAmRUapSCGu8ED9W6oDMSgv6Zz8idoc4a6mr8BDzTJY47LJhkJ8UB7WEGuduB"
+        )
+        val wshDescriptor = Descriptor.newWshSortedmulti(2u, pkList);
+
+        assertEquals(wshDescriptor.descType(), DescriptorType.WSH_SORTED_MULTI)
+    }
+
+    @Test
+    fun createInvalidMutlisigDescriptor() {
+        val invalidPkList = listOf(
+            "invalid_xpub",
+            "1111111111111",
+            "***"
+        )
+        assertFails {
+            Descriptor.newWshSortedmulti(2u, invalidPkList);
+        }
+    }
+
+    @Test
+    fun createSingleKeyDescriptor() {
+        val newPkDescriptor = Descriptor.newPk("xpub661MyMwAqRbcFW31YEwpkMuc5THy2PSt5bDMsktWQcFF8syAmRUapSCGu8ED9W6oDMSgv6Zz8idoc4a6mr8BDzTJY47LJhkJ8UB7WEGuduB")
+        assertEquals(newPkDescriptor.descType(), DescriptorType.BARE)
+    }
+
     // Cannot create addr() descriptor.
     @Test
     fun cannotCreateAddrDescriptor() {

--- a/bdk-ffi/src/descriptor.rs
+++ b/bdk-ffi/src/descriptor.rs
@@ -312,7 +312,7 @@ impl Descriptor {
         let bdk_pks: Vec<BdkDescriptorPublicKey> = pks
             .iter()
             .map(|pk| {
-                BdkDescriptorPublicKey::from_str(pk).map_err(|e| DescriptorError::Miniscript {
+                BdkDescriptorPublicKey::from_str(pk).map_err(|e| DescriptorError::Key {
                     error_message: e.to_string(),
                 })
             })
@@ -337,10 +337,9 @@ impl Descriptor {
     /// Create a new pay-to-pubkey descriptor from a public key string.
     #[uniffi::constructor]
     pub fn new_pk(pk: String) -> Result<Self, DescriptorError> {
-        let key =
-            BdkDescriptorPublicKey::from_str(&pk).map_err(|e| DescriptorError::Miniscript {
-                error_message: e.to_string(),
-            })?;
+        let key = BdkDescriptorPublicKey::from_str(&pk).map_err(|e| DescriptorError::Key {
+            error_message: e.to_string(),
+        })?;
 
         let miniscript_descriptor = bdk_wallet::miniscript::Descriptor::new_pk(key);
         let extended_descriptor = ExtendedDescriptor::from(miniscript_descriptor);


### PR DESCRIPTION
<!-- Erase any parts of this template not applicable to your Pull Request. -->

### Description
This Pr is based on my comment from #687 [here](https://github.com/bitcoindevkit/bdk-ffi/issues/687#issuecomment-3877896847). 

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

### Notes to the reviewers
In bdk-wallet we can do the following to create a 1 of 2 multisig descriptor. Thanks so miniscript helper functions
```rust
let multisig_descriptor = Descriptor::new_wsh_sortedmulti(1, vec![key.clone(), key2.clone()]).unwrap();
```

In bindings: kotlin, we do:
```kotlin
val multisigDescriptor = Descriptor("wsh(multi(1,$key,$key2))", Network.REGTEST)
```
Current we have to concatenate a string with the keys and script type to parse the descriptor.

Much easier and safer to be able to do:
```kotlin
val multisigDescriptor = Descriptor.newWshSortedmulti(2u, pkList);
```
<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Documentation

<!-- Paste the canonical docs/spec for anything this PR wraps or updates. -->
- new_wsh_sortedmulti - https://docs.rs/miniscript/12.3.5/miniscript/descriptor/enum.Descriptor.html#method.new_sh_wsh_sortedmulti

- new_pk - https://docs.rs/miniscript/12.3.5/miniscript/descriptor/enum.Descriptor.html#method.new_pk
- [ ] [`bdk_wallet`](https://docs.rs/bdk_wallet/latest/bdk_wallet/)
  <!-- Add a link below with the docs.rs page. -->
- [ ] [`bitcoin`](https://docs.rs/bitcoin/latest/bitcoin/index.html)
  <!-- Add a link below with the docs.rs page. -->
- [ ] [`uniffi`](https://github.com/mozilla/uniffi-rs) <!-- Add a link below with the version changelog or any other docs. -->
- [x] Other: <!-- Add a link below with additional references -->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
* [ ] I've added a changelog in the next release tracking issue (see [example](https://github.com/bitcoindevkit/bdk-ffi/issues/875))
* [x] I've linked the relevant upstream docs or specs above

#### New Features:

* [x] I've added tests for the new feature
* [x] I've added docs for the new feature