### PR TITLE
test: cover unsupported descriptor forms

### DIFF
--- a/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/DescriptorTest.kt
+++ b/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/DescriptorTest.kt
@@ -137,14 +137,18 @@ class DescriptorTest {
         }
     }
 
-    // Cannot create addr() descriptor.
     @Test
-    fun cannotCreateAddrDescriptor() {
-        assertFails {
-            val descriptor: Descriptor = Descriptor(
-                "addr(tb1qhjys9wxlfykmte7ftryptx975uqgd6kcm6a7z4)",
-                NetworkKind.TEST
-            )
+    fun unsupportedDescriptorFormsFail() {
+        val unsupported = listOf(
+            "addr(tb1qhjys9wxlfykmte7ftryptx975uqgd6kcm6a7z4)",
+            "raw(6a)",
+            "combo(0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798)"
+        )
+
+        unsupported.forEach { descriptor ->
+            assertFails {
+                Descriptor(descriptor, NetworkKind.TEST)
+            }
         }
     }
 

--- a/bdk-ffi/src/tests/descriptor.rs
+++ b/bdk-ffi/src/tests/descriptor.rs
@@ -117,6 +117,23 @@ fn test_descriptor_from_string() {
 }
 
 #[test]
+fn test_unsupported_descriptor_forms() {
+    let unsupported = [
+        "addr(tb1qhjys9wxlfykmte7ftryptx975uqgd6kcm6a7z4)",
+        "raw(6a)",
+        "combo(0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798)",
+    ];
+
+    for descriptor in unsupported {
+        assert!(
+            Descriptor::new(descriptor.to_string(), NetworkKind::Test).is_err(),
+            "{} should not be supported",
+            descriptor
+        );
+    }
+}
+
+#[test]
 fn test_new_bip84_public_invalid_fingerprint() {
     let master: DescriptorSecretKey = get_descriptor_secret_key();
     let public_84 = master


### PR DESCRIPTION
### Description

Adds explicit Rust and Android binding tests showing that unsupported descriptor forms are rejected by `Descriptor(...)`. Covers `addr()`, `raw()` and `combo()`.

Fixes #1002.

### Notes to the reviewers

Android test execution was not run locally because Java is not installed in this environment.

### Documentation

- [x] [`bdk_wallet`](https://docs.rs/bdk_wallet/latest/bdk_wallet/)
- [x] [`bitcoin`](https://docs.rs/bitcoin/latest/bitcoin/index.html)
- [x] [`uniffi`](https://github.com/mozilla/uniffi-rs)
- [x] Other: [BIP 380 output script descriptors](https://github.com/bitcoin/bips/blob/master/bip-0380.mediawiki)

### Changelog

`changelog: none`

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
* [ ] I've added exactly one `changelog:*` label
* [x] I've linked the relevant upstream docs or specs above

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [x] I've added tests to reproduce the issue which are now passing
* [x] I'm linking the issue being fixed by this PR
