### PR TITLE
Add a Swift version of WalletSetupBip32, MultsigTransaction and MultisigTaprootTransaction examples

### DIFF
--- a/.github/workflows/test-swift.yaml
+++ b/.github/workflows/test-swift.yaml
@@ -42,3 +42,4 @@ jobs:
           swift test --filter Offline
           swift build --target WalletSetupBip32
           swift build --target MultisigTransaction
+          swift build --target MultisigTaprootTransaction

--- a/.github/workflows/test-swift.yaml
+++ b/.github/workflows/test-swift.yaml
@@ -41,3 +41,4 @@ jobs:
         run: |
           swift test --filter Offline
           swift build --target WalletSetupBip32
+          swift build --target MultisigTransaction

--- a/.github/workflows/test-swift.yaml
+++ b/.github/workflows/test-swift.yaml
@@ -38,4 +38,6 @@ jobs:
         run: bash ./build-xcframework.sh
 
       - name: "Run Swift tests"
-        run: swift test --filter Offline
+        run: |
+          swift test --filter Offline
+          swift build --target WalletSetupBip32

--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ Info.plist
 bdkffi.xcframework
 Sources/
 xcuserdata
+bdk-swift/data
 
 # Python related
 __pycache__

--- a/MultisigTaprootTransaction.kt
+++ b/MultisigTaprootTransaction.kt
@@ -1,0 +1,133 @@
+package org.bitcoindevkit
+
+fun main() {
+    // Add your regtest URL here. Regtest environment must have esplora to run this.
+    // See here for regtest podman setup https://github.com/thunderbiscuit/podman-regtest-infinity-pro
+    val REGTEST_URL = "http://127.0.0.1:3002"
+
+    // An unspendable compressed public key to use as internal key for Taproot multisig
+    // This could be any valid compressed public key that no one has the private key for or
+    // full descriptor path including derivation.
+    val UNSPENDABLE_KEY = "0250929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0"
+
+    // Create 3 wallets using existing helper (P2TR = Taproot)
+    val aliceWallet = getNewWallet(ActiveWalletScriptType.P2TR, Network.REGTEST)
+    val bobWallet = getNewWallet(ActiveWalletScriptType.P2TR, Network.REGTEST)
+    val mattWallet = getNewWallet(ActiveWalletScriptType.P2TR, Network.REGTEST)
+
+    // Get the public descriptors of each wallet. Extract inner key expressions
+    var alicePublicDescriptor = aliceWallet.publicDescriptor(KeychainKind.EXTERNAL)
+    alicePublicDescriptor = alicePublicDescriptor.substring(alicePublicDescriptor.indexOf("(") + 1, alicePublicDescriptor.indexOf(")"))
+    var bobPublicDescriptor = bobWallet.publicDescriptor(KeychainKind.EXTERNAL)
+    bobPublicDescriptor = bobPublicDescriptor.substring(bobPublicDescriptor.indexOf("(") + 1, bobPublicDescriptor.indexOf(")"))
+    var mattPublicDescriptor = mattWallet.publicDescriptor(KeychainKind.EXTERNAL)
+    mattPublicDescriptor = mattPublicDescriptor.substring(mattPublicDescriptor.indexOf("(") + 1, mattPublicDescriptor.indexOf(")"))
+
+    // Get the change descriptors of each wallet (for change path)
+    var aliceChangeDescriptor = aliceWallet.publicDescriptor(KeychainKind.INTERNAL)
+    aliceChangeDescriptor = aliceChangeDescriptor.substring(aliceChangeDescriptor.indexOf("(") + 1, aliceChangeDescriptor.indexOf(")"))
+    var bobChangeDescriptor = bobWallet.publicDescriptor(KeychainKind.INTERNAL)
+    bobChangeDescriptor = bobChangeDescriptor.substring(bobChangeDescriptor.indexOf("(") + 1, bobChangeDescriptor.indexOf(")"))
+    var mattChangeDescriptor = mattWallet.publicDescriptor(KeychainKind.INTERNAL)
+    mattChangeDescriptor = mattChangeDescriptor.substring(mattChangeDescriptor.indexOf("(") + 1, mattChangeDescriptor.indexOf(")"))
+
+    // Define Taproot multisig descriptors. For Taproot, an internal key is required.
+    // We use a random unspendable compressed public key as the internal key. This means
+    // that the wallet can only be spent via the script path (no key-path spending).
+    val externalDescriptor = Descriptor(
+        descriptor = "tr($UNSPENDABLE_KEY,multi_a(2,$alicePublicDescriptor,$bobPublicDescriptor,$mattPublicDescriptor))",
+        network = Network.REGTEST
+    )
+    val changeDescriptor = Descriptor(
+        descriptor = "tr($UNSPENDABLE_KEY,multi_a(2,$aliceChangeDescriptor,$bobChangeDescriptor,$mattChangeDescriptor))",
+        network = Network.REGTEST
+    )
+
+    // Create multisig wallet (reuse shared persistence helper)
+    val connection: Persister = Persister.newSqlite(generateUniquePersistenceFilePath())
+    val multisigWallet = Wallet(externalDescriptor, changeDescriptor, Network.REGTEST, connection)
+
+    val changeAddress = multisigWallet.revealNextAddress(KeychainKind.INTERNAL)
+    val address = multisigWallet.revealNextAddress(KeychainKind.EXTERNAL)
+    println("Change address: ${changeAddress.address}")
+
+    // Fund this address. Alice, Bob and Matt own funds sent here
+    println("receiving address: ${address.address}")
+
+    // Client: wait for funding then scan
+    println("Waiting 40 seconds for funds to arrive here before scanning ${address.address} ...")
+    Thread.sleep(40000)
+
+    val esploraClient = EsploraClient(REGTEST_URL)
+    val fullScanRequest: FullScanRequest = multisigWallet.startFullScan().build()
+    val update = esploraClient.fullScan(fullScanRequest, 10uL, 1uL)
+    multisigWallet.applyUpdate(update)
+    multisigWallet.persist(connection)
+    println("Balance: ${multisigWallet.balance().total.toSat()}")
+
+    Thread.sleep(40000)
+
+    // Create PSBT
+    val recipient = Address("bcrt1q645m0j78v9pajdfp0g0w6wacl4v8s7mvrwsjx5", Network.REGTEST)
+    println("Balance: ${multisigWallet.balance().total.toSat()}")
+    val psbt: Psbt = TxBuilder()
+        .addRecipient(recipient.scriptPubkey(), Amount.fromSat(4420uL))
+        .feeRate(FeeRate.fromSatPerVb(22uL))
+        .finish(multisigWallet)
+
+    val psbtTransaction = psbt.extractTx()
+    println(psbtTransaction.toString())
+    println("Before any signature ${psbt.serialize()}")
+    println("Before any signature. Json: ${psbt.jsonSerialize()}")
+
+    // Sign Psbt via script path; do not allow key-path signing so taptree fields are populated
+    aliceWallet.sign(psbt, SignOptions(
+        trustWitnessUtxo = false,
+        assumeHeight = null,
+        allowAllSighashes = false,
+        tryFinalize = false,
+        signWithTapInternalKey = false,
+        allowGrinding = false
+    ))
+    println("After signing with aliceWallet ${psbt.serialize()}")
+    println("After signing with aliceWallet Json ${psbt.jsonSerialize()}")
+    println("Transaction after signing with wallet1: ${psbt.extractTx().toString()}")
+
+    bobWallet.sign(psbt, SignOptions(
+        trustWitnessUtxo = false,
+        assumeHeight = null,
+        allowAllSighashes = false,
+        tryFinalize = false,
+        signWithTapInternalKey = false,
+        allowGrinding = false
+    ))
+    println("After signing with bobWallet ${psbt.serialize()}")
+    println("After signing with bobWallet Json ${psbt.jsonSerialize()}")
+    println("Transaction after signing with bobWallet: ${psbt.extractTx().toString()}")
+
+    // Matt does not need to sign since it is a 2 of 3 multisig. Alice and Bob have already signed.
+    mattWallet.sign(psbt, SignOptions(
+        trustWitnessUtxo = false,
+        assumeHeight = null,
+        allowAllSighashes = false,
+        tryFinalize = false,
+        signWithTapInternalKey = false,
+        allowGrinding = false
+    ))
+    println("After signing with mattWallet ${psbt.serialize()}")
+    println("After signing with mattWallet Json ${psbt.jsonSerialize()}")
+    println("Transaction after signing with mattWallet: ${psbt.extractTx().toString()}")
+
+    multisigWallet.finalizePsbt(psbt)
+    println("After finalize: ${psbt.serialize()}")
+    println("After finalize Json: ${psbt.jsonSerialize()}")
+    println("Transaction after finalize: ${psbt.extractTx().toString()}")
+
+
+    val tx: Transaction = psbt.extractTx()
+    println("Txid is: ${tx.computeTxid()}")
+
+    // Now you can broadcast the transaction
+    esploraClient.broadcast(tx)
+    println("Tx was broadcasted")
+}

