### PR TITLE
test: remove noisy print statements

### DIFF
--- a/bdk-ffi/src/tests/bitcoin.rs
+++ b/bdk-ffi/src/tests/bitcoin.rs
@@ -1,4 +1,4 @@
-use crate::bitcoin::{Address, Key, Network, ProprietaryKey, Psbt};
+use crate::bitcoin::{Address, AddressData, Key, Network, ProprietaryKey, Psbt};
 use bdk_electrum::bdk_core::bitcoin::hex::DisplayHex;
 
 #[test]
@@ -335,7 +335,6 @@ fn test_to_address_data() {
     )
     .unwrap();
     let p2pkh_data = p2pkh.to_address_data();
-    println!("P2PKH data: {:#?}", p2pkh_data);
 
     // P2SH address
     let p2sh = Address::new(
@@ -344,7 +343,6 @@ fn test_to_address_data() {
     )
     .unwrap();
     let p2sh_data = p2sh.to_address_data();
-    println!("P2SH data: {:#?}", p2sh_data);
 
     // Segwit address (P2WPKH)
     let segwit = Address::new(
@@ -353,15 +351,16 @@ fn test_to_address_data() {
     )
     .unwrap();
     let segwit_data = segwit.to_address_data();
-    println!("Segwit data: {:#?}", segwit_data);
+
+    assert!(matches!(p2pkh_data, AddressData::P2pkh { .. }));
+    assert!(matches!(p2sh_data, AddressData::P2sh { .. }));
+    assert!(matches!(segwit_data, AddressData::Segwit { .. }));
 }
 
 #[test]
 fn test_psbt_spend_utxo() {
     let psbt = sample_psbt();
     let psbt_utxo = psbt.spend_utxo(0);
-
-    println!("Psbt utxo: {:?}", psbt_utxo);
 
     assert_eq!(
         psbt_utxo,
@@ -374,10 +373,7 @@ fn test_psbt_spend_utxo() {
 fn test_psbt_input_length() {
     let psbt = sample_psbt2();
     let psbt_inputs = psbt.input();
-    println!("Psbt Input: {:?}", psbt_inputs);
 
-    let unknown = &psbt_inputs[0].unknown;
-    println!("Unknown field in Psbt Input: {:?}", unknown);
     assert_eq!(psbt_inputs.len(), 1);
 }
 
@@ -385,7 +381,6 @@ fn test_psbt_input_length() {
 fn test_psbt_input_partial_sigs() {
     let psbt = sample_psbt();
     let psbt_inputs = psbt.input();
-    println!("Psbt Input: {:?}", psbt_inputs);
     assert_eq!(psbt_inputs.len(), 1);
 
     let psbt_input = &psbt_inputs[0];
@@ -396,7 +391,6 @@ fn test_psbt_input_partial_sigs() {
 
     let public_key = "032e15f9dfd07dfef5cf33d7c4ae05586e71fb02ff2aef77cbf2c6e69fb4ac8db1";
     let signature: Option<Vec<u8>> = partial_sigs.get(public_key).cloned();
-    println!("Signature for pubkey {}: {:?}", public_key, signature);
     assert!(
         signature.is_some(),
         "Signature for the given pubkey should be present"
@@ -404,7 +398,6 @@ fn test_psbt_input_partial_sigs() {
 
     // Convert signature from bytes to hex string (Including last byte 0x01 for sighash type)
     let signature_hex = DisplayHex::to_lower_hex_string(&signature.unwrap());
-    println!("Signature in hex: {}", signature_hex);
 
     let expected_signature_hex = "3045022100f5bd0e740480b343f6ba14229e337b4063f98d7fdbdf62dc4a10669f2f14d1150220179bc6f0836e97210a3a8b02138c8f2753f340c0ce891a6a51b357b5d54ec6e201";
     assert_eq!(
@@ -426,10 +419,6 @@ fn test_psbt_input_bip32_derivation() {
 
     let public_key = "032e15f9dfd07dfef5cf33d7c4ae05586e71fb02ff2aef77cbf2c6e69fb4ac8db1";
     let derivation = bip32_derivations.get(public_key);
-    println!(
-        "BIP32 Derivation for pubkey {}: {:?}",
-        public_key, derivation
-    );
     assert!(
         derivation.is_some(),
         "BIP32 derivation for the given pubkey should be present"
@@ -478,7 +467,6 @@ fn test_psbt_input_unknown() {
 
     let psbt_input = &psbt_inputs[0];
     let unknown = &psbt_input.unknown;
-    println!("Unknown : {:?}", unknown);
 
     assert_eq!(unknown.len(), 1, "There should be 1 unknown fields");
 
@@ -506,7 +494,6 @@ fn test_psbt_input_proprietary() {
 
     let psbt_input = &psbt_inputs[0];
     let proprietary = &psbt_input.proprietary;
-    println!("Proprietary : {:?}", proprietary);
     assert_eq!(proprietary.len(), 1, "There should be 1 proprietary fields");
     let key = proprietary.keys().next().unwrap();
     let value = proprietary.get(key).unwrap();
@@ -528,7 +515,6 @@ fn test_psbt_input_proprietary() {
 fn test_psbt_output_length() {
     let psbt = sample_psbt();
     let psbt_outputs = psbt.output();
-    println!("Psbt Output: {:?}", psbt_outputs);
 
     assert_eq!(psbt_outputs.len(), 2);
 }
@@ -536,10 +522,8 @@ fn test_psbt_output_length() {
 #[test]
 fn test_psbt_output_witness_script() {
     let psbt = sample_psbt();
-    println!("Psbt: {:?}", psbt.json_serialize());
     let psbt_outputs = psbt.output();
     assert!(!psbt_outputs.is_empty(), "Output should not be empty");
-    println!("Psbt Output: {:?}", psbt_outputs);
     let output = &psbt_outputs[0];
     let witness_script = output
         .witness_script
@@ -557,10 +541,8 @@ fn test_psbt_output_witness_script() {
 #[test]
 fn test_psbt_output_tap_tree() {
     let psbt = sample_psbt_taproot();
-    println!("Psbt: {:?}", psbt.json_serialize());
     let psbt_outputs = psbt.output();
     assert!(!psbt_outputs.is_empty(), "Output should not be empty");
-    println!("Psbt Output: {:?}", psbt_outputs);
     let output = &psbt_outputs[1];
     let tap_tree = output
         .tap_tree
@@ -581,7 +563,6 @@ fn test_psbt_output_tap_tree() {
 
     // Get script and version from the first leaf node
     let node_info = tap_tree.node_info();
-    println!("Tap tree node infos: {:?}", node_info);
 
     let leaf_nodes = node_info.leaf_nodes();
     let leaf_node = &leaf_nodes[0];

--- a/bdk-ffi/src/tests/descriptor.rs
+++ b/bdk-ffi/src/tests/descriptor.rs
@@ -13,31 +13,26 @@ fn get_descriptor_secret_key() -> DescriptorSecretKey {
 #[test]
 fn test_descriptor_templates() {
     let master: DescriptorSecretKey = get_descriptor_secret_key();
-    println!("Master: {:?}", master.to_string());
     // tprv8ZgxMBicQKsPdWuqM1t1CDRvQtQuBPyfL6GbhQwtxDKgUAVPbxmj71pRA8raTqLrec5LyTs5TqCxdABcZr77bt2KyWA5bizJHnC4g4ysm4h
     let handmade_public_44 = master
         .derive(&DerivationPath::new("m/44h/1h/0h".to_string()).unwrap())
         .unwrap()
         .as_public();
-    println!("Public 44: {}", handmade_public_44);
     // Public 44: [d1d04177/44'/1'/0']tpubDCoPjomfTqh1e7o1WgGpQtARWtkueXQAepTeNpWiitS3Sdv8RKJ1yvTrGHcwjDXp2SKyMrTEca4LoN7gEUiGCWboyWe2rz99Kf4jK4m2Zmx/*
     let handmade_public_49 = master
         .derive(&DerivationPath::new("m/49h/1h/0h".to_string()).unwrap())
         .unwrap()
         .as_public();
-    println!("Public 49: {}", handmade_public_49);
     // Public 49: [d1d04177/49'/1'/0']tpubDC65ZRvk1NDddHrVAUAZrUPJ772QXzooNYmPywYF9tMyNLYKf5wpKE7ZJvK9kvfG3FV7rCsHBNXy1LVKW95jrmC7c7z4hq7a27aD2sRrAhR/*
     let handmade_public_84 = master
         .derive(&DerivationPath::new("m/84h/1h/0h".to_string()).unwrap())
         .unwrap()
         .as_public();
-    println!("Public 84: {}", handmade_public_84);
     // Public 84: [d1d04177/84'/1'/0']tpubDDNxbq17egjFk2edjv8oLnzxk52zny9aAYNv9CMqTzA4mQDiQq818sEkNe9Gzmd4QU8558zftqbfoVBDQorG3E4Wq26tB2JeE4KUoahLkx6/*
     let handmade_public_86 = master
         .derive(&DerivationPath::new("m/86h/1h/0h".to_string()).unwrap())
         .unwrap()
         .as_public();
-    println!("Public 86: {}", handmade_public_86);
     // Public 86: [d1d04177/86'/1'/0']tpubDCJzjbcGbdEfXMWaL6QmgVmuSfXkrue7m2YNoacWwyc7a2XjXaKojRqNEbo41CFL3PyYmKdhwg2fkGpLX4SQCbQjCGxAkWHJTw9WEeenrJb/*
     let template_private_44 =
         Descriptor::new_bip44(&master, KeychainKind::External, Network::Testnet);
@@ -48,10 +43,6 @@ fn test_descriptor_templates() {
     let template_private_86 =
         Descriptor::new_bip86(&master, KeychainKind::External, Network::Testnet);
     // the extended public keys are the same when creating them manually as they are with the templates
-    println!("Template 49: {}", template_private_49);
-    println!("Template 44: {}", template_private_44);
-    println!("Template 84: {}", template_private_84);
-    println!("Template 86: {}", template_private_86);
     let template_public_44 = Descriptor::new_bip44_public(
         &handmade_public_44,
         "d1d04177".to_string(),
@@ -80,10 +71,6 @@ fn test_descriptor_templates() {
         Network::Testnet,
     )
     .unwrap();
-    println!("Template public 49: {}", template_public_49);
-    println!("Template public 44: {}", template_public_44);
-    println!("Template public 84: {}", template_public_84);
-    println!("Template public 86: {}", template_public_86);
     // when using a public key, both to_string and to_string_private return the same string
     assert_eq!(
         template_public_44.to_string_with_secret(),
@@ -156,7 +143,6 @@ fn test_max_weight_to_satisfy() {
     ).unwrap();
 
     let weight = descriptor.max_weight_to_satisfy().unwrap();
-    println!("P2WPKH max weight to satisfy: {} wu", weight);
 
     // Verify the method works and returns a positive weight
     assert!(weight > 0, "Weight must be positive");

--- a/bdk-ffi/src/tests/keys.rs
+++ b/bdk-ffi/src/tests/keys.rs
@@ -78,7 +78,6 @@ fn test_extend_descriptor_keys() {
     let wif = "L2wTu6hQrnDMiFNWA5na6jB12ErGQqtXwqpSL7aWquJaZG8Ai3ch";
     let extended_key = DescriptorSecretKey::from_string(wif.to_string()).unwrap();
     let result = extended_key.derive(&DerivationPath::new("m/0".to_string()).unwrap());
-    dbg!(&result);
     assert!(result.is_err());
 }
 
@@ -86,10 +85,8 @@ fn test_extend_descriptor_keys() {
 fn test_from_str_inner() {
     let key1 = "L2wTu6hQrnDMiFNWA5na6jB12ErGQqtXwqpSL7aWquJaZG8Ai3ch";
     let key2 = "tprv8ZgxMBicQKsPcwcD4gSnMti126ZiETsuX7qwrtMypr6FBwAP65puFn4v6c3jrN9VwtMRMph6nyT63NrfUL4C3nBzPcduzVSuHD7zbX2JKVc/1/1/1/*";
-    let private_descriptor_key1 = DescriptorSecretKey::from_string(key1.to_string()).unwrap();
-    let private_descriptor_key2 = DescriptorSecretKey::from_string(key2.to_string()).unwrap();
-    dbg!(private_descriptor_key1);
-    dbg!(private_descriptor_key2);
+    let _private_descriptor_key1 = DescriptorSecretKey::from_string(key1.to_string()).unwrap();
+    let _private_descriptor_key2 = DescriptorSecretKey::from_string(key2.to_string()).unwrap();
     // Should error out because you can't produce a DescriptorSecretKey from an xpub
     let key0 = "tpubDBrgjcxBxnXyL575sHdkpKohWu5qHKoQ7TJXKNrYznh5fVEGBv89hA8ENW7A8MFVpFUSvgLqc4Nj1WZcpePX6rrxviVtPowvMuGF5rdT2Vi";
     assert!(DescriptorSecretKey::from_string(key0.to_string()).is_err());


### PR DESCRIPTION
## Summary

Remove unconditional debug/print output from a small set of Rust test files where the assertions already provide enough signal on failure.

## Scope

This change is intentionally limited to test cleanup in:

- `bdk-ffi/src/tests/descriptor.rs`
- `bdk-ffi/src/tests/keys.rs`
- `bdk-ffi/src/tests/bitcoin.rs`

I left `tx_builder.rs` unchanged in this pass because those prints are mixed into live-network and failure-diagnostic paths, so I wanted to keep the scope conservative.

## What changed

- removed `println!` calls from descriptor template/address-data/psbt-related tests where they were only adding noise on success
- removed `dbg!` calls from key tests
- kept test behavior the same
- replaced one print-driven sanity check in `test_to_address_data` with explicit variant assertions

## Verification

- `cargo fmt --check`
- `cargo test descriptor`
- `cargo test psbt`
- `cargo test test_to_address_data`
- `cargo test test_from_str_inner`
