### PR TITLE
test: add offline wallet smoke tests

### DIFF
--- a/bdk-ffi/src/tests/mod.rs
+++ b/bdk-ffi/src/tests/mod.rs
@@ -3,3 +3,4 @@ mod descriptor;
 mod error;
 mod keys;
 mod tx_builder;
+mod wallet;

--- a/bdk-ffi/src/tests/wallet.rs
+++ b/bdk-ffi/src/tests/wallet.rs
@@ -1,0 +1,107 @@
+use crate::bitcoin::Network;
+use crate::descriptor::Descriptor;
+use crate::store::Persister;
+use crate::wallet::Wallet;
+
+use bdk_wallet::KeychainKind;
+
+use std::sync::Arc;
+
+const EXTERNAL_DESCRIPTOR: &str = "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/1h/0/*)";
+const INTERNAL_DESCRIPTOR: &str = "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/1h/1/*)";
+const TWO_PATH_DESCRIPTOR: &str = "wpkh([9a6a2580/84'/1'/0']tpubDDnGNapGEY6AZAdQbfRJgMg9fvz8pUBrLwvyvUqEgcUfgzM6zc2eVK4vY9x9L5FJWdX8WumXuLEDV5zDZnTfbn87vLe9XceCFwTu9so9Kks/<0;1>/*)";
+const EXPECTED_FIRST_ADDRESS: &str = "tb1qhjys9wxlfykmte7ftryptx975uqgd6kcm6a7z4";
+
+fn external_descriptor() -> Arc<Descriptor> {
+    Arc::new(Descriptor::new(EXTERNAL_DESCRIPTOR.to_string(), Network::Signet).unwrap())
+}
+
+fn internal_descriptor() -> Arc<Descriptor> {
+    Arc::new(Descriptor::new(INTERNAL_DESCRIPTOR.to_string(), Network::Signet).unwrap())
+}
+
+fn two_path_descriptor() -> Arc<Descriptor> {
+    Arc::new(Descriptor::new(TWO_PATH_DESCRIPTOR.to_string(), Network::Signet).unwrap())
+}
+
+fn build_wallet() -> Wallet {
+    Wallet::new(
+        external_descriptor(),
+        internal_descriptor(),
+        Network::Signet,
+        Arc::new(Persister::new_in_memory().unwrap()),
+        25,
+    )
+    .unwrap()
+}
+
+#[test]
+fn test_create_wallet() {
+    let wallet = build_wallet();
+
+    assert_eq!(wallet.network(), Network::Signet);
+    assert_eq!(wallet.balance().total.to_sat(), 0u64);
+    assert!(wallet.list_unspent().is_empty());
+    assert_eq!(wallet.derivation_index(KeychainKind::External), None);
+    assert_eq!(wallet.next_derivation_index(KeychainKind::External), 0);
+}
+
+#[test]
+fn test_reveal_next_address() {
+    let wallet = build_wallet();
+
+    let address_info = wallet.reveal_next_address(KeychainKind::External);
+
+    assert_eq!(address_info.index, 0);
+    assert_eq!(address_info.keychain, KeychainKind::External);
+    assert_eq!(address_info.address.to_string(), EXPECTED_FIRST_ADDRESS);
+}
+
+#[test]
+fn test_create_single_wallet() {
+    let wallet = Wallet::create_single(
+        external_descriptor(),
+        Network::Signet,
+        Arc::new(Persister::new_in_memory().unwrap()),
+        25,
+    )
+    .unwrap();
+
+    assert_eq!(wallet.derivation_index(KeychainKind::External), None);
+
+    let address_info = wallet.reveal_next_address(KeychainKind::External);
+
+    assert_eq!(address_info.index, 0);
+    assert_eq!(address_info.keychain, KeychainKind::External);
+    assert_eq!(address_info.address.to_string(), EXPECTED_FIRST_ADDRESS);
+    assert_eq!(wallet.derivation_index(KeychainKind::External), Some(0));
+    assert_eq!(wallet.next_derivation_index(KeychainKind::External), 1);
+}
+
+#[test]
+fn test_create_two_path_wallet() {
+    let wallet = Wallet::create_from_two_path_descriptor(
+        two_path_descriptor(),
+        Network::Signet,
+        Arc::new(Persister::new_in_memory().unwrap()),
+        25,
+    )
+    .unwrap();
+
+    assert_eq!(wallet.derivation_index(KeychainKind::External), None);
+    assert_eq!(wallet.derivation_index(KeychainKind::Internal), None);
+
+    let external_address = wallet.reveal_next_address(KeychainKind::External);
+    let internal_address = wallet.reveal_next_address(KeychainKind::Internal);
+
+    assert_eq!(external_address.index, 0);
+    assert_eq!(external_address.keychain, KeychainKind::External);
+    assert_eq!(internal_address.index, 0);
+    assert_eq!(internal_address.keychain, KeychainKind::Internal);
+    assert_ne!(
+        external_address.address.to_string(),
+        internal_address.address.to_string()
+    );
+    assert_eq!(wallet.derivation_index(KeychainKind::External), Some(0));
+    assert_eq!(wallet.derivation_index(KeychainKind::Internal), Some(0));
+}


### PR DESCRIPTION
### Description

Add small Rust-side wallet smoke tests covering realistic wallet usage flows.

The tests focus on:
- creating a wallet
- revealing the next address
- checking initial balance
- verifying derivation index progression
- validating simple `create_single` behavior

### Notes to the reviewers

I updated the original wallet tests based on review feedback:
- removed the incorrect `create_single` external/internal keychain comparison
- dropped the `_offline` suffix from test names
- reworked the tests to read more like usage flows rather than isolated assertions
- explicitly verified derivation index behavior before and after the first reveal

Scope is limited to Rust wallet tests.

### Documentation

- [x] [`bdk_wallet`](https://docs.rs/bdk_wallet/latest/bdk_wallet/)
  - [`Wallet`](https://docs.rs/bdk_wallet/latest/bdk_wallet/struct.Wallet.html)
- [ ] [`bitcoin`](https://docs.rs/bitcoin/latest/bitcoin/index.html)
- [x] [`uniffi`](https://github.com/mozilla/uniffi-rs)
- [x] Other:
  - [`bdk-ffi` `Wallet::create_single` docs](https://github.com/bitcoindevkit/bdk-ffi/blob/master/bdk-ffi/src/wallet.rs)
  - [`bdk-jvm` bindings-style test example](https://github.com/bitcoindevkit/bdk-jvm/blob/master/lib/src/test/kotlin/org/bitcoindevkit/LoadWalletTest.kt)
  - [`bdk-ffi` issue: rethinking our test suite](https://github.com/bitcoindevkit/bdk-ffi/issues/769)

### Checklists

#### All Submissions:

* [ ] I've signed all my commits
* [ ] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
* [ ] I've added a changelog in the next release tracking issue (see [example](https://github.com/bitcoindevkit/bdk-ffi/issues/875))
* [x] I've linked the relevant upstream docs or specs above

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR

cc @thunderbiscuit and @reez