--- a/bdk-swift/Examples/MultisigTaprootTransaction/main.swift
+++ b/bdk-swift/Examples/MultisigTaprootTransaction/main.swift
@@ -1,0 +1,216 @@
+import Foundation
+import BitcoinDevKit
+
+// Add your regtest URL here. Regtest environment must have esplora to run this.
+// See here for regtest podman setup https://github.com/thunderbiscuit/podman-regtest-infinity-pro
+let REGTEST_URL = "http://127.0.0.1:3002"
+
+// An unspendable compressed public key to use as internal key for Taproot multisig.
+// This could be any valid compressed public key that no one has the private key for or
+// full descriptor path including derivation.
+let UNSPENDABLE_KEY = "0250929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0"
+
+// Create 3 wallets (P2TR = Taproot)
+let aliceWallet = getNewWallet(script: .p2tr, network: .regtest)
+let bobWallet = getNewWallet(script: .p2tr, network: .regtest)
+let mattWallet = getNewWallet(script: .p2tr, network: .regtest)
+
+// Get the public descriptors of each wallet. Extract inner key expressions
+let alicePublicDescriptor = getKey(aliceWallet.publicDescriptor(keychain: .external))
+let bobPublicDescriptor = getKey(bobWallet.publicDescriptor(keychain: .external))
+let mattPublicDescriptor = getKey(mattWallet.publicDescriptor(keychain: .external))
+
+// Get the change descriptors of each wallet (for change path)
+let aliceChangeDescriptor = getKey(aliceWallet.publicDescriptor(keychain: .internal))
+let bobChangeDescriptor = getKey(bobWallet.publicDescriptor(keychain: .internal))
+let mattChangeDescriptor = getKey(mattWallet.publicDescriptor(keychain: .internal))
+
+// Define Taproot multisig descriptors. For Taproot, an internal key is required.
+// We use a random unspendable compressed public key as the internal key. This means
+// that the wallet can only be spent via the script path (no key-path spending).
+let externalDescriptor = try! Descriptor(
+    descriptor: "tr(\(UNSPENDABLE_KEY),multi_a(2,\(alicePublicDescriptor),\(bobPublicDescriptor),\(mattPublicDescriptor)))",
+    network: .regtest
+)
+let changeDescriptor = try! Descriptor(
+    descriptor: "tr(\(UNSPENDABLE_KEY),multi_a(2,\(aliceChangeDescriptor),\(bobChangeDescriptor),\(mattChangeDescriptor)))",
+    network: .regtest
+)
+
+// Create multisig wallet
+let connection = try! Persister.newSqlite(path: generateUniquePersistenceFilePath())
+let multisigWallet = try! Wallet(
+    descriptor: externalDescriptor,
+    changeDescriptor: changeDescriptor,
+    network: .regtest,
+    persister: connection
+)
+
+let changeAddress = multisigWallet.revealNextAddress(keychain: .internal)
+let address = multisigWallet.revealNextAddress(keychain: .external)
+print("Change address: \(changeAddress.address)")
+
+// Fund this address. Alice, Bob and Matt own funds sent here
+print("recieving address: \(address.address)")
+
+// Client
+// Wait 40 seconds for you to send funds before scanning
+print("Waiting 40 seconds for funds to arrive here before scanning \(address.address) ...")
+Thread.sleep(forTimeInterval: 40)
+
+let esploraClient = EsploraClient(url: REGTEST_URL)
+let fullScanRequest = try! multisigWallet.startFullScan().build()
+let update = try! esploraClient.fullScan(request: fullScanRequest, stopGap: 10, parallelRequests: 1)
+try! multisigWallet.applyUpdate(update: update)
+_ = try! multisigWallet.persist(persister: connection)
+print("Balance: \(multisigWallet.balance().total.toSat())")
+
+Thread.sleep(forTimeInterval: 40)
+
+// Create PSBT
+// Add your own recipient Address here. (Address to send funds to)
+let recipient = try! Address(address: "bcrt1q645m0j78v9pajdfp0g0w6wacl4v8s7mvrwsjx5", network: .regtest)
+print("Balance: \(multisigWallet.balance().total.toSat())")
+let psbt = try! TxBuilder()
+    .addRecipient(script: recipient.scriptPubkey(), amount: Amount.fromSat(satoshi: 4420))
+    .feeRate(feeRate: try! FeeRate.fromSatPerVb(satVb: 22))
+    .finish(wallet: multisigWallet)
+
+let psbtTransaction = try! psbt.extractTx()
+print(psbtTransaction)
+print("Before any signature \(psbt.serialize())")
+print("Before any signature. Json: \(psbt.jsonSerialize())")
+
+// Sign Psbt via script path; do not allow key-path signing so taptree fields are populated
+_ = try! aliceWallet.sign(psbt: psbt, signOptions: SignOptions(
+    trustWitnessUtxo: false,
+    assumeHeight: nil,
+    allowAllSighashes: false,
+    tryFinalize: false,
+    signWithTapInternalKey: false,
+    allowGrinding: false
+))
+print("After signing with aliceWallet \(psbt.serialize())")
+print("After signing with aliceWallet Json \(psbt.jsonSerialize())")
+print("Transaction after signing with wallet1: \(try! psbt.extractTx())")
+
+_ = try! bobWallet.sign(psbt: psbt, signOptions: SignOptions(
+    trustWitnessUtxo: false,
+    assumeHeight: nil,
+    allowAllSighashes: false,
+    tryFinalize: false,
+    signWithTapInternalKey: false,
+    allowGrinding: false
+))
+print("After signing with bobWallet \(psbt.serialize())")
+print("After signing with bobWallet Json \(psbt.jsonSerialize())")
+print("Transaction after signing with bobWallet: \(try! psbt.extractTx())")
+
+// Matt does not need to sign since it is a 2 of 3 multisig. Alice and Bob have already signed.
+_ = try! mattWallet.sign(psbt: psbt, signOptions: SignOptions(
+    trustWitnessUtxo: false,
+    assumeHeight: nil,
+    allowAllSighashes: false,
+    tryFinalize: false,
+    signWithTapInternalKey: false,
+    allowGrinding: false
+))
+print("After signing with mattWallet \(psbt.serialize())")
+print("After signing with mattWallet Json \(psbt.jsonSerialize())")
+print("Transaction after signing with mattWallet: \(try! psbt.extractTx())")
+
+_ = try! multisigWallet.finalizePsbt(psbt: psbt)
+print("After finalize: \(psbt.serialize())")
+print("After finalize Json: \(psbt.jsonSerialize())")
+print("Transaction after finalize: \(try! psbt.extractTx())")
+
+let tx = try! psbt.extractTx()
+print("Txid is: \(tx.computeTxid())")
+
+// Now you can broadcast the transaction
+try! esploraClient.broadcast(transaction: tx)
+print("Tx was broadcasted")
+
+func getNewWallet(script: ActiveWalletScriptType, network: Network) -> Wallet {
+    let (descriptor, changeDescriptor) = createDescriptorsFromBip32RootKey(
+        scriptType: script,
+        network: network
+    )
+    let connection = try! Persister.newSqlite(path: generateUniquePersistenceFilePath())
+    return try! Wallet(
+        descriptor: descriptor,
+        changeDescriptor: changeDescriptor,
+        network: network,
+        persister: connection
+    )
+}
+
+func createDescriptorsFromBip32RootKey(
+    scriptType: ActiveWalletScriptType,
+    network: Network
+) -> (Descriptor, Descriptor) {
+    let mnemonic = Mnemonic(wordCount: .words12)
+    let bip32ExtendedRootKey = DescriptorSecretKey(
+        network: network,
+        mnemonic: mnemonic,
+        password: nil
+    )
+    let descriptor = createScriptAppropriateDescriptor(
+        scriptType: scriptType,
+        bip32ExtendedRootKey: bip32ExtendedRootKey,
+        network: network,
+        keychain: .external
+    )
+    let changeDescriptor = createScriptAppropriateDescriptor(
+        scriptType: scriptType,
+        bip32ExtendedRootKey: bip32ExtendedRootKey,
+        network: network,
+        keychain: .internal
+    )
+    return (descriptor, changeDescriptor)
+}
+
+func createScriptAppropriateDescriptor(
+    scriptType: ActiveWalletScriptType,
+    bip32ExtendedRootKey: DescriptorSecretKey,
+    network: Network,
+    keychain: KeychainKind
+) -> Descriptor {
+    switch scriptType {
+    case .p2wpkh:
+        return Descriptor.newBip84(
+            secretKey: bip32ExtendedRootKey,
+            keychainKind: keychain,
+            network: network
+        )
+    case .p2tr:
+        return Descriptor.newBip86(
+            secretKey: bip32ExtendedRootKey,
+            keychainKind: keychain,
+            network: network
+        )
+    }
+}
+
+func generateUniquePersistenceFilePath() -> String {
+    let cwd = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+    let persistenceDirectory = cwd.appendingPathComponent("data")
+
+    if !FileManager.default.fileExists(atPath: persistenceDirectory.path) {
+        try? FileManager.default.createDirectory(at: persistenceDirectory, withIntermediateDirectories: true)
+    }
+
+    let randomSuffix = Int.random(in: 1...100000)
+    return persistenceDirectory.appendingPathComponent("bdk_persistence_\(randomSuffix).sqlite").path
+}
+
+func getKey(_ descriptor: String) -> String {
+    let open = descriptor.firstIndex(of: "(")!
+    let close = descriptor.firstIndex(of: ")")!
+    return String(descriptor[descriptor.index(after: open)..<close])
+}
+
+enum ActiveWalletScriptType {
+    case p2wpkh
+    case p2tr
+}

