### PR TITLE
Expose the `NetworkKind` type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased](https://github.com/bitcoindevkit/bdk-ffi/compare/v2.3.0...HEAD)
 
 ### Added
+
 - Expose miniscript `has_wildcard` and `sanity_check` methods on `Descriptor` type #945
 - Expose `new_wsh_sortedmulti` and `new_pk` methods on `Descriptor` type #949
 - Expose `new_sh_sortedmulti`, `new_sh_wsh_sortedmulti`, `new_pkh`, `new_wpkh`, `new_sh_wpkh` methods on `Descriptor` type #973
@@ -15,6 +16,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Expose locked outpoint wallet APIs and locked outpoint persistence in `ChangeSet` #971
 - Expose transaction builder controls for sighash, transaction ordering, and adding foreign UTXOs with explicit sequence values #971
 - Expose `Persister::get_pre_v1_wallet_keychains` for pre-v1 SQLite wallet migration support #971
+- Expose `NetworkKind` type #986
+
+### Breaking
+
+- `Descriptor` and `DescriptorSecretKey` constructors now require a `NetworkKind` #986
+
+[#986]: https://github.com/bitcoindevkit/bdk-ffi/pull/986
 
 ## [v2.3.0]
 

--- a/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/CbfSyncTest.kt
+++ b/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/CbfSyncTest.kt
@@ -5,7 +5,6 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.time.withTimeout
 import kotlinx.coroutines.withTimeout
 import org.junit.runner.RunWith
 import org.kotlinbitcointools.regtesttoolbox.regenv.RegEnv

--- a/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/Constants.kt
+++ b/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/Constants.kt
@@ -14,32 +14,32 @@ const val BIP86_MAINNET_RECEIVE_PATH = "86h/0h/0h/1"
 
 val BIP84_DESCRIPTOR: Descriptor = Descriptor(
     "wpkh($TEST_EXTENDED_PRIVKEY/$BIP84_TEST_RECEIVE_PATH/*)",
-    Network.TESTNET
+    NetworkKind.TEST
 )
 val BIP84_CHANGE_DESCRIPTOR: Descriptor = Descriptor(
     "wpkh($TEST_EXTENDED_PRIVKEY/$BIP84_TEST_CHANGE_PATH/*)",
-    Network.TESTNET
+    NetworkKind.TEST
 )
 val BIP86_DESCRIPTOR: Descriptor = Descriptor(
     "tr($TEST_EXTENDED_PRIVKEY/$BIP86_TEST_RECEIVE_PATH/*)",
-    Network.TESTNET
+    NetworkKind.TEST
 )
 val BIP86_CHANGE_DESCRIPTOR: Descriptor = Descriptor(
     "tr($TEST_EXTENDED_PRIVKEY/$BIP86_TEST_CHANGE_PATH/*)",
-    Network.TESTNET
+    NetworkKind.TEST
 )
 val NON_EXTENDED_DESCRIPTOR_0: Descriptor = Descriptor(
     descriptor = "wpkh($TEST_EXTENDED_PRIVKEY/$BIP84_TEST_RECEIVE_PATH/0)",
-    network = Network.TESTNET
+    networkKind = NetworkKind.TEST
 )
 val NON_EXTENDED_DESCRIPTOR_1: Descriptor = Descriptor(
     descriptor = "wpkh($TEST_EXTENDED_PRIVKEY/$BIP84_TEST_RECEIVE_PATH/1)",
-    network = Network.TESTNET
+    networkKind = NetworkKind.TEST
 )
 
 // Using the MNEMONIC_AWESOME
 const val TEST_EXTENDED_PRIVKEY_0 = "tprv8ZgxMBicQKsPdWAHbugK2tjtVtRjKGixYVZUdL7xLHMgXZS6BFbFi1UDb1CHT25Z5PU1F9j7wGxwUiRhqz9E3nZRztikGUV6HoRDYcqPhM4"
 const val BIP84_TEST_RECEIVE_PATH_0 = "84h/1h/0h/0"
-val TEST_BIP84_DESCRIPTOR_0 = Descriptor("wpkh($TEST_EXTENDED_PRIVKEY_0/$BIP84_TEST_RECEIVE_PATH_0/*)", Network.REGTEST)
+val TEST_BIP84_DESCRIPTOR_0 = Descriptor("wpkh($TEST_EXTENDED_PRIVKEY_0/$BIP84_TEST_RECEIVE_PATH_0/*)", NetworkKind.TEST)
 
 const val ESPLORA_REGTEST_URL = "http://10.0.2.2:3002"

--- a/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/CreatingWalletTest.kt
+++ b/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/CreatingWalletTest.kt
@@ -57,7 +57,7 @@ class CreatingWalletTest {
     fun createWalletWithMultipathDescriptor() {
         val multipathDescriptor = Descriptor(
             "wpkh([9a6a2580/84'/0'/0']xpub6DEzNop46vmxR49zYWFnMwmEfawSNmAMf6dLH5YKDY463twtvw1XD7ihwJRLPRGZJz799VPFzXHpZu6WdhT29WnaeuChS6aZHZPFmqczR5K/<0;1>/*)",
-            Network.BITCOIN
+            NetworkKind.MAIN
         )
 
         Wallet.createFromTwoPathDescriptor(
@@ -73,7 +73,7 @@ class CreatingWalletTest {
         assertFails {
             Descriptor(
                 descriptor = "tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/<0;1>/*)",
-                Network.TESTNET
+                NetworkKind.TEST
             )
         }
     }

--- a/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/DescriptorTest.kt
+++ b/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/DescriptorTest.kt
@@ -14,31 +14,22 @@ class DescriptorTest {
     // Create extended WPKH descriptors for all networks.
     @Test
     fun createExtendedWPKHDescriptors() {
-        Descriptor("wpkh($TEST_EXTENDED_PRIVKEY/$BIP84_TEST_RECEIVE_PATH/*)", Network.REGTEST)
-        Descriptor("wpkh($TEST_EXTENDED_PRIVKEY/$BIP84_TEST_RECEIVE_PATH/*)", Network.TESTNET)
-        Descriptor("wpkh($TEST_EXTENDED_PRIVKEY/$BIP84_TEST_RECEIVE_PATH/*)", Network.TESTNET4)
-        Descriptor("wpkh($TEST_EXTENDED_PRIVKEY/$BIP84_TEST_RECEIVE_PATH/*)", Network.SIGNET)
-        Descriptor("wpkh($MAINNET_EXTENDED_PRIVKEY/$BIP84_MAINNET_RECEIVE_PATH/*)", Network.BITCOIN)
+        Descriptor("wpkh($TEST_EXTENDED_PRIVKEY/$BIP84_TEST_RECEIVE_PATH/*)", NetworkKind.TEST)
+        Descriptor("wpkh($MAINNET_EXTENDED_PRIVKEY/$BIP84_MAINNET_RECEIVE_PATH/*)", NetworkKind.MAIN)
     }
 
     // Create extended TR descriptors for all networks.
     @Test
     fun createExtendedTRDescriptors() {
-        Descriptor("tr($TEST_EXTENDED_PRIVKEY/$BIP86_TEST_RECEIVE_PATH/*)", Network.REGTEST)
-        Descriptor("tr($TEST_EXTENDED_PRIVKEY/$BIP86_TEST_RECEIVE_PATH/*)", Network.TESTNET)
-        Descriptor("tr($TEST_EXTENDED_PRIVKEY/$BIP86_TEST_RECEIVE_PATH/*)", Network.TESTNET4)
-        Descriptor("tr($TEST_EXTENDED_PRIVKEY/$BIP86_TEST_RECEIVE_PATH/*)", Network.SIGNET)
-        Descriptor("tr($MAINNET_EXTENDED_PRIVKEY/$BIP86_MAINNET_RECEIVE_PATH/*)", Network.BITCOIN)
+        Descriptor("tr($TEST_EXTENDED_PRIVKEY/$BIP86_TEST_RECEIVE_PATH/*)", NetworkKind.TEST)
+        Descriptor("tr($MAINNET_EXTENDED_PRIVKEY/$BIP86_MAINNET_RECEIVE_PATH/*)", NetworkKind.MAIN)
     }
 
     // Create non-extended descriptors for all networks.
     @Test
     fun createNonExtendedDescriptors() {
-        Descriptor("tr($TEST_EXTENDED_PRIVKEY/$BIP86_TEST_RECEIVE_PATH/0)", Network.REGTEST)
-        Descriptor("tr($TEST_EXTENDED_PRIVKEY/$BIP86_TEST_RECEIVE_PATH/0)", Network.TESTNET)
-        Descriptor("tr($TEST_EXTENDED_PRIVKEY/$BIP86_TEST_RECEIVE_PATH/0)", Network.TESTNET4)
-        Descriptor("tr($TEST_EXTENDED_PRIVKEY/$BIP86_TEST_RECEIVE_PATH/0)", Network.SIGNET)
-        Descriptor("tr($MAINNET_EXTENDED_PRIVKEY/$BIP86_MAINNET_RECEIVE_PATH/0)", Network.BITCOIN)
+        Descriptor("tr($TEST_EXTENDED_PRIVKEY/$BIP86_TEST_RECEIVE_PATH/0)", NetworkKind.TEST)
+        Descriptor("tr($MAINNET_EXTENDED_PRIVKEY/$BIP86_MAINNET_RECEIVE_PATH/0)", NetworkKind.MAIN)
     }
 
     // Create a multisig descriptor.
@@ -89,19 +80,19 @@ class DescriptorTest {
         assertFails {
             val descriptor: Descriptor = Descriptor(
                 "addr(tb1qhjys9wxlfykmte7ftryptx975uqgd6kcm6a7z4)",
-                Network.TESTNET
+                NetworkKind.TEST
             )
         }
     }
 
     @Test
     fun sanityCheck() {
-        val safeDescriptor = Descriptor("multi(1,L4rK1yDtCWekvXuE6oXD9jCYfFNV2cWRpVuPLBcCU2z8TrisoyY1,5KYZdUEo39z3FPrtuX2QbbwGnNP5zTd7yyr2SC1j299sBCnWjss)", Network.BITCOIN)
+        val safeDescriptor = Descriptor("multi(1,L4rK1yDtCWekvXuE6oXD9jCYfFNV2cWRpVuPLBcCU2z8TrisoyY1,5KYZdUEo39z3FPrtuX2QbbwGnNP5zTd7yyr2SC1j299sBCnWjss)", NetworkKind.MAIN)
 
         safeDescriptor.sanityCheck()
 
         //multi(2, key1, key1)) is structurally valid but unsafe
-        val unsafeDescriptor = Descriptor("multi(2,L4rK1yDtCWekvXuE6oXD9jCYfFNV2cWRpVuPLBcCU2z8TrisoyY1,L4rK1yDtCWekvXuE6oXD9jCYfFNV2cWRpVuPLBcCU2z8TrisoyY1)", Network.BITCOIN)
+        val unsafeDescriptor = Descriptor("multi(2,L4rK1yDtCWekvXuE6oXD9jCYfFNV2cWRpVuPLBcCU2z8TrisoyY1,L4rK1yDtCWekvXuE6oXD9jCYfFNV2cWRpVuPLBcCU2z8TrisoyY1)", NetworkKind.MAIN)
 
         // descriptor failed as expected because it uses the same public key twice in a 2 of 2 multisig
         assertFailsWith<DescriptorException.Miniscript> {
@@ -111,8 +102,8 @@ class DescriptorTest {
 
     @Test
     fun checkDescriptorWildcard(){
-        val wildcardDescriptor = Descriptor("wpkh($TEST_EXTENDED_PRIVKEY/$BIP84_TEST_RECEIVE_PATH/*)", Network.REGTEST)
-        val nonWildcardDescriptor = Descriptor("wpkh($TEST_EXTENDED_PRIVKEY/$BIP84_TEST_RECEIVE_PATH/0)", Network.REGTEST)
+        val wildcardDescriptor = Descriptor("wpkh($TEST_EXTENDED_PRIVKEY/$BIP84_TEST_RECEIVE_PATH/*)", NetworkKind.TEST)
+        val nonWildcardDescriptor = Descriptor("wpkh($TEST_EXTENDED_PRIVKEY/$BIP84_TEST_RECEIVE_PATH/0)", NetworkKind.TEST)
 
         assertTrue(wildcardDescriptor.hasWildcard())
 
@@ -123,19 +114,19 @@ class DescriptorTest {
     fun testDescriptorTypes() {
         // Taken from the BIPs: https://github.com/bitcoin/bips/blob/master/bip-0380.mediawiki
 
-        val descriptor1 = Descriptor("pk(L4rK1yDtCWekvXuE6oXD9jCYfFNV2cWRpVuPLBcCU2z8TrisoyY1)", Network.SIGNET)
-        val descriptor2 = Descriptor("pkh([deadbeef/1/2'/3/4']L4rK1yDtCWekvXuE6oXD9jCYfFNV2cWRpVuPLBcCU2z8TrisoyY1)", Network.SIGNET)
-        val descriptor3 = Descriptor("sh(pk(03a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd))", Network.SIGNET)
-        val descriptor4 = Descriptor("wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/0/*)", Network.SIGNET)
-        val descriptor5 = Descriptor("sh(wpkh(xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi/10/20/30/40/*h))", Network.BITCOIN)
-        val descriptor6 = Descriptor("multi(1,L4rK1yDtCWekvXuE6oXD9jCYfFNV2cWRpVuPLBcCU2z8TrisoyY1,5KYZdUEo39z3FPrtuX2QbbwGnNP5zTd7yyr2SC1j299sBCnWjss)", Network.BITCOIN)
-        val descriptor7 = Descriptor("tr(a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd)", Network.BITCOIN)
-        val descriptor8 = Descriptor("sh(multi(2,[00000000/111'/222]xprvA1RpRA33e1JQ7ifknakTFpgNXPmW2YvmhqLQYMmrj4xJXXWYpDPS3xz7iAxn8L39njGVyuoseXzU6rcxFLJ8HFsTjSyQbLYnMpCqE2VbFWc,xprv9uPDJpEQgRQfDcW7BkF7eTya6RPxXeJCqCJGHuCJ4GiRVLzkTXBAJMu2qaMWPrS7AANYqdq6vcBcBUdJCVVFceUvJFjaPdGZ2y9WACViL4L/0))", Network.BITCOIN)
-        val descriptor9 = Descriptor("sh(sortedmulti(2,[00000000/111'/222]xprvA1RpRA33e1JQ7ifknakTFpgNXPmW2YvmhqLQYMmrj4xJXXWYpDPS3xz7iAxn8L39njGVyuoseXzU6rcxFLJ8HFsTjSyQbLYnMpCqE2VbFWc,xprv9uPDJpEQgRQfDcW7BkF7eTya6RPxXeJCqCJGHuCJ4GiRVLzkTXBAJMu2qaMWPrS7AANYqdq6vcBcBUdJCVVFceUvJFjaPdGZ2y9WACViL4L/0))", Network.BITCOIN)
-        val descriptor10 = Descriptor("wsh(sortedmulti(2,[00000000/111'/222]xprvA1RpRA33e1JQ7ifknakTFpgNXPmW2YvmhqLQYMmrj4xJXXWYpDPS3xz7iAxn8L39njGVyuoseXzU6rcxFLJ8HFsTjSyQbLYnMpCqE2VbFWc,xprv9uPDJpEQgRQfDcW7BkF7eTya6RPxXeJCqCJGHuCJ4GiRVLzkTXBAJMu2qaMWPrS7AANYqdq6vcBcBUdJCVVFceUvJFjaPdGZ2y9WACViL4L/0))", Network.BITCOIN)
-        val descriptor11 = Descriptor("sh(wsh(sortedmulti(2,[00000000/111'/222]xprvA1RpRA33e1JQ7ifknakTFpgNXPmW2YvmhqLQYMmrj4xJXXWYpDPS3xz7iAxn8L39njGVyuoseXzU6rcxFLJ8HFsTjSyQbLYnMpCqE2VbFWc,xprv9uPDJpEQgRQfDcW7BkF7eTya6RPxXeJCqCJGHuCJ4GiRVLzkTXBAJMu2qaMWPrS7AANYqdq6vcBcBUdJCVVFceUvJFjaPdGZ2y9WACViL4L/0)))", Network.BITCOIN)
-        val descriptor12 = Descriptor("wsh(multi(2,[00000000/111'/222]xprvA1RpRA33e1JQ7ifknakTFpgNXPmW2YvmhqLQYMmrj4xJXXWYpDPS3xz7iAxn8L39njGVyuoseXzU6rcxFLJ8HFsTjSyQbLYnMpCqE2VbFWc,xprv9uPDJpEQgRQfDcW7BkF7eTya6RPxXeJCqCJGHuCJ4GiRVLzkTXBAJMu2qaMWPrS7AANYqdq6vcBcBUdJCVVFceUvJFjaPdGZ2y9WACViL4L/0))", Network.BITCOIN)
-        val descriptor13 = Descriptor("sh(wsh(multi(2,[00000000/111'/222]xprvA1RpRA33e1JQ7ifknakTFpgNXPmW2YvmhqLQYMmrj4xJXXWYpDPS3xz7iAxn8L39njGVyuoseXzU6rcxFLJ8HFsTjSyQbLYnMpCqE2VbFWc,xprv9uPDJpEQgRQfDcW7BkF7eTya6RPxXeJCqCJGHuCJ4GiRVLzkTXBAJMu2qaMWPrS7AANYqdq6vcBcBUdJCVVFceUvJFjaPdGZ2y9WACViL4L/0)))", Network.BITCOIN)
+        val descriptor1 = Descriptor("pk(L4rK1yDtCWekvXuE6oXD9jCYfFNV2cWRpVuPLBcCU2z8TrisoyY1)", NetworkKind.TEST)
+        val descriptor2 = Descriptor("pkh([deadbeef/1/2'/3/4']L4rK1yDtCWekvXuE6oXD9jCYfFNV2cWRpVuPLBcCU2z8TrisoyY1)", NetworkKind.TEST)
+        val descriptor3 = Descriptor("sh(pk(03a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd))", NetworkKind.TEST)
+        val descriptor4 = Descriptor("wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/0/*)", NetworkKind.TEST)
+        val descriptor5 = Descriptor("sh(wpkh(xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi/10/20/30/40/*h))", NetworkKind.MAIN)
+        val descriptor6 = Descriptor("multi(1,L4rK1yDtCWekvXuE6oXD9jCYfFNV2cWRpVuPLBcCU2z8TrisoyY1,5KYZdUEo39z3FPrtuX2QbbwGnNP5zTd7yyr2SC1j299sBCnWjss)", NetworkKind.MAIN)
+        val descriptor7 = Descriptor("tr(a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd)", NetworkKind.MAIN)
+        val descriptor8 = Descriptor("sh(multi(2,[00000000/111'/222]xprvA1RpRA33e1JQ7ifknakTFpgNXPmW2YvmhqLQYMmrj4xJXXWYpDPS3xz7iAxn8L39njGVyuoseXzU6rcxFLJ8HFsTjSyQbLYnMpCqE2VbFWc,xprv9uPDJpEQgRQfDcW7BkF7eTya6RPxXeJCqCJGHuCJ4GiRVLzkTXBAJMu2qaMWPrS7AANYqdq6vcBcBUdJCVVFceUvJFjaPdGZ2y9WACViL4L/0))", NetworkKind.MAIN)
+        val descriptor9 = Descriptor("sh(sortedmulti(2,[00000000/111'/222]xprvA1RpRA33e1JQ7ifknakTFpgNXPmW2YvmhqLQYMmrj4xJXXWYpDPS3xz7iAxn8L39njGVyuoseXzU6rcxFLJ8HFsTjSyQbLYnMpCqE2VbFWc,xprv9uPDJpEQgRQfDcW7BkF7eTya6RPxXeJCqCJGHuCJ4GiRVLzkTXBAJMu2qaMWPrS7AANYqdq6vcBcBUdJCVVFceUvJFjaPdGZ2y9WACViL4L/0))", NetworkKind.MAIN)
+        val descriptor10 = Descriptor("wsh(sortedmulti(2,[00000000/111'/222]xprvA1RpRA33e1JQ7ifknakTFpgNXPmW2YvmhqLQYMmrj4xJXXWYpDPS3xz7iAxn8L39njGVyuoseXzU6rcxFLJ8HFsTjSyQbLYnMpCqE2VbFWc,xprv9uPDJpEQgRQfDcW7BkF7eTya6RPxXeJCqCJGHuCJ4GiRVLzkTXBAJMu2qaMWPrS7AANYqdq6vcBcBUdJCVVFceUvJFjaPdGZ2y9WACViL4L/0))", NetworkKind.MAIN)
+        val descriptor11 = Descriptor("sh(wsh(sortedmulti(2,[00000000/111'/222]xprvA1RpRA33e1JQ7ifknakTFpgNXPmW2YvmhqLQYMmrj4xJXXWYpDPS3xz7iAxn8L39njGVyuoseXzU6rcxFLJ8HFsTjSyQbLYnMpCqE2VbFWc,xprv9uPDJpEQgRQfDcW7BkF7eTya6RPxXeJCqCJGHuCJ4GiRVLzkTXBAJMu2qaMWPrS7AANYqdq6vcBcBUdJCVVFceUvJFjaPdGZ2y9WACViL4L/0)))", NetworkKind.MAIN)
+        val descriptor12 = Descriptor("wsh(multi(2,[00000000/111'/222]xprvA1RpRA33e1JQ7ifknakTFpgNXPmW2YvmhqLQYMmrj4xJXXWYpDPS3xz7iAxn8L39njGVyuoseXzU6rcxFLJ8HFsTjSyQbLYnMpCqE2VbFWc,xprv9uPDJpEQgRQfDcW7BkF7eTya6RPxXeJCqCJGHuCJ4GiRVLzkTXBAJMu2qaMWPrS7AANYqdq6vcBcBUdJCVVFceUvJFjaPdGZ2y9WACViL4L/0))", NetworkKind.MAIN)
+        val descriptor13 = Descriptor("sh(wsh(multi(2,[00000000/111'/222]xprvA1RpRA33e1JQ7ifknakTFpgNXPmW2YvmhqLQYMmrj4xJXXWYpDPS3xz7iAxn8L39njGVyuoseXzU6rcxFLJ8HFsTjSyQbLYnMpCqE2VbFWc,xprv9uPDJpEQgRQfDcW7BkF7eTya6RPxXeJCqCJGHuCJ4GiRVLzkTXBAJMu2qaMWPrS7AANYqdq6vcBcBUdJCVVFceUvJFjaPdGZ2y9WACViL4L/0)))", NetworkKind.MAIN)
 
         assertEquals(
             expected = DescriptorType.BARE,

--- a/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/MnemonicTest.kt
+++ b/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/MnemonicTest.kt
@@ -11,8 +11,8 @@ class MnemonicTest {
     @Test
     fun mnemonicsCreateValidDescriptors() {
         val mnemonic: Mnemonic = Mnemonic.fromString("space echo position wrist orient erupt relief museum myself grain wisdom tumble")
-        val descriptorSecretKey: DescriptorSecretKey = DescriptorSecretKey(Network.TESTNET, mnemonic, null)
-        val descriptor: Descriptor = Descriptor.newBip86(descriptorSecretKey, KeychainKind.EXTERNAL, Network.TESTNET)
+        val descriptorSecretKey: DescriptorSecretKey = DescriptorSecretKey(NetworkKind.TEST, mnemonic, null)
+        val descriptor: Descriptor = Descriptor.newBip86(descriptorSecretKey, KeychainKind.EXTERNAL, NetworkKind.TEST)
 
         assertEquals(
             expected = "tr([be1eec8f/86'/1'/0']tpubDCTtszwSxPx3tATqDrsSyqScPNnUChwQAVAkanuDUCJQESGBbkt68nXXKRDifYSDbeMa2Xg2euKbXaU3YphvGWftDE7ozRKPriT6vAo3xsc/0/*)#m7puekcx",

--- a/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/PersistenceTest.kt
+++ b/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/PersistenceTest.kt
@@ -50,11 +50,11 @@ class PersistenceTest {
 
     private val descriptor: Descriptor = Descriptor(
         "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/0/*)",
-        Network.SIGNET
+        NetworkKind.TEST
     )
     private val changeDescriptor: Descriptor = Descriptor(
         "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/1/*)",
-        Network.SIGNET
+        NetworkKind.TEST
     )
 
     // fun `Correctly load wallet from sqlite persistence`() {

--- a/bdk-ffi/src/bitcoin.rs
+++ b/bdk-ffi/src/bitcoin.rs
@@ -9,6 +9,7 @@ use crate::{impl_from_core_type, impl_hash_like, impl_into_core_type};
 use bdk_wallet::bitcoin::address::NetworkChecked;
 use bdk_wallet::bitcoin::address::NetworkUnchecked;
 use bdk_wallet::bitcoin::address::{Address as BdkAddress, AddressData as BdkAddressData};
+use bdk_wallet::bitcoin::bip32::ChildNumber as BdkChildNumber;
 use bdk_wallet::bitcoin::blockdata::block::Block as BdkBlock;
 use bdk_wallet::bitcoin::blockdata::block::Header as BdkHeader;
 use bdk_wallet::bitcoin::consensus::encode::deserialize;
@@ -20,8 +21,6 @@ use bdk_wallet::bitcoin::io::Cursor;
 use bdk_wallet::bitcoin::psbt::Input as BdkInput;
 use bdk_wallet::bitcoin::psbt::Output as BdkOutput;
 use bdk_wallet::bitcoin::secp256k1::Secp256k1;
-
-use bdk_wallet::bitcoin::bip32::ChildNumber as BdkChildNumber;
 use bdk_wallet::bitcoin::taproot::LeafNode as BdkLeafNode;
 use bdk_wallet::bitcoin::taproot::NodeInfo as BdkNodeInfo;
 use bdk_wallet::bitcoin::taproot::TapTree as BdkTapTree;
@@ -51,6 +50,16 @@ use std::sync::{Arc, Mutex};
 
 pub type DescriptorType = bdk_wallet::miniscript::descriptor::DescriptorType;
 pub type Network = bdk_wallet::bitcoin::Network;
+pub(crate) type NetworkKind = bdk_wallet::bitcoin::NetworkKind;
+
+/// What kind of network we are on.
+#[uniffi::remote(Enum)]
+pub enum NetworkKind {
+    /// The Bitcoin mainnet network.
+    Main,
+    /// Some kind of testnet network.
+    Test,
+}
 
 /// A reference to an unspent output by TXID and output index.
 #[derive(Debug, Clone, Eq, PartialEq, std::hash::Hash, uniffi:: Record)]

--- a/bdk-ffi/src/descriptor.rs
+++ b/bdk-ffi/src/descriptor.rs
@@ -1,6 +1,6 @@
-use crate::bitcoin::Address;
 use crate::bitcoin::DescriptorId;
 use crate::bitcoin::DescriptorType;
+use crate::bitcoin::{Address, NetworkKind};
 use crate::error::DescriptorError;
 use crate::error::MiniscriptError;
 use crate::keys::DescriptorPublicKey;
@@ -36,10 +36,10 @@ pub struct Descriptor {
 impl Descriptor {
     /// Parse a string as a descriptor for the given network.
     #[uniffi::constructor]
-    pub fn new(descriptor: String, network: Network) -> Result<Self, DescriptorError> {
+    pub fn new(descriptor: String, network_kind: NetworkKind) -> Result<Self, DescriptorError> {
         let secp = Secp256k1::new();
         let (extended_descriptor, key_map) =
-            descriptor.into_wallet_descriptor(&secp, network.into())?;
+            descriptor.into_wallet_descriptor(&secp, network_kind)?;
         Ok(Self {
             extended_descriptor,
             key_map,
@@ -51,7 +51,7 @@ impl Descriptor {
     pub fn new_bip44(
         secret_key: &DescriptorSecretKey,
         keychain_kind: KeychainKind,
-        network: Network,
+        network_kind: NetworkKind,
     ) -> Self {
         let derivable_key = &secret_key.0;
 
@@ -62,7 +62,7 @@ impl Descriptor {
             BdkDescriptorSecretKey::XPrv(descriptor_x_key) => {
                 let derivable_key = descriptor_x_key.xkey;
                 let (extended_descriptor, key_map, _) = Bip44(derivable_key, keychain_kind)
-                    .build(network.into())
+                    .build(network_kind)
                     .unwrap();
                 Self {
                     extended_descriptor,
@@ -81,7 +81,7 @@ impl Descriptor {
         public_key: &DescriptorPublicKey,
         fingerprint: String,
         keychain_kind: KeychainKind,
-        network: Network,
+        network_kind: NetworkKind,
     ) -> Result<Self, DescriptorError> {
         let fingerprint = Fingerprint::from_str(fingerprint.as_str()).map_err(|error| {
             DescriptorError::Bip32 {
@@ -98,7 +98,7 @@ impl Descriptor {
                 let derivable_key = descriptor_x_key.xkey;
                 let (extended_descriptor, key_map, _) =
                     Bip44Public(derivable_key, fingerprint, keychain_kind)
-                        .build(network.into())
+                        .build(network_kind)
                         .map_err(DescriptorError::from)?;
 
                 Ok(Self {
@@ -117,7 +117,7 @@ impl Descriptor {
     pub fn new_bip49(
         secret_key: &DescriptorSecretKey,
         keychain_kind: KeychainKind,
-        network: Network,
+        network_kind: NetworkKind,
     ) -> Self {
         let derivable_key = &secret_key.0;
 
@@ -128,7 +128,7 @@ impl Descriptor {
             BdkDescriptorSecretKey::XPrv(descriptor_x_key) => {
                 let derivable_key = descriptor_x_key.xkey;
                 let (extended_descriptor, key_map, _) = Bip49(derivable_key, keychain_kind)
-                    .build(network.into())
+                    .build(network_kind)
                     .unwrap();
                 Self {
                     extended_descriptor,
@@ -147,7 +147,7 @@ impl Descriptor {
         public_key: &DescriptorPublicKey,
         fingerprint: String,
         keychain_kind: KeychainKind,
-        network: Network,
+        network_kind: NetworkKind,
     ) -> Result<Self, DescriptorError> {
         let fingerprint = Fingerprint::from_str(fingerprint.as_str()).map_err(|error| {
             DescriptorError::Bip32 {
@@ -164,7 +164,7 @@ impl Descriptor {
                 let derivable_key = descriptor_x_key.xkey;
                 let (extended_descriptor, key_map, _) =
                     Bip49Public(derivable_key, fingerprint, keychain_kind)
-                        .build(network.into())
+                        .build(network_kind)
                         .map_err(DescriptorError::from)?;
 
                 Ok(Self {
@@ -183,7 +183,7 @@ impl Descriptor {
     pub fn new_bip84(
         secret_key: &DescriptorSecretKey,
         keychain_kind: KeychainKind,
-        network: Network,
+        network_kind: NetworkKind,
     ) -> Self {
         let derivable_key = &secret_key.0;
 
@@ -194,7 +194,7 @@ impl Descriptor {
             BdkDescriptorSecretKey::XPrv(descriptor_x_key) => {
                 let derivable_key = descriptor_x_key.xkey;
                 let (extended_descriptor, key_map, _) = Bip84(derivable_key, keychain_kind)
-                    .build(network.into())
+                    .build(network_kind)
                     .unwrap();
                 Self {
                     extended_descriptor,
@@ -213,7 +213,7 @@ impl Descriptor {
         public_key: &DescriptorPublicKey,
         fingerprint: String,
         keychain_kind: KeychainKind,
-        network: Network,
+        network_kind: NetworkKind,
     ) -> Result<Self, DescriptorError> {
         let fingerprint = Fingerprint::from_str(fingerprint.as_str()).map_err(|error| {
             DescriptorError::Bip32 {
@@ -230,7 +230,7 @@ impl Descriptor {
                 let derivable_key = descriptor_x_key.xkey;
                 let (extended_descriptor, key_map, _) =
                     Bip84Public(derivable_key, fingerprint, keychain_kind)
-                        .build(network.into())
+                        .build(network_kind)
                         .map_err(DescriptorError::from)?;
 
                 Ok(Self {
@@ -249,7 +249,7 @@ impl Descriptor {
     pub fn new_bip86(
         secret_key: &DescriptorSecretKey,
         keychain_kind: KeychainKind,
-        network: Network,
+        network_kind: NetworkKind,
     ) -> Self {
         let derivable_key = &secret_key.0;
 
@@ -260,7 +260,7 @@ impl Descriptor {
             BdkDescriptorSecretKey::XPrv(descriptor_x_key) => {
                 let derivable_key = descriptor_x_key.xkey;
                 let (extended_descriptor, key_map, _) = Bip86(derivable_key, keychain_kind)
-                    .build(network.into())
+                    .build(network_kind)
                     .unwrap();
                 Self {
                     extended_descriptor,
@@ -279,7 +279,7 @@ impl Descriptor {
         public_key: &DescriptorPublicKey,
         fingerprint: String,
         keychain_kind: KeychainKind,
-        network: Network,
+        network_kind: NetworkKind,
     ) -> Result<Self, DescriptorError> {
         let fingerprint = Fingerprint::from_str(fingerprint.as_str()).map_err(|error| {
             DescriptorError::Bip32 {
@@ -296,7 +296,7 @@ impl Descriptor {
                 let derivable_key = descriptor_x_key.xkey;
                 let (extended_descriptor, key_map, _) =
                     Bip86Public(derivable_key, fingerprint, keychain_kind)
-                        .build(network.into())
+                        .build(network_kind)
                         .map_err(DescriptorError::from)?;
 
                 Ok(Self {

--- a/bdk-ffi/src/keys.rs
+++ b/bdk-ffi/src/keys.rs
@@ -1,4 +1,4 @@
-use crate::bitcoin::ChildNumber;
+use crate::bitcoin::{ChildNumber, NetworkKind};
 use crate::error::{Bip32Error, Bip39Error, DescriptorKeyError};
 use crate::{impl_from_core_type, impl_into_core_type};
 
@@ -7,7 +7,6 @@ use bdk_wallet::bitcoin::bip32::DerivationPath as BdkDerivationPath;
 use bdk_wallet::bitcoin::key::Secp256k1;
 use bdk_wallet::bitcoin::secp256k1::rand;
 use bdk_wallet::bitcoin::secp256k1::rand::Rng;
-use bdk_wallet::bitcoin::Network;
 use bdk_wallet::keys::bip39::WordCount;
 use bdk_wallet::keys::bip39::{Language, Mnemonic as BdkMnemonic};
 use bdk_wallet::keys::{
@@ -142,12 +141,12 @@ pub struct DescriptorSecretKey(pub(crate) BdkDescriptorSecretKey);
 impl DescriptorSecretKey {
     /// Construct a secret descriptor using a mnemonic.
     #[uniffi::constructor]
-    pub fn new(network: Network, mnemonic: &Mnemonic, password: Option<String>) -> Self {
+    pub fn new(network_kind: NetworkKind, mnemonic: &Mnemonic, password: Option<String>) -> Self {
         let mnemonic = mnemonic.0.clone();
         let xkey: ExtendedKey = (mnemonic, password).into_extended_key().unwrap();
         let descriptor_secret_key = BdkDescriptorSecretKey::XPrv(DescriptorXKey {
             origin: None,
-            xkey: xkey.into_xprv(network.into()).unwrap(),
+            xkey: xkey.into_xprv(network_kind).unwrap(),
             derivation_path: BdkDerivationPath::master(),
             wildcard: Wildcard::Unhardened,
         });

--- a/bdk-ffi/src/tests/descriptor.rs
+++ b/bdk-ffi/src/tests/descriptor.rs
@@ -1,4 +1,4 @@
-use crate::bitcoin::Network;
+use crate::bitcoin::{Network, NetworkKind};
 use crate::descriptor::Descriptor;
 use crate::error::DescriptorError;
 use crate::keys::{DerivationPath, DescriptorSecretKey, Mnemonic};
@@ -8,7 +8,7 @@ use assert_matches::assert_matches;
 
 fn get_descriptor_secret_key() -> DescriptorSecretKey {
     let mnemonic = Mnemonic::from_string("chaos fabric time speed sponsor all flat solution wisdom trophy crack object robot pave observe combine where aware bench orient secret primary cable detect".to_string()).unwrap();
-    DescriptorSecretKey::new(Network::Testnet, &mnemonic, None)
+    DescriptorSecretKey::new(NetworkKind::Test, &mnemonic, None)
 }
 
 #[test]
@@ -36,40 +36,40 @@ fn test_descriptor_templates() {
         .as_public();
     // Public 86: [d1d04177/86'/1'/0']tpubDCJzjbcGbdEfXMWaL6QmgVmuSfXkrue7m2YNoacWwyc7a2XjXaKojRqNEbo41CFL3PyYmKdhwg2fkGpLX4SQCbQjCGxAkWHJTw9WEeenrJb/*
     let template_private_44 =
-        Descriptor::new_bip44(&master, KeychainKind::External, Network::Testnet);
+        Descriptor::new_bip44(&master, KeychainKind::External, NetworkKind::Test);
     let template_private_49 =
-        Descriptor::new_bip49(&master, KeychainKind::External, Network::Testnet);
+        Descriptor::new_bip49(&master, KeychainKind::External, NetworkKind::Test);
     let template_private_84 =
-        Descriptor::new_bip84(&master, KeychainKind::External, Network::Testnet);
+        Descriptor::new_bip84(&master, KeychainKind::External, NetworkKind::Test);
     let template_private_86 =
-        Descriptor::new_bip86(&master, KeychainKind::External, Network::Testnet);
+        Descriptor::new_bip86(&master, KeychainKind::External, NetworkKind::Test);
     // the extended public keys are the same when creating them manually as they are with the templates
     let template_public_44 = Descriptor::new_bip44_public(
         &handmade_public_44,
         "d1d04177".to_string(),
         KeychainKind::External,
-        Network::Testnet,
+        NetworkKind::Test,
     )
     .unwrap();
     let template_public_49 = Descriptor::new_bip49_public(
         &handmade_public_49,
         "d1d04177".to_string(),
         KeychainKind::External,
-        Network::Testnet,
+        NetworkKind::Test,
     )
     .unwrap();
     let template_public_84 = Descriptor::new_bip84_public(
         &handmade_public_84,
         "d1d04177".to_string(),
         KeychainKind::External,
-        Network::Testnet,
+        NetworkKind::Test,
     )
     .unwrap();
     let template_public_86 = Descriptor::new_bip86_public(
         &handmade_public_86,
         "d1d04177".to_string(),
         KeychainKind::External,
-        Network::Testnet,
+        NetworkKind::Test,
     )
     .unwrap();
     // when using a public key, both to_string and to_string_private return the same string
@@ -109,8 +109,8 @@ fn test_descriptor_templates() {
 }
 #[test]
 fn test_descriptor_from_string() {
-    let descriptor1 = Descriptor::new("wpkh(tprv8hwWMmPE4BVNxGdVt3HhEERZhondQvodUY7Ajyseyhudr4WabJqWKWLr4Wi2r26CDaNCQhhxEftEaNzz7dPGhWuKFU4VULesmhEfZYyBXdE/0/*)".to_string(), Network::Testnet);
-    let descriptor2 = Descriptor::new("wpkh(tprv8hwWMmPE4BVNxGdVt3HhEERZhondQvodUY7Ajyseyhudr4WabJqWKWLr4Wi2r26CDaNCQhhxEftEaNzz7dPGhWuKFU4VULesmhEfZYyBXdE/0/*)".to_string(), Network::Bitcoin);
+    let descriptor1 = Descriptor::new("wpkh(tprv8hwWMmPE4BVNxGdVt3HhEERZhondQvodUY7Ajyseyhudr4WabJqWKWLr4Wi2r26CDaNCQhhxEftEaNzz7dPGhWuKFU4VULesmhEfZYyBXdE/0/*)".to_string(), NetworkKind::Test);
+    let descriptor2 = Descriptor::new("wpkh(tprv8hwWMmPE4BVNxGdVt3HhEERZhondQvodUY7Ajyseyhudr4WabJqWKWLr4Wi2r26CDaNCQhhxEftEaNzz7dPGhWuKFU4VULesmhEfZYyBXdE/0/*)".to_string(), NetworkKind::Main);
     // Creating a Descriptor using an extended key that doesn't match the network provided will throw a DescriptorError::Key with inner InvalidNetwork error
     assert!(descriptor1.is_ok());
     assert_matches!(descriptor2.unwrap_err(), DescriptorError::Key { .. });
@@ -128,7 +128,7 @@ fn test_new_bip84_public_invalid_fingerprint() {
         &public_84,
         "not-a-fingerprint".to_string(),
         KeychainKind::External,
-        Network::Testnet,
+        NetworkKind::Test,
     )
     .unwrap_err();
 
@@ -140,7 +140,7 @@ fn test_max_weight_to_satisfy() {
     // Test P2WPKH descriptor using standard test descriptor
     let descriptor = Descriptor::new(
         "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/1h/0/*)".to_string(),
-        Network::Testnet
+        NetworkKind::Test
     ).unwrap();
 
     let weight = descriptor.max_weight_to_satisfy().unwrap();
@@ -154,7 +154,7 @@ fn test_descriptor_derive_address() {
     let descriptor = Descriptor::new_bip84(
         &get_descriptor_secret_key(),
         KeychainKind::External,
-        Network::Testnet,
+        NetworkKind::Test,
     );
 
     let derived = descriptor
@@ -176,7 +176,7 @@ fn test_descriptor_derive_address() {
 fn test_descriptor_derive_address_multipath_error() {
     let descriptor = Descriptor::new(
         "wpkh([9a6a2580/84'/1'/0']tpubDDnGNapGEY6AZAdQbfRJgMg9fvz8pUBrLwvyvUqEgcUfgzM6zc2eVK4vY9x9L5FJWdX8WumXuLEDV5zDZnTfbn87vLe9XceCFwTu9so9Kks/<0;1>/*)".to_string(),
-        Network::Testnet,
+        NetworkKind::Test,
     )
     .expect("multipath descriptor parses");
 

--- a/bdk-ffi/src/tests/keys.rs
+++ b/bdk-ffi/src/tests/keys.rs
@@ -1,11 +1,11 @@
-use crate::bitcoin::Network;
+use crate::bitcoin::NetworkKind;
 use crate::error::DescriptorKeyError;
 use crate::keys::{DerivationPath, DescriptorPublicKey, DescriptorSecretKey, Mnemonic};
 use std::sync::Arc;
 
 fn get_inner() -> DescriptorSecretKey {
     let mnemonic = Mnemonic::from_string("chaos fabric time speed sponsor all flat solution wisdom trophy crack object robot pave observe combine where aware bench orient secret primary cable detect".to_string()).unwrap();
-    DescriptorSecretKey::new(Network::Testnet, &mnemonic, None)
+    DescriptorSecretKey::new(NetworkKind::Test, &mnemonic, None)
 }
 
 fn derive_dsk(

--- a/bdk-ffi/src/tests/tx_builder.rs
+++ b/bdk-ffi/src/tests/tx_builder.rs
@@ -1,4 +1,4 @@
-use crate::bitcoin::{Amount, Input, Network, OutPoint, Script, TxOut};
+use crate::bitcoin::{Amount, Input, Network, NetworkKind, OutPoint, Script, TxOut};
 use crate::descriptor::Descriptor;
 use crate::error::SighashParseError;
 use crate::esplora::EsploraClient;
@@ -72,8 +72,8 @@ fn create_and_sync_wallet() -> Wallet {
         "tprv8ZgxMBicQKsPeitVUz3s6cfyCECovNP7t82FaKPa4UKqV1kssWcXgLkMDjzDbgG9GWoza4pL7z727QitfzkiwX99E1Has3T3a1MKHvYWmQZ"
     );
     let wallet = Wallet::new(
-        Arc::new(Descriptor::new(external_descriptor, Network::Signet).unwrap()),
-        Arc::new(Descriptor::new(internal_descriptor, Network::Signet).unwrap()),
+        Arc::new(Descriptor::new(external_descriptor, NetworkKind::Test).unwrap()),
+        Arc::new(Descriptor::new(internal_descriptor, NetworkKind::Test).unwrap()),
         Network::Signet,
         Arc::new(Persister::new_in_memory().unwrap()),
         25,

--- a/bdk-ffi/src/tests/wallet.rs
+++ b/bdk-ffi/src/tests/wallet.rs
@@ -1,4 +1,4 @@
-use crate::bitcoin::Network;
+use crate::bitcoin::{Network, NetworkKind};
 use crate::descriptor::Descriptor;
 use crate::store::Persister;
 use crate::wallet::Wallet;
@@ -13,15 +13,15 @@ const TWO_PATH_DESCRIPTOR: &str = "wpkh([9a6a2580/84'/1'/0']tpubDDnGNapGEY6AZAdQ
 const EXPECTED_FIRST_ADDRESS: &str = "tb1qhjys9wxlfykmte7ftryptx975uqgd6kcm6a7z4";
 
 fn external_descriptor() -> Arc<Descriptor> {
-    Arc::new(Descriptor::new(EXTERNAL_DESCRIPTOR.to_string(), Network::Signet).unwrap())
+    Arc::new(Descriptor::new(EXTERNAL_DESCRIPTOR.to_string(), NetworkKind::Test).unwrap())
 }
 
 fn internal_descriptor() -> Arc<Descriptor> {
-    Arc::new(Descriptor::new(INTERNAL_DESCRIPTOR.to_string(), Network::Signet).unwrap())
+    Arc::new(Descriptor::new(INTERNAL_DESCRIPTOR.to_string(), NetworkKind::Test).unwrap())
 }
 
 fn two_path_descriptor() -> Arc<Descriptor> {
-    Arc::new(Descriptor::new(TWO_PATH_DESCRIPTOR.to_string(), Network::Signet).unwrap())
+    Arc::new(Descriptor::new(TWO_PATH_DESCRIPTOR.to_string(), NetworkKind::Test).unwrap())
 }
 
 fn build_wallet() -> Wallet {

--- a/bdk-swift/Tests/BitcoinDevKitTests/OfflineDescriptorTests.swift
+++ b/bdk-swift/Tests/BitcoinDevKitTests/OfflineDescriptorTests.swift
@@ -5,14 +5,14 @@ final class OfflineDescriptorTests: XCTestCase {
     func testDescriptorBip86() throws {
         let mnemonic: Mnemonic = try Mnemonic.fromString(mnemonic: "space echo position wrist orient erupt relief museum myself grain wisdom tumble")
         let descriptorSecretKey: DescriptorSecretKey = DescriptorSecretKey(
-            network: Network.testnet,
+            networkKind: NetworkKind.test,
             mnemonic: mnemonic,
             password: nil
         )
         let descriptor: Descriptor = Descriptor.newBip86(
             secretKey: descriptorSecretKey,
             keychainKind: KeychainKind.external,
-            network: Network.testnet
+            networkKind: NetworkKind.test
         )
 
         XCTAssertEqual(descriptor.description, "tr([be1eec8f/86'/1'/0']tpubDCTtszwSxPx3tATqDrsSyqScPNnUChwQAVAkanuDUCJQESGBbkt68nXXKRDifYSDbeMa2Xg2euKbXaU3YphvGWftDE7ozRKPriT6vAo3xsc/0/*)#m7puekcx")

--- a/bdk-swift/Tests/BitcoinDevKitTests/OfflinePersistenceTests.swift
+++ b/bdk-swift/Tests/BitcoinDevKitTests/OfflinePersistenceTests.swift
@@ -3,12 +3,12 @@ import XCTest
 
 final class OfflinePersistenceTests: XCTestCase {
     private let descriptor = try! Descriptor(
-    descriptor: "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/0/*)", 
-    network: Network.signet
+        descriptor: "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/0/*)", 
+        networkKind: NetworkKind.test
     )
     private let changeDescriptor = try! Descriptor(
         descriptor: "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/1/*)", 
-        network: Network.signet
+        networkKind: NetworkKind.test
     )
     var dbFilePath: URL!
 
@@ -44,11 +44,11 @@ final class OfflinePersistenceTests: XCTestCase {
         
         let descriptorPub = try Descriptor(
             descriptor: "wpkh([9122d9e0/84'/1'/0']tpubDCYVtmaSaDzTxcgvoP5AHZNbZKZzrvoNH9KARep88vESc6MxRqAp4LmePc2eeGX6XUxBcdhAmkthWTDqygPz2wLAyHWisD299Lkdrj5egY6/0/*)#zpaanzgu",
-            network: Network.signet
+            networkKind: NetworkKind.test
         )
         let changeDescriptorPub = try Descriptor(
             descriptor: "wpkh([9122d9e0/84'/1'/0']tpubDCYVtmaSaDzTxcgvoP5AHZNbZKZzrvoNH9KARep88vESc6MxRqAp4LmePc2eeGX6XUxBcdhAmkthWTDqygPz2wLAyHWisD299Lkdrj5egY6/1/*)#n4cuwhcy",
-            network: Network.signet
+            networkKind: NetworkKind.test
         )
         
         let wallet = try Wallet.load(

--- a/bdk-swift/Tests/BitcoinDevKitTests/OfflineWalletTests.swift
+++ b/bdk-swift/Tests/BitcoinDevKitTests/OfflineWalletTests.swift
@@ -3,12 +3,12 @@ import XCTest
 
 final class OfflineWalletTests: XCTestCase {
     private let descriptor = try! Descriptor(
-    descriptor: "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/1h/0/*)", 
-    network: Network.signet
+        descriptor: "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/1h/0/*)", 
+        networkKind: NetworkKind.test
     )
     private let changeDescriptor = try! Descriptor(
         descriptor: "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/1h/1/*)", 
-        network: Network.signet
+        networkKind: NetworkKind.test
     )
     
     func testNewAddress() throws {


### PR DESCRIPTION
This PR exposes the `NetworkKind` type, mirroring changes in the bdk_wallet 3.0 API. At first glance it's not obvious if this new type is required/useful, but I see a few upsides to adding it:

1. Some types (`Descriptor` and keys for example) previously required a Network to construct, but this was hiding the fact that they only produce two types of descriptors/extended keys: main and test (all test networks use the same extended keys).
2. Places where Network is _really_ required become clearer (a wallet needs to know the network it operates on because the local_chain requires a specific genesis block).
3. If we're going to break the API for the 3.0 release, might as well bring it in now!
4. Note how it cleans up the tests in [DescriptorTest.kt](https://github.com/bitcoindevkit/bdk-ffi/blob/731a3860f7a973d25514d7e503623dfae8e05b99/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/DescriptorTest.kt#L16-L22) for example, and how it answers the [question here](https://github.com/bitcoindevkit/bdk-ffi/pull/965#discussion_r2906809014).

### Documentation

- [x] [`bitcoin`](https://docs.rs/bitcoin/latest/bitcoin/enum.NetworkKind.html)

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
* [x] I've added a changelog in the next release tracking issue (see [example](https://github.com/bitcoindevkit/bdk-ffi/issues/875))
* [x] I've linked the relevant upstream docs or specs above

#### New Features:

* [x] I've added tests for the new feature
* [x] I've added docs for the new feature
