### PR TITLE
Fix iOS deployment target for bdk-swift

### DIFF
--- a/bdk-swift/build-xcframework-dev.sh
+++ b/bdk-swift/build-xcframework-dev.sh
@@ -11,6 +11,7 @@ NEW_HEADER_DIR="../bdk-ffi/target/include"
 PROFILE_DIR="debug"
 SWIFT_OUT_DIR="../bdk-swift/Sources/BitcoinDevKit"
 HEADER_OUT_DIR="${NEW_HEADER_DIR}/${HEADER_BASENAME}"
+MIN_IOS_VERSION="15.0"
 
 HOST_ARCH=$(uname -m)
 if [ "$HOST_ARCH" = "arm64" ]; then
@@ -21,6 +22,8 @@ else
     IOS_SIM_TARGET="x86_64-apple-ios"
 fi
 IOS_DEVICE_TARGET="aarch64-apple-ios"
+
+export IPHONEOS_DEPLOYMENT_TARGET="${MIN_IOS_VERSION}"
 
 cd ../bdk-ffi/ || exit
 

--- a/bdk-swift/build-xcframework.sh
+++ b/bdk-swift/build-xcframework.sh
@@ -12,6 +12,9 @@ STATIC_LIB_NAME="lib${NAME}.a"
 NEW_HEADER_DIR="../bdk-ffi/target/include"
 SWIFT_OUT_DIR="../bdk-swift/Sources/BitcoinDevKit"
 HEADER_OUT_DIR="${NEW_HEADER_DIR}/${HEADER_BASENAME}"
+MIN_IOS_VERSION="15.0"
+
+export IPHONEOS_DEPLOYMENT_TARGET="${MIN_IOS_VERSION}"
 
 cd ../bdk-ffi/ || exit
 


### PR DESCRIPTION
### Description

Package.swift provides minimum supported iOS version is 15.0 but it's not applied to the build script. Build script takes default iOS version from device where it's built as minimum version for it's packages. For example last bdk-swift [release 2.3.0](https://github.com/bitcoindevkit/bdk-swift/releases/tag/2.3.0) has inner version for packages is 17.5, previous one [2.2.1](https://github.com/bitcoindevkit/bdk-swift/releases/tag/2.2.1) had 17.2. This approach produce warning when building bdk-swift for iOS version lower than this inner version when Package.swift claims support for iOS 15.0+.

```
Object file (/Build/Products/Debug(production)-iphonesimulator/lib<REDACTED>.a[arm64]77) was built for newer 'iOS-simulator' version (17.5) than being linked (16.4)
--
⚠️ | Object file (/Build/Products/Debug(production)-iphonesimulator/lib<REDACTED>.a[arm64]78) was built for newer 'iOS-simulator' version (17.5) than being linked (16.4)
⚠️ | Object file (/Build/Products/Debug(production)-iphonesimulator/lib<REDACTED>.a[arm64]79) was built for newer 'iOS-simulator' version (17.5) than being linked (16.4)
⚠️ | Object file (/Build/Products/Debug(production)-iphonesimulator/lib<REDACTED>.a[arm64]80) was built for newer 'iOS-simulator' version (17.5) than being linked (16.4)
⚠️ | Object file (/Build/Products/Debug(production)-iphonesimulator/lib<REDACTED>.a[arm64]81) was built for newer 'iOS-simulator' version (17.5) than being linked (16.4)
⚠️ | Object file (/Build/Products/Debug(production)-iphonesimulator/lib<REDACTED>.a[arm64]83) was built for newer 'iOS-simulator' version (17.5) than being linked (16.4)

Object file (/Build/Products/Debug(production)-iphonesimulator/lib<REDACTED>.a[arm64][77](curve25519.o)) was built for newer 'iOS-simulator' version (17.5) than being linked (16.4)
⚠️	Object file (/Build/Products/Debug(production)-iphonesimulator/lib<REDACTED>.a[arm64][78](aes_nohw.o)) was built for newer 'iOS-simulator' version (17.5) than being linked (16.4)
⚠️	Object file (/Build/Products/Debug(production)-iphonesimulator/lib<REDACTED>.a[arm64][79](montgomery.o)) was built for newer 'iOS-simulator' version (17.5) than being linked (16.4)
⚠️	Object file (/Build/Products/Debug(production)-iphonesimulator/lib<REDACTED>.a[arm64][80](montgomery_inv.o)) was built for newer 'iOS-simulator' version (17.5) than being linked (16.4)
⚠️	Object file (/Build/Products/Debug(production)-iphonesimulator/lib<REDACTED>.a[arm64][81](ecp_nistz.o)) was built for newer 'iOS-simulator' version (17.5) than being linked (16.4)
⚠️	Object file (/Build/Products/Debug(production)-iphonesimulator/lib<REDACTED>.a[arm64][83](gfp_p384.o)) was built for newer 'iOS-simulator' version (17.5) than being linked (16.4)
```

The issue can be reproduced by linking actual bdk-swift version [2.3.0](https://github.com/bitcoindevkit/bdk-swift/releases/tag/2.3.0) to xcode project and building for iOS version lower than 17.5. 

### Solution 
This PR provides fix for issue above by declaring iOS build target version in build script that solves it. 

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
* [ ] I've added a changelog in the next release tracking issue (see [example](https://github.com/bitcoindevkit/bdk-ffi/issues/875))
* [ ] I've linked the relevant upstream docs or specs above