--- a/bdk-swift/Examples/MultisigTransaction/main.swift
+++ b/bdk-swift/Examples/MultisigTransaction/main.swift
@@ -1,0 +1,209 @@
+import Foundation
+import BitcoinDevKit
+
+// Add your regtest URL here. Regtest environment must have esplora to run this.
+// See here for regtest podman setup https://github.com/thunderbiscuit/podman-regtest-infinity-pro
+let REGTEST_URL = "http://127.0.0.1:3002"
+
+// Create 3 wallets
+let aliceWallet = getNewWallet(script: .p2wpkh, network: .regtest)
+let bobWallet = getNewWallet(script: .p2wpkh, network: .regtest)
+let mattWallet = getNewWallet(script: .p2wpkh, network: .regtest)
+
+// Get the public descriptors of each wallet. We only want the derivation path, so we take it out of the string
+let alicePublicDescriptor = getKey(aliceWallet.publicDescriptor(keychain: .external))
+let bobPublicDescriptor = getKey(bobWallet.publicDescriptor(keychain: .external))
+let mattPublicDescriptor = getKey(mattWallet.publicDescriptor(keychain: .external))
+
+// Get the change descriptors of each wallet
+let aliceChangeDescriptor = getKey(aliceWallet.publicDescriptor(keychain: .internal))
+let bobChangeDescriptor = getKey(bobWallet.publicDescriptor(keychain: .internal))
+let mattChangeDescriptor = getKey(mattWallet.publicDescriptor(keychain: .internal))
+
+// Define the descriptors for a multisig wallet with Alice, Bob and Matt's public descriptors.
+let externalDescriptor = try! Descriptor(
+    descriptor: "wsh(multi(2,\(alicePublicDescriptor),\(bobPublicDescriptor),\(mattPublicDescriptor)))",
+    network: .regtest
+)
+let changeDescriptor = try! Descriptor(
+    descriptor: "wsh(multi(2,\(aliceChangeDescriptor),\(bobChangeDescriptor),\(mattChangeDescriptor)))",
+    network: .regtest
+)
+
+// Create multisig wallet
+let connection = try! Persister.newSqlite(path: generateUniquePersistenceFilePath())
+let multisigWallet = try! Wallet(
+    descriptor: externalDescriptor,
+    changeDescriptor: changeDescriptor,
+    network: .regtest,
+    persister: connection
+)
+
+let changeAddress = multisigWallet.revealNextAddress(keychain: .internal)
+let address = multisigWallet.revealNextAddress(keychain: .external)
+print("Change address: \(changeAddress.address)")
+
+// Fund this address. Alice, Bob and Matt own funds sent here
+print("recieving address: \(address.address)")
+
+// Client
+// Wait 40 second for you to send funds before scanning
+print("Waiting 40 seconds for funds to arrive here before scanning \(address.address) ...")
+Thread.sleep(forTimeInterval: 40)
+
+let esploraClient = EsploraClient(url: REGTEST_URL)
+let fullScanRequest = try! multisigWallet.startFullScan().build()
+let update = try! esploraClient.fullScan(request: fullScanRequest, stopGap: 10, parallelRequests: 1)
+try! multisigWallet.applyUpdate(update: update)
+_ = try! multisigWallet.persist(persister: connection)
+print("Balance: \(multisigWallet.balance().total.toSat())")
+
+Thread.sleep(forTimeInterval: 40)
+
+// Create PSBT
+// Add your own recipient Address here. (Address to send funds to)
+let recipient = try! Address(address: "bcrt1q645m0j78v9pajdfp0g0w6wacl4v8s7mvrwsjx5", network: .regtest)
+print("Balance: \(multisigWallet.balance().total.toSat())")
+let psbt = try! TxBuilder()
+    .addRecipient(script: recipient.scriptPubkey(), amount: Amount.fromSat(satoshi: 4420))
+    .feeRate(feeRate: try! FeeRate.fromSatPerVb(satVb: 22))
+    .finish(wallet: multisigWallet)
+
+let psbtTransaction = try! psbt.extractTx()
+print(psbtTransaction)
+print("Before any signature \(psbt.serialize())")
+print("Before any signature. Json: \(psbt.jsonSerialize())")
+
+// Sign Psbt
+_ = try! aliceWallet.sign(psbt: psbt, signOptions: SignOptions(
+    trustWitnessUtxo: false,
+    assumeHeight: nil,
+    allowAllSighashes: false,
+    tryFinalize: false,
+    signWithTapInternalKey: true,
+    allowGrinding: false
+))
+print("After signing with aliceWallet \(psbt.serialize())")
+print("After signing with aliceWallet Json \(psbt.jsonSerialize())")
+print("Transaction after signing with wallet1: \(try! psbt.extractTx())")
+
+_ = try! bobWallet.sign(psbt: psbt, signOptions: SignOptions(
+    trustWitnessUtxo: false,
+    assumeHeight: nil,
+    allowAllSighashes: false,
+    tryFinalize: false,
+    signWithTapInternalKey: true,
+    allowGrinding: false
+))
+print("After signing with bobWallet \(psbt.serialize())")
+print("After signing with bobWallet Json \(psbt.jsonSerialize())")
+print("Transaction after signing with bobWallet: \(try! psbt.extractTx())")
+
+// Matt does not need to sign since it is a 2 or 3 multisig. Alice and Bob, have already signed, which satisfies the unlocking script.
+_ = try! mattWallet.sign(psbt: psbt, signOptions: SignOptions(
+    trustWitnessUtxo: false,
+    assumeHeight: nil,
+    allowAllSighashes: false,
+    tryFinalize: false,
+    signWithTapInternalKey: true,
+    allowGrinding: false
+))
+print("After signing with mattWallet \(psbt.serialize())")
+print("After signing with mattWallet Json \(psbt.jsonSerialize())")
+print("Transaction after signing with mattWallet: \(try! psbt.extractTx())")
+
+_ = try! multisigWallet.finalizePsbt(psbt: psbt)
+print("After finalize: \(psbt.serialize())")
+print("After finalize Json: \(psbt.jsonSerialize())")
+print("Transaction after finalize: \(try! psbt.extractTx())")
+
+let tx = try! psbt.extractTx()
+print("Txid is: \(tx.computeTxid())")
+
+// Now you can broadcast the transaction
+try! esploraClient.broadcast(transaction: tx)
+print("Tx was broadcasted")
+
+func getNewWallet(script: ActiveWalletScriptType, network: Network) -> Wallet {
+    let (descriptor, changeDescriptor) = createDescriptorsFromBip32RootKey(
+        scriptType: script,
+        network: network
+    )
+    let connection = try! Persister.newSqlite(path: generateUniquePersistenceFilePath())
+    return try! Wallet(
+        descriptor: descriptor,
+        changeDescriptor: changeDescriptor,
+        network: network,
+        persister: connection
+    )
+}
+
+func createDescriptorsFromBip32RootKey(
+    scriptType: ActiveWalletScriptType,
+    network: Network
+) -> (Descriptor, Descriptor) {
+    let mnemonic = Mnemonic(wordCount: .words12)
+    let bip32ExtendedRootKey = DescriptorSecretKey(
+        network: network,
+        mnemonic: mnemonic,
+        password: nil
+    )
+    let descriptor = createScriptAppropriateDescriptor(
+        scriptType: scriptType,
+        bip32ExtendedRootKey: bip32ExtendedRootKey,
+        network: network,
+        keychain: .external
+    )
+    let changeDescriptor = createScriptAppropriateDescriptor(
+        scriptType: scriptType,
+        bip32ExtendedRootKey: bip32ExtendedRootKey,
+        network: network,
+        keychain: .internal
+    )
+    return (descriptor, changeDescriptor)
+}
+
+func createScriptAppropriateDescriptor(
+    scriptType: ActiveWalletScriptType,
+    bip32ExtendedRootKey: DescriptorSecretKey,
+    network: Network,
+    keychain: KeychainKind
+) -> Descriptor {
+    switch scriptType {
+    case .p2wpkh:
+        return Descriptor.newBip84(
+            secretKey: bip32ExtendedRootKey,
+            keychainKind: keychain,
+            network: network
+        )
+    case .p2tr:
+        return Descriptor.newBip86(
+            secretKey: bip32ExtendedRootKey,
+            keychainKind: keychain,
+            network: network
+        )
+    }
+}
+
+func generateUniquePersistenceFilePath() -> String {
+    let cwd = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+    let persistenceDirectory = cwd.appendingPathComponent("data")
+
+    if !FileManager.default.fileExists(atPath: persistenceDirectory.path) {
+        try? FileManager.default.createDirectory(at: persistenceDirectory, withIntermediateDirectories: true)
+    }
+
+    let randomSuffix = Int.random(in: 1...100000)
+    return persistenceDirectory.appendingPathComponent("bdk_persistence_\(randomSuffix).sqlite").path
+}
+
+func getKey(_ descriptor: String) -> String {
+    let open = descriptor.firstIndex(of: "(")!
+    let close = descriptor.firstIndex(of: ")")!
+    return String(descriptor[descriptor.index(after: open)..<close])
+}
+
+enum ActiveWalletScriptType {
+    case p2wpkh
+    case p2tr
+}

