### PR TITLE
Expose validate_domain config in electrum constructor

### DIFF
--- a/bdk-ffi/src/electrum.rs
+++ b/bdk-ffi/src/electrum.rs
@@ -29,9 +29,15 @@ pub struct ElectrumClient(BdkBdkElectrumClient<bdk_electrum::electrum_client::Cl
 impl ElectrumClient {
     /// Creates a new bdk client from a electrum_client::ElectrumApi
     /// Optional: Set the proxy of the builder
-    #[uniffi::constructor(default(socks5 = None))]
-    pub fn new(url: String, socks5: Option<String>) -> Result<Self, ElectrumError> {
+    /// Optional: Set whether the server's TLS certificate is validated.
+    #[uniffi::constructor(default(socks5 = None, validate_domain = true))]
+    pub fn new(
+        url: String,
+        socks5: Option<String>,
+        validate_domain: bool,
+    ) -> Result<Self, ElectrumError> {
         let mut config = bdk_electrum::electrum_client::ConfigBuilder::new();
+        config = config.validate_domain(validate_domain);
         if let Some(socks5) = socks5 {
             config = config.socks5(Some(bdk_electrum::electrum_client::Socks5Config::new(
                 socks5.as_str(),


### PR DESCRIPTION
### Description

I have an iOS wallet that uses Electrum and I would like to support self signed TLS certs. By exposing the validate_domain parameter this would allow the user to disabled all certificates verification.

I made this change locally and tested with my iOS wallet without any issues. Here is a screenshot of what I represent this validate_domain config to an end user in the app:

<img width="400" height="372" alt="image" src="https://github.com/user-attachments/assets/c033e9c7-a762-4e6f-b4f5-2d8321aa8ee0" />

<img width="350" height="280" alt="image" src="https://github.com/user-attachments/assets/b54c285e-149f-41a7-b8d5-a9c11ad06d66" />

I don't believe adding this additional defaulted parameter would be a breaking change.

### Notes to the reviewers

I believe this change is straight forward, but this is my first PR to BDK. Not sure if I'm missing anything that a contributor would be expected to provide. Not sure what kind of unit testing would be needed. Open to guidance.

### Documentation

<!-- Paste the canonical docs/spec for anything this PR wraps or updates. -->

- [ ] [`bdk_wallet`](https://docs.rs/bdk_wallet/latest/bdk_wallet/)
  <!-- Add a link below with the docs.rs page. -->
- [ ] [`bitcoin`](https://docs.rs/bitcoin/latest/bitcoin/index.html)
  <!-- Add a link below with the docs.rs page. -->
- [ ] [`uniffi`](https://github.com/mozilla/uniffi-rs) <!-- Add a link below with the version changelog or any other docs. -->
- [ ] Other: <!-- Add a link below with additional references -->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
* [ ] I've added a changelog in the next release tracking issue (see [example](https://github.com/bitcoindevkit/bdk-ffi/issues/875))
* [ ] I've linked the relevant upstream docs or specs above

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
