### PR TITLE
Changelog

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -42,24 +42,24 @@ just test
 
 9. - [ ] Update the Android and Swift libraries as per the _Part 2_ section above. Open a single PR on `master` for all of these changes called `Prepare language bindings libraries for 0.X release`. See [example PR here](https://github.com/bitcoindevkit/bdk-ffi/pull/315).
 10. - [ ] Create a new branch off of `master` called `release/<feature version>`, e.g. `release/1.2`
-11. - [ ] Update the bdk-android version from a `SNAPSHOT` version to a release version (`2.4.0-SNAPSHOT` -> `2.4.0` and the Rust library version in `Cargo.toml` from an alpha a release version (`2.4.0-alpha.0` -> `2.4.0`), and open a PR to the release branch that updates these versions.
-12. - [ ] Get a review and ACK and merge this PR on the release branch.
-13. - [ ] Create the tag for the release and make sure to add the changelog info to the tag (works better if you prepare the tag message on the side in a text editor). Push the tag to GitHub.
+11. - [ ] Generate release notes with GitHub's built-in release note generator, using the previous release tag as the previous tag and the release branch as the target. Review the generated notes and prepare the final changelog text on the side in a text editor.
+12. - [ ] Update the bdk-android version from a `SNAPSHOT` version to a release version (`2.4.0-SNAPSHOT` -> `2.4.0`), update the Rust library version in `Cargo.toml` from an alpha to a release version (`2.4.0-alpha.0` -> `2.4.0`), add the reviewed release notes to the changelog file, and open a PR to the release branch with these changes.
+13. - [ ] Get a review and ACK and merge this PR on the release branch.
+14. - [ ] Create the tag for the release and make sure to add the reviewed changelog info to the tag. Push the tag to GitHub.
 ```shell
 git tag v0.6.0 --sign --edit
 git push upstream v0.6.0
 ```
-14. - [ ] Trigger manual releases for both libraries (for Swift, go to the [bdk-swift](https://github.com/bitcoindevkit/bdk-swift) repository and trigger the workflow using `master`. Simply add the version number and tag name in the text fields when running the workflow manually. Note that the version number must not contain the `v`, i.e. `0.26.0`, but the tag will have it, i.e. `v0.26.0`). For Android, trigger the release workflow using the tag (not a branch).
-15. - [ ] Make sure the released libraries work and contain the artifacts you would expect.
-16. - [ ] Build the Rust API docs and publish them to the repo's GitHub Pages.
+15. - [ ] Trigger manual releases for both libraries (for Swift, go to the [bdk-swift](https://github.com/bitcoindevkit/bdk-swift) repository and trigger the workflow using `master`. Simply add the version number and tag name in the text fields when running the workflow manually. Note that the version number must not contain the `v`, i.e. `0.26.0`, but the tag will have it, i.e. `v0.26.0`). For Android, trigger the release workflow using the tag (not a branch).
+16. - [ ] Make sure the released libraries work and contain the artifacts you would expect.
+17. - [ ] Build the Rust API docs and publish them to the repo's GitHub Pages.
 ```shell
 cd bdk-ffi/
 just docs
 ```
-17. - [ ] Aggregate all the changelog notices from the PRs and add them to the changelog file. PR that.
 18. - [ ] Bump the version on master from `1.1.0-SNAPSHOT` to `1.2.0-SNAPSHOT` (Android) and `1.1.0-alpha.0` to `1.2.0-alpha.0` (Rust).
 19. - [ ] Apply changes to the release issue template if needed.
-20. - [ ] Make release on GitHub (generate auto release notes between the previous tag and the new one).
+20. - [ ] Make release on GitHub using the reviewed release notes.
 21. - [ ] Build API docs for Android locally and PR the website to the bitcoindevkit.org repo.
 22. - [ ] Post in the announcement channel.
 23. - [ ] Tweet about the new release!

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -20,6 +20,14 @@ of the PR were done in a specific way -->
 - [ ] [`uniffi`](https://github.com/mozilla/uniffi-rs) <!-- Add a link below with the version changelog or any other docs. -->
 - [ ] Other: <!-- Add a link below with additional references -->
 
+### Changelog
+
+<!-- Add exactly one changelog label to this PR:
+`changelog: added`, `changelog: changed`, `changelog: fixed`, `changelog: breaking`, or `changelog: none`.
+These labels map to the Keep a Changelog categories used by `CHANGELOG.md` where possible.
+GitHub generated release notes use the label plus the PR title to draft the changelog.
+-->
+
 ### Checklists
 
 #### All Submissions:
@@ -27,7 +35,7 @@ of the PR were done in a specific way -->
 * [ ] I've signed all my commits
 * [ ] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
 * [ ] I ran `cargo fmt` and `cargo clippy` before committing
-* [ ] I've added a changelog in the next release tracking issue (see [example](https://github.com/bitcoindevkit/bdk-ffi/issues/875))
+* [ ] I've added exactly one `changelog:*` label
 * [ ] I've linked the relevant upstream docs or specs above
 
 #### New Features:

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,20 @@
+changelog:
+  exclude:
+    labels:
+      - "changelog: none"
+  categories:
+    - title: "Breaking Changes"
+      labels:
+        - "changelog: breaking"
+    - title: "Added"
+      labels:
+        - "changelog: added"
+    - title: "Changed"
+      labels:
+        - "changelog: changed"
+    - title: "Fixed"
+      labels:
+        - "changelog: fixed"
+    - title: "Needs Label Review"
+      labels:
+        - "*"

--- a/.github/workflows/changelog-label.yaml
+++ b/.github/workflows/changelog-label.yaml
@@ -1,0 +1,58 @@
+name: Changelog Label
+
+# Enforces that every pull request declares how it should appear in release notes.
+# Repository branch protection should require this workflow before merging.
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - labeled
+      - unlabeled
+      - ready_for_review
+
+permissions: {}
+
+jobs:
+  check:
+    name: "Require changelog label"
+    runs-on: ubuntu-24.04
+    steps:
+      - name: "Check changelog label"
+        env:
+          LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          import sys
+
+          allowed = {
+              "changelog: added",
+              "changelog: changed",
+              "changelog: fixed",
+              "changelog: breaking",
+              "changelog: none",
+          }
+
+          labels = json.loads(os.environ["LABELS"])
+          changelog_labels = [
+              label for label in labels if label.startswith("changelog:")
+          ]
+
+          if len(changelog_labels) != 1:
+              print("Expected exactly one changelog label.")
+              print(f"Found: {changelog_labels}")
+              print(f"Allowed labels: {sorted(allowed)}")
+              sys.exit(1)
+
+          label = changelog_labels[0]
+          if label not in allowed:
+              print(f"Invalid changelog label: {label}")
+              print(f"Allowed labels: {sorted(allowed)}")
+              sys.exit(1)
+
+          print(f"Changelog label OK: {label}")
+          PY

--- a/DEVELOPMENT_CYCLE.md
+++ b/DEVELOPMENT_CYCLE.md
@@ -30,6 +30,14 @@ properly.
 To create a new release a release manager will create a new issue using a `Release` template and
 follow the template instructions.
 
+Pull requests declare changelog intent with exactly one `changelog:*` label. The labels map to
+[Keep a Changelog] categories where possible: use `changelog: added`, `changelog: changed`,
+`changelog: fixed`, or `changelog: breaking` for user-facing release notes, and
+`changelog: none` for changes that should not appear in the changelog. Release managers use
+GitHub's generated release notes, review the wording, and commit the final changelog update during
+the release.
+
 [used by the Rust language]: https://doc.rust-lang.org/book/appendix-07-nightly-rust.html
+[Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
 [Semantic Versioning]: https://semver.org/
 [`bdk`]: https://github.com/bitcoindevkit/bdk


### PR DESCRIPTION
<!-- Erase any parts of this template not applicable to your Pull Request. -->

### Description

## Summary

This PR changes changelog collection from manual changelog text to label based generated release notes.

The current process has manual changelog flow without enough enforcement: contributors still have to do extra work, release maintainers still have to reconstruct/review the release, and items can still be missed.

The goal of this PR is to make the process **_explicit but lighter_**:

- lower the amount contributors have to do: choose one label instead of writing changelog info
- lower the amount the release maintainer has to do: review generated release notes instead of reconstructing changes manually
- prevent changelog worthy changes from being missed: require every PR to explicitly declare its changelog impact

Instead of asking contributors to write changelog in PRs or release issues, each PR gets exactly one `changelog:*` label. CI enforces that a label is present. At release time, GitHub uses those labels to generate grouped release notes, which the release maintainer reviews and copies into `CHANGELOG.md`.

## Flow

PR opened/updated
-> contributor adds exactly one `changelog:*` label
-> CI verifies exactly one valid changelog label exists
-> PR merges without touching `CHANGELOG.md`
-> release manager creates the release branch
-> GitHub generates release notes from previous tag to release branch, grouped by label
-> release manager reviews/edits the generated notes
-> release manager opens the release PR with version bumps and the final `CHANGELOG.md` update
-> release is tagged using the reviewed changelog text

## Labels

The labels map to Keep a Changelog categories where possible:

- `changelog: added`
- `changelog: changed`
- `changelog: fixed`
- `changelog: breaking`
- `changelog: none`

`changelog: none` is intentional. It means “reviewed for changelog impact; intentionally omitted,” which is better than absence meaning “maybe someone forgot.”

`changelog: breaking` is not a Keep a Changelog category, but it keeps API breaking binding changes visible during release review. The release maintainer can still edit the final wording/section before committing `CHANGELOG.md`.

## Setup After Merge

- Create the five repository labels listed above.
- Mark the `Changelog Label / Require changelog label` check as required in branch protection/rulesets.

## Tradeoffs

This means `CHANGELOG.md` is not continuously updated on every PR. Instead it's updated during release preparation after GitHub generates grouped release notes. The benefit is less contributor friction while still preventing changelog worthy PRs from being forgotten.

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Documentation

<!-- Paste the canonical docs/spec for anything this PR wraps or updates. -->

- [ ] [`bdk_wallet`](https://docs.rs/bdk_wallet/latest/bdk_wallet/)
  <!-- Add a link below with the docs.rs page. -->
- [ ] [`bitcoin`](https://docs.rs/bitcoin/latest/bitcoin/index.html)
  <!-- Add a link below with the docs.rs page. -->
- [ ] [`uniffi`](https://github.com/mozilla/uniffi-rs) <!-- Add a link below with the version changelog or any other docs. -->
- [ ] Other: <!-- Add a link below with additional references -->

### Checklists

#### All Submissions:

* [ ] I've signed all my commits
* [ ] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [ ] I ran `cargo fmt` and `cargo clippy` before committing
* [ ] I've added a changelog in the next release tracking issue (see [example](https://github.com/bitcoindevkit/bdk-ffi/issues/875))
* [ ] I've linked the relevant upstream docs or specs above

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
