### PR TITLE
Post release fixes

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -8,15 +8,15 @@ assignees: ""
 
 ## Part 1: Bump BDK Rust Version
 
-1. - [ ] Open a PR with an update to `Cargo.toml` to the new bdk release candidate and ensure all CI workflows run correctly. Fix errors if necessary.
-2. - [ ] Once the new bdk release is out, update the PR to replace the release candidate with the full release and merge.
+- [ ] Open a PR with an update to `Cargo.toml` to the new bdk release candidate and ensure all CI workflows run correctly. Fix errors if necessary.
+- [ ] Once the new bdk release is out, update the PR to replace the release candidate with the full release and merge.
 
 ## Part 2: Prepare Libraries for Release Branch
 
 ### _Android_
 
-3. - [ ] Delete the `target` directory in bdk-ffi and all `build` directories (in root and `lib`) in the bdk-android directory to make sure you're building the library from scratch.
-4. - [ ] Build the library and run the offline and live tests, and adjust them if necessary (note that you'll need an Android emulator running).
+- [ ] Delete the `target` directory in bdk-ffi and all `build` directories (in root and `lib`) in the bdk-android directory to make sure you're building the library from scratch.
+- [ ] Build the library and run the offline and live tests, and adjust them if necessary (note that you'll need an Android emulator running).
 ```shell
 # start an emulator prior to running the tests
 cd ./bdk-android/
@@ -24,42 +24,43 @@ just clean
 just build
 just test
 ```
-5. - [ ] Update the readme if necessary.
+- [ ] Update the readme if necessary.
 
 ### _Swift_
 
-6. - [ ] Delete the `target` directory in bdk-ffi.
-7. - [ ] Run all offline and live tests and adjust them if necessary.
+- [ ] Delete the `target` directory in bdk-ffi.
+- [ ] Run all offline and live tests and adjust them if necessary.
 ```shell
 cd ./bdk-swift/
 just clean
 just build
 just test
 ```
-8. - [ ] Update the readme if necessary.
+- [ ] Update the readme if necessary.
 
 ## Part 3: Release Workflow
 
-9. - [ ] Update the Android and Swift libraries as per the _Part 2_ section above. Open a single PR on `master` for all of these changes called `Prepare language bindings libraries for 0.X release`. See [example PR here](https://github.com/bitcoindevkit/bdk-ffi/pull/315).
-10. - [ ] Create a new branch off of `master` called `release/<feature version>`, e.g. `release/1.2`
-11. - [ ] Generate release notes with GitHub's built-in release note generator, using the previous release tag as the previous tag and the release branch as the target. Review the generated notes and prepare the final changelog text on the side in a text editor.
-12. - [ ] Update the bdk-android version from a `SNAPSHOT` version to a release version (`2.4.0-SNAPSHOT` -> `2.4.0`), update the Rust library version in `Cargo.toml` from an alpha to a release version (`2.4.0-alpha.0` -> `2.4.0`), add the reviewed release notes to the changelog file, and open a PR to the release branch with these changes.
-13. - [ ] Get a review and ACK and merge this PR on the release branch.
-14. - [ ] Create the tag for the release and make sure to add the reviewed changelog info to the tag. Push the tag to GitHub.
+- [ ] Update the Android and Swift libraries as per the _Part 2_ section above. Open a single PR on `master` for all of these changes called `Prepare language bindings libraries for 0.X release`. See [example PR here](https://github.com/bitcoindevkit/bdk-ffi/pull/315).
+- [ ] Create a new branch off of `master` called `release/<feature version>`, e.g. `release/1.2`
+- [ ] Generate release notes with GitHub's built-in release note generator, using the previous release tag as the previous tag and the release branch as the target. Review the generated notes and prepare the final changelog text on the side in a text editor.
+- [ ] Update the bdk-android version from a `SNAPSHOT` version to a release version (`2.4.0-SNAPSHOT` -> `2.4.0`), update the Rust library version in `Cargo.toml` from an alpha to a release version (`2.4.0-alpha.0` -> `2.4.0`), add the reviewed release notes to the changelog file, and open a PR to the release branch with these changes.
+- [ ] Get a review and ACK and merge this PR on the release branch.
+- [ ] Create the tag for the release and make sure to add the reviewed changelog info to the tag. Push the tag to GitHub.
 ```shell
 git tag v0.6.0 --sign --edit
 git push upstream v0.6.0
 ```
-15. - [ ] Trigger manual releases for both libraries (for Swift, go to the [bdk-swift](https://github.com/bitcoindevkit/bdk-swift) repository and trigger the workflow using `master`. Simply add the version number and tag name in the text fields when running the workflow manually. Note that the version number must not contain the `v`, i.e. `0.26.0`, but the tag will have it, i.e. `v0.26.0`). For Android, trigger the release workflow using the tag (not a branch).
-16. - [ ] Make sure the released libraries work and contain the artifacts you would expect.
-17. - [ ] Build the Rust API docs and publish them to the repo's GitHub Pages.
+- [ ] Update all downstream libraries (dart, rn, python, and jvm) to the given tag. This allows for everyone to test their own workflows, run their CI, etc.
+- [ ] Trigger releases for both libraries (for Swift, go to the [bdk-swift](https://github.com/bitcoindevkit/bdk-swift) repository and trigger the workflow using `master`. Simply add the version number and tag name in the text fields when running the workflow manually. Note that the version number must not contain the `v`, i.e. `0.26.0`, but the tag will have it, i.e. `v0.26.0`). For Android, trigger the release locally.
+- [ ] Make sure the released libraries work and contain the artifacts you would expect.
+- [ ] Build the Rust API docs and publish them to the repo's GitHub Pages.
 ```shell
 cd bdk-ffi/
 just docs
 ```
-18. - [ ] Bump the version on master from `1.1.0-SNAPSHOT` to `1.2.0-SNAPSHOT` (Android) and `1.1.0-alpha.0` to `1.2.0-alpha.0` (Rust).
-19. - [ ] Apply changes to the release issue template if needed.
-20. - [ ] Make release on GitHub using the reviewed release notes.
-21. - [ ] Build API docs for Android locally and PR the website to the bitcoindevkit.org repo.
-22. - [ ] Post in the announcement channel.
-23. - [ ] Tweet about the new release!
+- [ ] Bump the version on master from `1.1.0-SNAPSHOT` to `1.2.0-SNAPSHOT` (Android) and `1.1.0-alpha.0` to `1.2.0-alpha.0` (Rust).
+- [ ] Apply changes to the release issue template if needed.
+- [ ] Make release on GitHub using the reviewed release notes.
+- [ ] Build API docs for Android locally and PR the website to the bitcoindevkit.org repo.
+- [ ] Post in the announcement channel.
+- [ ] Tweet about the new release!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,20 @@ Changelog information can also be found in each release's git tag (which can be 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/bitcoindevkit/bdk-ffi/compare/v2.3.0...HEAD)
+## [Unreleased](https://github.com/bitcoindevkit/bdk-ffi/compare/v3.0.0...HEAD)
 
-## Breaking
+## [v3.0.0]
+
+This is version `3.0.0` of the BDK language bindings! This release uses the following Rust dependencies:
+
+- bdk_wallet `3.0.0`
+- bdk_electrum `0.24.0`
+- bdk_esplora `0.22.2`
+- bdk_kyoto `0.17.0`
+- bitcoin `0.32.8`
+- uniffi `0.30.0`
+
+### Breaking
 
 - The `DescriptorSecretKey::new` constructor does not produce an extended key with an automatic wildcard anymore [#853]
 - `Descriptor` and `DescriptorSecretKey` constructors now require a `NetworkKind` [#986]
@@ -26,14 +37,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - New `DescriptorPublicKey::add_wildcard` method, which adds an unhardened wildcard to the derivation path of the descriptor [#853]
 - New `DescriptorSecretKey::add_wildcard(wildcard_type: WildcardType)` method, which adds a wildcard to the derivation path of the descriptor [#853]
 - Exposed `new_sh`, `new_wsh`,`new_bare` and `new_sh_wsh` methods on `Descriptor` type [#988]
+- Add optional `timeout` and `retry` parameters to the Electrum client constructor [#1010]
 
 [#853]: https://github.com/bitcoindevkit/bdk-ffi/pull/853
-[#853]: https://github.com/bitcoindevkit/bdk-ffi/pull/945
-[#853]: https://github.com/bitcoindevkit/bdk-ffi/pull/949
-[#986]: https://github.com/bitcoindevkit/bdk-ffi/pull/971
-[#986]: https://github.com/bitcoindevkit/bdk-ffi/pull/973
+[#945]: https://github.com/bitcoindevkit/bdk-ffi/pull/945
+[#949]: https://github.com/bitcoindevkit/bdk-ffi/pull/949
+[#971]: https://github.com/bitcoindevkit/bdk-ffi/pull/971
+[#973]: https://github.com/bitcoindevkit/bdk-ffi/pull/973
 [#986]: https://github.com/bitcoindevkit/bdk-ffi/pull/986
-[#986]: https://github.com/bitcoindevkit/bdk-ffi/pull/988
+[#988]: https://github.com/bitcoindevkit/bdk-ffi/pull/988
+[#1010]: https://github.com/bitcoindevkit/bdk-ffi/pull/1010
 
 ## [v2.3.0]
 
@@ -48,24 +61,36 @@ This is version `2.3.0` of the BDK language bindings! This release uses the foll
 
 ### Added
 
-- Expose `Wallet::apply_update_events` which returns a `WalletEvent` type #908
-- Expose `Psbt::output` which returns a list of psbt `Output` #903
-- `Other` variant added to CBF `RecoveryPoint` to enable wallet birthdays #920
-- Implement `Display` trait for `FeeRate` #859
-- Expose `FeeRate::fee_vb` and `FeeRate::fee_wu` methods #859
-- Wallet API: expose `TxBuilder::only_witness_utxo` and `TxBuilder::add_foreign_utxo` #928
-- Esplora API: expose `get_block_by_hash` which returns a `Block` #936
-- Esplora API: expose `get_tip_hash` #930
-- Esplora API: expose `get_header_by_hash` #930
-- Esplora API: expose `get_address_txs` #930
-- Esplora API: expose `get_tx_no_opt` #930
-- Esplora API: expose `get_txid_at_block_index` #930
-- Esplora API: expose `get_merkle_proof` and `get_output_status` #942
-- Electrum API: expose `fetch_tx` #931
-- Electrum API: expose `block_header` #931
-- Electrum API: expose `block_headers_pop` #931
-- Electrum API: expose `relay_fee` and `transaction_get_raw` #938
-- DerivationPath: expose `child`, `extend`, and `to_u32_vec` #935
+- Expose `Wallet::apply_update_events` which returns a `WalletEvent` type [#908]
+- Expose `Psbt::output` which returns a list of psbt `Output` [#903]
+- `Other` variant added to CBF `RecoveryPoint` to enable wallet birthdays [#920]
+- Implement `Display` trait for `FeeRate` [#859]
+- Expose `FeeRate::fee_vb` and `FeeRate::fee_wu` methods [#859]
+- Wallet API: expose `TxBuilder::only_witness_utxo` and `TxBuilder::add_foreign_utxo` [#928]
+- Esplora API: expose `get_block_by_hash` which returns a `Block` [#936]
+- Esplora API: expose `get_tip_hash` [#930]
+- Esplora API: expose `get_header_by_hash` [#930]
+- Esplora API: expose `get_address_txs` [#930]
+- Esplora API: expose `get_tx_no_opt` [#930]
+- Esplora API: expose `get_txid_at_block_index` [#930]
+- Esplora API: expose `get_merkle_proof` and `get_output_status` [#942]
+- Electrum API: expose `fetch_tx` [#931]
+- Electrum API: expose `block_header` [#931]
+- Electrum API: expose `block_headers_pop` [#931]
+- Electrum API: expose `relay_fee` and `transaction_get_raw` [#938]
+- DerivationPath: expose `child`, `extend`, and `to_u32_vec` [#935]
+
+[#859]: https://github.com/bitcoindevkit/bdk-ffi/pull/859
+[#903]: https://github.com/bitcoindevkit/bdk-ffi/pull/903
+[#908]: https://github.com/bitcoindevkit/bdk-ffi/pull/908
+[#920]: https://github.com/bitcoindevkit/bdk-ffi/pull/920
+[#928]: https://github.com/bitcoindevkit/bdk-ffi/pull/928
+[#930]: https://github.com/bitcoindevkit/bdk-ffi/pull/930
+[#931]: https://github.com/bitcoindevkit/bdk-ffi/pull/931
+[#935]: https://github.com/bitcoindevkit/bdk-ffi/pull/935
+[#936]: https://github.com/bitcoindevkit/bdk-ffi/pull/936
+[#938]: https://github.com/bitcoindevkit/bdk-ffi/pull/938
+[#942]: https://github.com/bitcoindevkit/bdk-ffi/pull/942
 
 ## [v2.2.0]
 
@@ -298,6 +323,7 @@ This release updates the `bdk-ffi` libraries to the latest `bdk_wallet` `1.0.0-b
 [#623]: https://github.com/bitcoindevkit/bdk-ffi/pull/623
 [#625]: https://github.com/bitcoindevkit/bdk-ffi/pull/625
 [#629]: https://github.com/bitcoindevkit/bdk-ffi/pull/629
+[#630]: https://github.com/bitcoindevkit/bdk-ffi/pull/630
 [#645]: https://github.com/bitcoindevkit/bdk-ffi/pull/645
 
 ## [v1.0.0-beta.5]
@@ -617,6 +643,7 @@ This release has a number of new APIs, and adds support for Windows in bdk-jvm.
 [#154]: https://github.com/bitcoindevkit/bdk-ffi/pull/154
 [#184]: https://github.com/bitcoindevkit/bdk-ffi/pull/184
 [#185]: https://github.com/bitcoindevkit/bdk-ffi/pull/185
+[#186]: https://github.com/bitcoindevkit/bdk-ffi/pull/186
 [#193]: https://github.com/bitcoindevkit/bdk-ffi/pull/193
 
 ## [v0.8.0]
@@ -683,6 +710,7 @@ This release has a number of new APIs, and adds support for Windows in bdk-jvm.
 
 [BIP 0174]:https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki#encoding
 
+[v3.0.0]: https://github.com/bitcoindevkit/bdk-ffi/compare/v2.3.0...v3.0.0
 [v2.3.0]: https://github.com/bitcoindevkit/bdk-ffi/compare/v2.2.0...v2.3.0
 [v2.2.0]: https://github.com/bitcoindevkit/bdk-ffi/compare/v2.0.0...v2.2.0
 [v2.0.0]: https://github.com/bitcoindevkit/bdk-ffi/compare/v1.2.0...v2.0.0

--- a/bdk-android/README.md
+++ b/bdk-android/README.md
@@ -16,27 +16,12 @@ dependencies {
 }
 ```
 
-### Snapshot releases
-
-To use a snapshot release, specify the snapshot repository url in the `repositories` block and use the snapshot version in the `dependencies` block:
-```kotlin
-repositories {
-    maven("https://s01.oss.sonatype.org/content/repositories/snapshots/")
-}
-
-dependencies {
-    implementation("org.bitcoindevkit:bdk-android:<version-SNAPSHOT>")
-}
-```
-
 ### Example Projects
 
 * [Devkit Wallet](https://github.com/bitcoindevkit/devkit-wallet)
 * [Padawan Wallet](https://github.com/thunderbiscuit/padawan-wallet)
 
 ### How to build
-
-_Note that Kotlin version `2.1.10` or later is required to build the library._
 
 1. Clone this repository.
 ```shell
@@ -67,8 +52,7 @@ bash ./scripts/build-<your-local-architecture>.sh
 ## How to publish to your local Maven repo
 
 ```shell
-cd bdk-android
-./gradlew publishToMavenLocal
+just publish-local
 ```
 
 ## Known issues

--- a/bdk-android/justfile
+++ b/bdk-android/justfile
@@ -16,7 +16,7 @@ docs:
 [group("Repo")]
 [doc("Publish the library to your local Maven repository.")]
 publish-local:
-  ./gradlew publishToMavenLocal
+  ./gradlew publishToMavenLocal -P skipSigning
 
 [group("Build")]
 [doc("Build the library for given ARCH.")]

--- a/bdk-android/lib/build.gradle.kts
+++ b/bdk-android/lib/build.gradle.kts
@@ -16,7 +16,7 @@ version = "2.4.0-SNAPSHOT"
 
 android {
     namespace = group.toString()
-    compileSdk = 34
+    compileSdk = 36
 
     defaultConfig {
         minSdk = 24

--- a/bdk-android/lib/build.gradle.kts
+++ b/bdk-android/lib/build.gradle.kts
@@ -104,7 +104,9 @@ mavenPublishing {
     )
 
     publishToMavenCentral()
-    signAllPublications()
+    if (!providers.gradleProperty("skipSigning").isPresent) {
+        signAllPublications()
+    }
 }
 
 dokka {

--- a/bdk-android/lib/build.gradle.kts
+++ b/bdk-android/lib/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 }
 
 group = "org.bitcoindevkit"
-version = "2.4.0-SNAPSHOT"
+version = "3.1.0-SNAPSHOT"
 
 android {
     namespace = group.toString()

--- a/bdk-ffi/Cargo.lock
+++ b/bdk-ffi/Cargo.lock
@@ -141,7 +141,7 @@ dependencies = [
 
 [[package]]
 name = "bdk-ffi"
-version = "3.0.0-alpha.0"
+version = "3.1.0-alpha.0"
 dependencies = [
  "assert_matches",
  "bdk_electrum",

--- a/bdk-ffi/Cargo.toml
+++ b/bdk-ffi/Cargo.toml
@@ -16,7 +16,7 @@ path = "uniffi-bindgen.rs"
 
 [dependencies]
 bdk_wallet = { version = "=3.0.0", features = ["all-keys", "keys-bip39", "rusqlite"] }
-bdk_esplora = { version = "0.22.1", default-features = false, features = ["std", "blocking", "blocking-https-rustls"] }
+bdk_esplora = { version = "0.22.2", default-features = false, features = ["std", "blocking", "blocking-https-rustls"] }
 bdk_electrum = { version = "0.24.0", default-features = false, features = ["use-rustls-ring"] }
 bdk_kyoto = { version = "0.17.0" }
 

--- a/bdk-ffi/Cargo.toml
+++ b/bdk-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk-ffi"
-version = "3.0.0-alpha.0"
+version = "3.1.0-alpha.0"
 homepage = "https://bitcoindevkit.org"
 repository = "https://github.com/bitcoindevkit/bdk"
 edition = "2018"


### PR DESCRIPTION
I might bundle a few things in this one. Note that it should not be merged until we cut the official 3.0.0 release.

So far in this PR:

1. I modified the local publishing of the bdk-android artifact to not require signatures
2. I cherry-picked a fix of the changelog that cleans up our links
3. I finalized the changelog for the 3.0 release
4. I bumped the dev version of the library sitting on the master branch to `3.1.0-alpha.0`
