### PR TITLE
Check Cargo.lock freshness

### DIFF
--- a/.github/workflows/rust-ci.yaml
+++ b/.github/workflows/rust-ci.yaml
@@ -32,6 +32,9 @@ jobs:
       - name: "Set up Rust"
         uses: actions-rust-lang/setup-rust-toolchain@v1
 
+      - name: "Check Cargo.lock"
+        run: cargo check --locked
+
       - name: "Build"
         run: cargo build
 

--- a/.github/workflows/rust-ci.yaml
+++ b/.github/workflows/rust-ci.yaml
@@ -33,7 +33,11 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: "Check Cargo.lock"
-        run: cargo check --locked
+        run: |
+          if ! cargo check --locked; then
+            echo "::error::Cargo.lock is stale. Run 'cargo generate-lockfile'."
+            exit 1
+          fi
 
       - name: "Build"
         run: cargo build


### PR DESCRIPTION
<!-- Erase any parts of this template not applicable to your Pull Request. -->

### Description

Adds a locked Cargo check to Rust CI so stale Cargo.lock changes fail clearly.

If the lockfile is out of sync, CI now suggests running `cargo check`.

### Notes to the reviewers

First commit adds `cargo check --locked` to Rust CI so stale `Cargo.lock` changes fail.

Second commit wraps the same command in a small shell block so CI can print a clearer hint to refresh the lockfile. (Totally dont have to do it this way so I can remove this commit if we want!)

### Documentation

<!-- Paste the canonical docs/spec for anything this PR wraps or updates. -->

- [ ] [`bdk_wallet`](https://docs.rs/bdk_wallet/latest/bdk_wallet/)
  <!-- Add a link below with the docs.rs page. -->
- [ ] [`bitcoin`](https://docs.rs/bitcoin/latest/bitcoin/index.html)
  <!-- Add a link below with the docs.rs page. -->
- [ ] [`uniffi`](https://github.com/mozilla/uniffi-rs) <!-- Add a link below with the version changelog or any other docs. -->
- [ ] Other: <!-- Add a link below with additional references -->

### Changelog

<!-- Add exactly one changelog label to this PR:
`changelog: added`, `changelog: changed`, `changelog: fixed`, `changelog: breaking`, or `changelog: none`.
These labels map to the Keep a Changelog categories used by `CHANGELOG.md` where possible.
GitHub generated release notes use the label plus the PR title to draft the changelog.
-->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
* [x] I've added exactly one `changelog:*` label
* [ ] I've linked the relevant upstream docs or specs above

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