--- a/bdk-swift/Examples/WalletSetupBip32/main.swift
+++ b/bdk-swift/Examples/WalletSetupBip32/main.swift
@@ -1,0 +1,95 @@
+import Foundation
+import BitcoinDevKit
+
+let (descriptor, changeDescriptor) = createDescriptorsFromBip32RootKey(
+    scriptType: .p2wpkh,
+    network: .regtest
+)
+print("Descriptor: \(descriptor)")
+print("Change descriptor: \(changeDescriptor)")
+
+let persistenceFilePath = getPersistenceFilePath()
+print("Persistence file path: \(persistenceFilePath)")
+
+let connection = try! Persister.newSqlite(path: persistenceFilePath)
+let wallet = try! Wallet(
+    descriptor: descriptor,
+    changeDescriptor: changeDescriptor,
+    network: .regtest,
+    persister: connection
+)
+let changeAddress = wallet.revealNextAddress(keychain: .internal).address
+let address = wallet.revealNextAddress(keychain: .external).address
+
+print("Change address: \(changeAddress)")
+print("Address: \(address)")
+
+func createDescriptorsFromBip32RootKey(
+    scriptType: ActiveWalletScriptType,
+    network: Network
+) -> (Descriptor, Descriptor) {
+    let mnemonic = Mnemonic(wordCount: .words12)
+    let bip32ExtendedRootKey = DescriptorSecretKey(
+        network: network,
+        mnemonic: mnemonic,
+        password: nil
+    )
+    print("Bip32 root key: \(bip32ExtendedRootKey)")
+
+    let descriptor = createScriptAppropriateDescriptor(
+        scriptType: scriptType,
+        bip32ExtendedRootKey: bip32ExtendedRootKey,
+        network: network,
+        keychain: .external
+    )
+    let changeDescriptor = createScriptAppropriateDescriptor(
+        scriptType: scriptType,
+        bip32ExtendedRootKey: bip32ExtendedRootKey,
+        network: network,
+        keychain: .internal
+    )
+    return (descriptor, changeDescriptor)
+}
+
+func createScriptAppropriateDescriptor(
+    scriptType: ActiveWalletScriptType,
+    bip32ExtendedRootKey: DescriptorSecretKey,
+    network: Network,
+    keychain: KeychainKind
+) -> Descriptor {
+    switch scriptType {
+    case .p2wpkh:
+        return Descriptor.newBip84(
+            secretKey: bip32ExtendedRootKey,
+            keychainKind: keychain,
+            network: network
+        )
+    case .p2tr:
+        return Descriptor.newBip86(
+            secretKey: bip32ExtendedRootKey,
+            keychainKind: keychain,
+            network: network
+        )
+    }
+}
+
+func getPersistenceFilePath() -> String {
+    let cwd = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+    let persistenceDirectory = cwd.appendingPathComponent("data")
+    let persistenceFilePath = persistenceDirectory.appendingPathComponent("bdk_persistence.sqlite").path
+
+    if !FileManager.default.fileExists(atPath: persistenceDirectory.path) {
+        try? FileManager.default.createDirectory(at: persistenceDirectory, withIntermediateDirectories: true)
+    }
+
+    if FileManager.default.fileExists(atPath: persistenceFilePath) {
+        try? FileManager.default.removeItem(atPath: persistenceFilePath)
+    }
+
+    return persistenceFilePath
+}
+
+enum ActiveWalletScriptType {
+    case p2wpkh
+    case p2tr
+}

