### PR TITLE
refactor: use types::KeychainKind where appropriate

### DIFF
--- a/bdk-ffi/src/descriptor.rs
+++ b/bdk-ffi/src/descriptor.rs
@@ -5,6 +5,7 @@ use crate::error::DescriptorError;
 use crate::error::MiniscriptError;
 use crate::keys::DescriptorPublicKey;
 use crate::keys::DescriptorSecretKey;
+use crate::types::KeychainKind;
 
 use bdk_wallet::bitcoin::bip32::Fingerprint;
 use bdk_wallet::bitcoin::key::Secp256k1;
@@ -18,7 +19,6 @@ use bdk_wallet::template::{
     Bip44, Bip44Public, Bip49, Bip49Public, Bip84, Bip84Public, Bip86, Bip86Public,
     DescriptorTemplate,
 };
-use bdk_wallet::KeychainKind;
 
 use std::fmt::Display;
 use std::str::FromStr;

--- a/bdk-ffi/src/electrum.rs
+++ b/bdk-ffi/src/electrum.rs
@@ -1,5 +1,6 @@
 use crate::bitcoin::{BlockHash, Header, Transaction, Txid};
 use crate::error::ElectrumError;
+use crate::types::KeychainKind;
 use crate::types::Update;
 use crate::types::{FullScanRequest, SyncRequest};
 
@@ -11,7 +12,6 @@ use bdk_wallet::chain::spk_client::FullScanRequest as BdkFullScanRequest;
 use bdk_wallet::chain::spk_client::FullScanResponse as BdkFullScanResponse;
 use bdk_wallet::chain::spk_client::SyncRequest as BdkSyncRequest;
 use bdk_wallet::chain::spk_client::SyncResponse as BdkSyncResponse;
-use bdk_wallet::KeychainKind;
 use bdk_wallet::Update as BdkUpdate;
 
 use bdk_electrum::electrum_client::ElectrumApi;

--- a/bdk-ffi/src/esplora.rs
+++ b/bdk-ffi/src/esplora.rs
@@ -5,6 +5,7 @@ use crate::bitcoin::Header;
 use crate::bitcoin::Transaction;
 use crate::bitcoin::Txid;
 use crate::error::EsploraError;
+use crate::types::KeychainKind;
 use crate::types::Tx;
 use crate::types::TxStatus;
 use crate::types::Update;
@@ -17,7 +18,6 @@ use bdk_wallet::chain::spk_client::FullScanRequest as BdkFullScanRequest;
 use bdk_wallet::chain::spk_client::FullScanResponse as BdkFullScanResponse;
 use bdk_wallet::chain::spk_client::SyncRequest as BdkSyncRequest;
 use bdk_wallet::chain::spk_client::SyncResponse as BdkSyncResponse;
-use bdk_wallet::KeychainKind;
 use bdk_wallet::Update as BdkUpdate;
 
 use std::collections::{BTreeMap, HashMap};

--- a/bdk-ffi/src/tests/descriptor.rs
+++ b/bdk-ffi/src/tests/descriptor.rs
@@ -2,8 +2,9 @@ use crate::bitcoin::Network;
 use crate::descriptor::Descriptor;
 use crate::error::DescriptorError;
 use crate::keys::{DerivationPath, DescriptorSecretKey, Mnemonic};
+use crate::types::KeychainKind;
+
 use assert_matches::assert_matches;
-use bdk_wallet::KeychainKind;
 
 fn get_descriptor_secret_key() -> DescriptorSecretKey {
     let mnemonic = Mnemonic::from_string("chaos fabric time speed sponsor all flat solution wisdom trophy crack object robot pave observe combine where aware bench orient secret primary cable detect".to_string()).unwrap();

--- a/bdk-ffi/src/tx_builder.rs
+++ b/bdk-ffi/src/tx_builder.rs
@@ -1,5 +1,6 @@
 use crate::bitcoin::{Amount, FeeRate, Input, OutPoint, Psbt, Script, Txid};
 use crate::error::{AddForeignUtxoError, CreateTxError};
+use crate::types::KeychainKind;
 use crate::types::{LockTime, ScriptAmount};
 use crate::wallet::Wallet;
 
@@ -10,7 +11,6 @@ use bdk_wallet::bitcoin::script::PushBytesBuf;
 use bdk_wallet::bitcoin::Psbt as BdkPsbt;
 use bdk_wallet::bitcoin::ScriptBuf as BdkScriptBuf;
 use bdk_wallet::bitcoin::{OutPoint as BdkOutPoint, Sequence, Weight as BdkWeight};
-use bdk_wallet::KeychainKind;
 
 use std::collections::BTreeMap;
 use std::collections::HashMap;

--- a/bdk-ffi/src/types.rs
+++ b/bdk-ffi/src/types.rs
@@ -43,7 +43,7 @@ use bdk_esplora::esplora_client::api::OutputStatus as BdkOutputStatus;
 use bdk_esplora::esplora_client::api::Tx as BdkTx;
 use bdk_esplora::esplora_client::api::TxStatus as BdkTxStatus;
 
-type KeychainKind = bdk_wallet::KeychainKind;
+pub(crate) type KeychainKind = bdk_wallet::KeychainKind;
 
 /// Types of keychains.
 #[uniffi::remote(Enum)]

--- a/bdk-ffi/src/wallet.rs
+++ b/bdk-ffi/src/wallet.rs
@@ -7,14 +7,14 @@ use crate::error::{
 use crate::store::{PersistenceType, Persister};
 use crate::types::{
     AddressInfo, Balance, BlockId, CanonicalTx, ChangeSet, EvictedTx, FullScanRequestBuilder,
-    KeychainAndIndex, LocalOutput, Policy, SentAndReceivedValues, SignOptions, SyncRequestBuilder,
-    UnconfirmedTx, Update, WalletEvent,
+    KeychainAndIndex, KeychainKind, LocalOutput, Policy, SentAndReceivedValues, SignOptions,
+    SyncRequestBuilder, UnconfirmedTx, Update, WalletEvent,
 };
 
 use bdk_wallet::bitcoin::Network;
 #[allow(deprecated)]
 use bdk_wallet::signer::SignOptions as BdkSignOptions;
-use bdk_wallet::{KeychainKind, PersistedWallet, Wallet as BdkWallet};
+use bdk_wallet::{PersistedWallet, Wallet as BdkWallet};
 
 use std::ops::DerefMut;
 use std::sync::{Arc, Mutex, MutexGuard};


### PR DESCRIPTION
This small fix came up in my review of #971. I realized we used what looked like on the surface to be 2 versions of the `KeychainKind` type, one directly from bdk_wallet and one from our custom-written types. 

This is not the case and they were both coming from our custom-written types, but the imports made this confusing and not obvious. This PR fixes that.

### Documentation

<!-- Paste the canonical docs/spec for anything this PR wraps or updates. -->

- [ ] [`bdk_wallet`](https://docs.rs/bdk_wallet/latest/bdk_wallet/)
  <!-- Add a link below with the docs.rs page. -->
- [ ] [`bitcoin`](https://docs.rs/bitcoin/latest/bitcoin/index.html)
  <!-- Add a link below with the docs.rs page. -->
- [ ] [`uniffi`](https://github.com/mozilla/uniffi-rs) <!-- Add a link below with the version changelog or any other docs. -->
- [ ] Other: <!-- Add a link below with additional references -->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
* [ ] I've added a changelog in the next release tracking issue (see [example](https://github.com/bitcoindevkit/bdk-ffi/issues/875))
* [ ] I've linked the relevant upstream docs or specs above

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
