### PR TITLE
feat: Add descriptor miniscript constructor method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - New `WildcardType` enum [#853]
 - New `DescriptorPublicKey::add_wildcard` method, which adds an unhardened wildcard to the derivation path of the descriptor [#853]
 - New `DescriptorSecretKey::add_wildcard(wildcard_type: WildcardType)` method, which adds a wildcard to the derivation path of the descriptor [#853]
+- Exposed `new_sh`, `new_wsh`,`new_bare` and `new_sh_wsh` methods on `Descriptor` type [#988]
 
 [#853]: https://github.com/bitcoindevkit/bdk-ffi/pull/853
 [#853]: https://github.com/bitcoindevkit/bdk-ffi/pull/945
@@ -32,6 +33,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 [#986]: https://github.com/bitcoindevkit/bdk-ffi/pull/971
 [#986]: https://github.com/bitcoindevkit/bdk-ffi/pull/973
 [#986]: https://github.com/bitcoindevkit/bdk-ffi/pull/986
+[#986]: https://github.com/bitcoindevkit/bdk-ffi/pull/988
 
 ## [v2.3.0]
 

--- a/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/DescriptorTest.kt
+++ b/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/DescriptorTest.kt
@@ -74,6 +74,69 @@ class DescriptorTest {
         assertEquals(newShWpkhDescriptor.descType(), DescriptorType.SH_WPKH)
     }
 
+    @Test
+    fun createMiniscriptDescriptors() {
+        val newShDescriptor = Descriptor.newSh("pk(02b4632d08485ff1df2db55b9dafd23347d1c47a457072a1e87be26896549a8737)")
+        val newWshDescriptor = Descriptor.newWsh("pk(02b4632d08485ff1df2db55b9dafd23347d1c47a457072a1e87be26896549a8737)")
+        val newShWshDescriptor = Descriptor.newShWsh("pk(02b4632d08485ff1df2db55b9dafd23347d1c47a457072a1e87be26896549a8737)")
+        val newBareDescriptor = Descriptor.newBare("pk(02b4632d08485ff1df2db55b9dafd23347d1c47a457072a1e87be26896549a8737)")
+
+        assertEquals(newShDescriptor.descType(), DescriptorType.SH)
+        assertEquals(newWshDescriptor.descType(), DescriptorType.WSH)
+        assertEquals(newShWshDescriptor.descType(), DescriptorType.SH_WSH)
+        assertEquals(newBareDescriptor.descType(), DescriptorType.BARE)
+    }
+
+    @Test
+    fun miniscriptConstructorsRejectInvalidExpressions() {
+        val invalid = "not_a_valid_miniscript"
+
+        assertFailsWith<DescriptorException.Miniscript> { Descriptor.newWsh(invalid) }
+        assertFailsWith<DescriptorException.Miniscript> { Descriptor.newSh(invalid) }
+        assertFailsWith<DescriptorException.Miniscript> { Descriptor.newShWsh(invalid) }
+        assertFailsWith<DescriptorException.Miniscript> { Descriptor.newBare(invalid) }
+    }
+
+    // BareCtx only allows pk(), pkh(), and multi(k<=3,...) at the top level. A timelock
+    // conjunction is valid miniscript for new_wsh but is rejected by new_bare.
+    @Test
+    fun notAllMiniscriptsWorkEverywhere() {
+        val compressedPk = "02b4632d08485ff1df2db55b9dafd23347d1c47a457072a1e87be26896549a8737"
+        val timelockConjunction = "and_v(v:pk($compressedPk),after(1000))"
+
+        // println("Complex miniscript: $timelockConjunction")
+        // println("Resulting descriptor: ${Descriptor.newWsh(timelockConjunction)}")
+
+        // Can do
+        Descriptor.newSh(timelockConjunction)
+        Descriptor.newWsh(timelockConjunction)
+
+        // No can do
+        assertFailsWith<DescriptorException.Miniscript> {
+            Descriptor.newBare(timelockConjunction)
+            Descriptor.newWpkh(timelockConjunction)
+            Descriptor.newWsh(timelockConjunction)
+            Descriptor.newPkh(timelockConjunction)
+        }
+    }
+
+    // Segwitv0 (new_wsh) requires all keys to be compressed. An uncompressed key is valid
+    // in Legacy context (new_sh) but rejected by new_wsh.
+    @Test
+    fun newWshRejectsUncompressedKey() {
+        // Satoshi's genesis block public key — a well-known uncompressed key.
+        val uncompressedPk = "04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5f"
+        val expression = "pk($uncompressedPk)"
+
+        // Can do
+        Descriptor.newSh(expression)
+
+        // No can do
+        assertFailsWith<DescriptorException.Miniscript> {
+            Descriptor.newWsh(expression)
+        }
+    }
+
     // Cannot create addr() descriptor.
     @Test
     fun cannotCreateAddrDescriptor() {

--- a/bdk-ffi/src/descriptor.rs
+++ b/bdk-ffi/src/descriptor.rs
@@ -15,6 +15,7 @@ use bdk_wallet::descriptor::{ExtendedDescriptor, IntoWalletDescriptor};
 use bdk_wallet::keys::DescriptorPublicKey as BdkDescriptorPublicKey;
 use bdk_wallet::keys::{DescriptorSecretKey as BdkDescriptorSecretKey, KeyMap};
 use bdk_wallet::miniscript::descriptor::ConversionError;
+use bdk_wallet::miniscript::Miniscript as BDKMiniscript;
 use bdk_wallet::template::{
     Bip44, Bip44Public, Bip49, Bip49Public, Bip84, Bip84Public, Bip86, Bip86Public,
     DescriptorTemplate,
@@ -474,6 +475,125 @@ impl Descriptor {
                 })
             }
         };
+        let extended_descriptor = ExtendedDescriptor::from(miniscript_descriptor);
+
+        Ok(Self {
+            extended_descriptor,
+            key_map: KeyMap::new(),
+        })
+    }
+
+    /// Create a new wsh descriptor from witness script Errors when miniscript exceeds resource limits
+    /// under p2sh context or does not type check at the top level
+    #[uniffi::constructor]
+    pub fn new_wsh(mini_script: String) -> Result<Self, DescriptorError> {
+        let parsed_miniscript = match BDKMiniscript::from_str(&mini_script) {
+            Ok(miniscript) => miniscript,
+            Err(e) => {
+                return Err(DescriptorError::Miniscript {
+                    error_message: e.to_string(),
+                });
+            }
+        };
+
+        let miniscript_descriptor =
+            match bdk_wallet::miniscript::Descriptor::new_wsh(parsed_miniscript) {
+                Ok(descriptor) => descriptor,
+                Err(e) => {
+                    return Err(DescriptorError::Miniscript {
+                        error_message: e.to_string(),
+                    })
+                }
+            };
+        let extended_descriptor = ExtendedDescriptor::from(miniscript_descriptor);
+
+        Ok(Self {
+            extended_descriptor,
+            key_map: KeyMap::new(),
+        })
+    }
+
+    /// Create a new sh wrapped wsh descriptor with witness script Errors when miniscript exceeds resource limits
+    /// under wsh context or does not type check at the top level
+    #[uniffi::constructor]
+    pub fn new_sh_wsh(mini_script: String) -> Result<Self, DescriptorError> {
+        let parsed_miniscript = match BDKMiniscript::from_str(&mini_script) {
+            Ok(miniscript) => miniscript,
+            Err(e) => {
+                return Err(DescriptorError::Miniscript {
+                    error_message: e.to_string(),
+                });
+            }
+        };
+
+        let miniscript_descriptor =
+            match bdk_wallet::miniscript::Descriptor::new_sh_wsh(parsed_miniscript) {
+                Ok(descriptor) => descriptor,
+                Err(e) => {
+                    return Err(DescriptorError::Miniscript {
+                        error_message: e.to_string(),
+                    })
+                }
+            };
+        let extended_descriptor = ExtendedDescriptor::from(miniscript_descriptor);
+
+        Ok(Self {
+            extended_descriptor,
+            key_map: KeyMap::new(),
+        })
+    }
+
+    /// Create a new sh for a given redeem script Errors when miniscript exceeds resource limits under p2sh context or does not type check at the top level
+    #[uniffi::constructor]
+    pub fn new_sh(mini_script: String) -> Result<Self, DescriptorError> {
+        let parsed_miniscript = match BDKMiniscript::from_str(&mini_script) {
+            Ok(miniscript) => miniscript,
+            Err(e) => {
+                return Err(DescriptorError::Miniscript {
+                    error_message: e.to_string(),
+                });
+            }
+        };
+
+        let miniscript_descriptor =
+            match bdk_wallet::miniscript::Descriptor::new_sh(parsed_miniscript) {
+                Ok(descriptor) => descriptor,
+                Err(e) => {
+                    return Err(DescriptorError::Miniscript {
+                        error_message: e.to_string(),
+                    })
+                }
+            };
+        let extended_descriptor = ExtendedDescriptor::from(miniscript_descriptor);
+
+        Ok(Self {
+            extended_descriptor,
+            key_map: KeyMap::new(),
+        })
+    }
+
+    /// Create a new bare descriptor from witness script Errors when miniscript exceeds resource limits
+    /// under bare context or does not type check at the top level
+    #[uniffi::constructor]
+    pub fn new_bare(mini_script: String) -> Result<Self, DescriptorError> {
+        let parsed_miniscript = match BDKMiniscript::from_str(&mini_script) {
+            Ok(miniscript) => miniscript,
+            Err(e) => {
+                return Err(DescriptorError::Miniscript {
+                    error_message: e.to_string(),
+                });
+            }
+        };
+
+        let miniscript_descriptor =
+            match bdk_wallet::miniscript::Descriptor::new_bare(parsed_miniscript) {
+                Ok(descriptor) => descriptor,
+                Err(e) => {
+                    return Err(DescriptorError::Miniscript {
+                        error_message: e.to_string(),
+                    })
+                }
+            };
         let extended_descriptor = ExtendedDescriptor::from(miniscript_descriptor);
 
         Ok(Self {


### PR DESCRIPTION
<!-- Erase any parts of this template not applicable to your Pull Request. -->

### Description
This is the third part of #973. Here I am adding in all the methods that accept Miniscript as parameter. The last batch to be added will be [new_sh_with_wpkh](https://docs.rs/miniscript/12.3.5/miniscript/descriptor/enum.Descriptor.html#method.new_sh_with_wpkh), [new_sh_with_wsh](https://docs.rs/miniscript/12.3.5/miniscript/descriptor/enum.Descriptor.html#method.new_sh_with_wsh), and [new_tr](https://docs.rs/miniscript/12.3.5/miniscript/descriptor/enum.Descriptor.html#method.new_tr) I am testing these ones out and trying to find best why to implement them in a follow up PR.

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

### Notes to the reviewers
These method implementions are not much different from what we have in #973. The main difference is how we parse the string param. In #973 we do `BdkDescriptorPublicKey::from_str(pk)` as the param expects a publickey. In this PR we do `BDKMiniscript::from_str(&mini_script)` as the params we expect is miniscript.

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Documentation

<!-- Paste the canonical docs/spec for anything this PR wraps or updates. -->

- [ ] [`bdk_wallet`](https://docs.rs/bdk_wallet/latest/bdk_wallet/)
  <!-- Add a link below with the docs.rs page. -->
- [ ] [`bitcoin`](https://docs.rs/bitcoin/latest/bitcoin/index.html)
  <!-- Add a link below with the docs.rs page. -->
- [ ] [`uniffi`](https://github.com/mozilla/uniffi-rs) <!-- Add a link below with the version changelog or any other docs. -->
- [x] Other: <!-- Add a link below with additional references -->

- new_sh - https://docs.rs/miniscript/12.3.5/miniscript/descriptor/enum.Descriptor.html#method.new_sh
- new_wsh - https://docs.rs/miniscript/12.3.5/miniscript/descriptor/enum.Descriptor.html#method.new_wsh
- new_sh_wsh - https://docs.rs/miniscript/12.3.5/miniscript/descriptor/enum.Descriptor.html#method.new_sh_wsh
- new_bare - https://docs.rs/miniscript/12.3.5/miniscript/descriptor/enum.Descriptor.html#method.new_bare

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
* [ ] I've added a changelog in the next release tracking issue (see [example](https://github.com/bitcoindevkit/bdk-ffi/issues/875))
* [x] I've linked the relevant upstream docs or specs above

#### New Features:

* [x] I've added tests for the new feature
* [x] I've added docs for the new feature