--- a/bdk-swift/Package.swift
+++ b/bdk-swift/Package.swift
@@ -17,6 +17,9 @@ let package = Package(
         .executable(
             name: "WalletSetupBip32",
             targets: ["WalletSetupBip32"]),
+        .executable(
+            name: "MultisigTransaction",
+            targets: ["MultisigTransaction"]),
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
@@ -45,6 +48,11 @@ let package = Package(
             name: "WalletSetupBip32",
             dependencies: ["BitcoinDevKit"],
             path: "Examples/WalletSetupBip32"
+        ),
+        .executableTarget(
+            name: "MultisigTransaction",
+            dependencies: ["BitcoinDevKit"],
+            path: "Examples/MultisigTransaction"
         ),
     ]
 )

--- a/bdk-swift/Package.swift
+++ b/bdk-swift/Package.swift
@@ -14,6 +14,9 @@ let package = Package(
         .library(
             name: "BitcoinDevKit",
             targets: ["bdkFFI", "BitcoinDevKit"]),
+        .executable(
+            name: "WalletSetupBip32",
+            targets: ["WalletSetupBip32"]),
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
@@ -37,6 +40,11 @@ let package = Package(
             resources: [
                 .copy("Resources/pre_existing_wallet_persistence_test.sqlite")
             ]
+        ),
+        .executableTarget(
+            name: "WalletSetupBip32",
+            dependencies: ["BitcoinDevKit"],
+            path: "Examples/WalletSetupBip32"
         ),
     ]
 )

