### PR TITLE
Update `bdk_kyoto` to `0.17.0`

### DIFF
--- a/bdk-ffi/Cargo.lock
+++ b/bdk-ffi/Cargo.lock
@@ -176,9 +176,9 @@ dependencies = [
 
 [[package]]
 name = "bdk_kyoto"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa6765bbb7d82c0b99ddd13d583b1157137b9e6a6ba3593bbbf75897599f3895"
+checksum = "346c1d502ee4613cf2201db9c3b93a2317772d8eaa372114f34bf5f374be94fd"
 dependencies = [
  "bdk_wallet",
  "bip157",
@@ -207,9 +207,9 @@ checksum = "32637268377fc7b10a8c6d51de3e7fba1ce5dd371a96e342b34e6078db558e7f"
 
 [[package]]
 name = "bip157"
-version = "0.4.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8af7987396c76633777e335345347395cd383b46bd95c1534691ab717859482e"
+checksum = "b0baddc6c57202ec7bb76d2232aa243f8f529c4450bb873d55349f4d55ce94a2"
 dependencies = [
  "bip324",
  "bitcoin",

--- a/bdk-ffi/Cargo.toml
+++ b/bdk-ffi/Cargo.toml
@@ -18,7 +18,7 @@ path = "uniffi-bindgen.rs"
 bdk_wallet = { version = "=3.0.0", features = ["all-keys", "keys-bip39", "rusqlite"] }
 bdk_esplora = { version = "0.22.1", default-features = false, features = ["std", "blocking", "blocking-https-rustls"] }
 bdk_electrum = { version = "0.23.2", default-features = false, features = ["use-rustls-ring"] }
-bdk_kyoto = { version = "0.16.0" }
+bdk_kyoto = { version = "0.17.0" }
 
 uniffi = { version = "=0.30.0", features = ["cli"]}
 thiserror = "2.0.17"

--- a/bdk-ffi/src/kyoto.rs
+++ b/bdk-ffi/src/kyoto.rs
@@ -1,3 +1,4 @@
+use bdk_kyoto::bip157;
 use bdk_kyoto::bip157::lookup_host;
 use bdk_kyoto::bip157::tokio;
 use bdk_kyoto::bip157::AddrV2;
@@ -6,7 +7,7 @@ use bdk_kyoto::bip157::Node;
 use bdk_kyoto::bip157::ServiceFlags;
 use bdk_kyoto::builder::Builder as BDKCbfBuilder;
 use bdk_kyoto::builder::BuilderExt;
-use bdk_kyoto::HeaderCheckpoint;
+use bdk_kyoto::HashCheckpoint;
 use bdk_kyoto::Receiver;
 use bdk_kyoto::RejectReason;
 use bdk_kyoto::Requester;
@@ -196,25 +197,25 @@ impl CbfBuilder {
                 if !matches!(network, Network::Bitcoin) {
                     bdk_kyoto::ScanType::Recovery {
                         used_script_index,
-                        checkpoint: HeaderCheckpoint::from_genesis(network),
+                        checkpoint: HashCheckpoint::from_genesis(network),
                     }
                 } else {
                     match checkpoint {
                         RecoveryPoint::GenesisBlock => bdk_kyoto::ScanType::Recovery {
                             used_script_index,
-                            checkpoint: HeaderCheckpoint::from_genesis(wallet.network()),
+                            checkpoint: HashCheckpoint::from_genesis(wallet.network()),
                         },
                         RecoveryPoint::SegwitActivation => bdk_kyoto::ScanType::Recovery {
                             used_script_index,
-                            checkpoint: HeaderCheckpoint::segwit_activation(),
+                            checkpoint: HashCheckpoint::segwit_activation(),
                         },
                         RecoveryPoint::TaprootActivation => bdk_kyoto::ScanType::Recovery {
                             used_script_index,
-                            checkpoint: HeaderCheckpoint::taproot_activation(),
+                            checkpoint: HashCheckpoint::taproot_activation(),
                         },
                         RecoveryPoint::Other { birthday } => bdk_kyoto::ScanType::Recovery {
                             used_script_index,
-                            checkpoint: HeaderCheckpoint::new(birthday.height, birthday.hash.0),
+                            checkpoint: HashCheckpoint::new(birthday.height, birthday.hash.0),
                         },
                     }
                 }
@@ -302,9 +303,9 @@ impl CbfClient {
 
     /// Broadcast a transaction to the network, erroring if the node has stopped running.
     pub async fn broadcast(&self, transaction: &Transaction) -> Result<Arc<Wtxid>, CbfError> {
-        let tx = transaction.into();
+        let tx: bip157::Transaction = transaction.into();
         self.sender
-            .broadcast_tx(tx)
+            .submit_package(tx)
             .await
             .map_err(From::from)
             .map(|wtxid| Arc::new(Wtxid(wtxid)))


### PR DESCRIPTION
With the release of `bitcoin = 0.32.9` there was a backport that unexplainably broke the P2P layer of Kyoto. This fixes the `bitcoin` version at `0.32.8` in the meantime while I investigate the behavior.