--- a/bdk-swift/Package.swift
+++ b/bdk-swift/Package.swift
@@ -20,6 +20,9 @@ let package = Package(
         .executable(
             name: "MultisigTransaction",
             targets: ["MultisigTransaction"]),
+        .executable(
+            name: "MultisigTaprootTransaction",
+            targets: ["MultisigTaprootTransaction"]),
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
@@ -53,6 +56,11 @@ let package = Package(
             name: "MultisigTransaction",
             dependencies: ["BitcoinDevKit"],
             path: "Examples/MultisigTransaction"
+        ),
+        .executableTarget(
+            name: "MultisigTaprootTransaction",
+            dependencies: ["BitcoinDevKit"],
+            path: "Examples/MultisigTaprootTransaction"
         ),
     ]
 )

--- a/bdk-swift/README.md
+++ b/bdk-swift/README.md
@@ -33,6 +33,13 @@ The `bdk-swift/build-xcframework.sh` script can be used instead to create a vers
 swift test
 ```
 
+### Run example files
+The `Examples` directory shows a sample of how some of the APIs can be used. The swift target to run is by convention the directory name of the example.
+
+```
+swift run WalletSetupBip32Example
+```
+
 ### Example Projects
 
 - [BDKSwiftExampleWallet](https://github.com/bitcoindevkit/BDKSwiftExampleWallet), iOS

--- a/bdk-swift/README.md
+++ b/bdk-swift/README.md
@@ -37,7 +37,7 @@ swift test
 The `Examples` directory shows a sample of how some of the APIs can be used. The swift target to run is by convention the directory name of the example.
 
 ```
-swift run WalletSetupBip32Example
+swift run WalletSetupBip32
 ```
 
 ### Example Projects

--- a/bdk-swift/README.md
+++ b/bdk-swift/README.md
@@ -34,10 +34,11 @@ swift test
 ```
 
 ### Run example files
-The `Examples` directory shows a sample of how some of the APIs can be used. The swift target to run is by convention the directory name of the example.
+The `Examples` directory shows samples of how some of the APIs can be used. The swift target to run is by convention the directory name of each example.
 
 ```
 swift run WalletSetupBip32
+swift run MultisigTransaction
 ```
 
 ### Example Projects

--- a/bdk-swift/README.md
+++ b/bdk-swift/README.md
@@ -39,6 +39,7 @@ The `Examples` directory shows samples of how some of the APIs can be used. The 
 ```
 swift run WalletSetupBip32
 swift run MultisigTransaction
+swift run MultisigTaprootTransaction
 ```
 
 ### Example Projects


### PR DESCRIPTION
### Description

Showing users how the APIs can be used across languages is valuable. This PR mirrors the WalletSetupBip32 JVM example in Swift as requested in [issue 818](https://github.com/bitcoindevkit/bdk-ffi/issues/818).

### Notes to the reviewers

This Swift example follows the Kotlin example as closely as possible.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `swift build` and `swift run` before committing
* [x] I've linked the relevant upstream docs or specs above

#### New Features:

* [x] I've added the new feature to the CI build
* [x] I've added docs for the new feature