### PR TITLE
Electrum params

### DIFF
--- a/bdk-ffi/Cargo.lock
+++ b/bdk-ffi/Cargo.lock
@@ -87,6 +87,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "base58ck"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -156,9 +178,9 @@ dependencies = [
 
 [[package]]
 name = "bdk_electrum"
-version = "0.23.2"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b59a3f7fbe678874fa34354097644a171276e02a49934c13b3d61c54610ddf39"
+checksum = "00a9846105bf6e751adbb6946b000ff919ce24a15a941cbfe68485549b552a9c"
 dependencies = [
  "bdk_core",
  "electrum-client",
@@ -414,6 +436,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -469,10 +493,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
-name = "electrum-client"
-version = "0.24.1"
+name = "cmake"
+version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5059f13888a90486e7268bbce59b175f5f76b1c55e5b9c568ceaa42d2b8507c"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "electrum-client"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1970c5d7bd9de6d4041cbfc3e46faa3e85fe7efcea2b0eb06750d3ae1ef577b7"
 dependencies = [
  "bitcoin",
  "byteorder",
@@ -555,6 +594,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -567,13 +612,25 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -682,6 +739,16 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
 
 [[package]]
 name = "leb128fmt"
@@ -845,6 +912,12 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
@@ -944,6 +1017,7 @@ version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -978,6 +1052,7 @@ version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",

--- a/bdk-ffi/Cargo.toml
+++ b/bdk-ffi/Cargo.toml
@@ -17,7 +17,7 @@ path = "uniffi-bindgen.rs"
 [dependencies]
 bdk_wallet = { version = "=3.0.0", features = ["all-keys", "keys-bip39", "rusqlite"] }
 bdk_esplora = { version = "0.22.1", default-features = false, features = ["std", "blocking", "blocking-https-rustls"] }
-bdk_electrum = { version = "0.23.2", default-features = false, features = ["use-rustls-ring"] }
+bdk_electrum = { version = "0.24.0", default-features = false, features = ["use-rustls-ring"] }
 bdk_kyoto = { version = "0.17.0" }
 
 uniffi = { version = "=0.31.1", features = ["cli"]}

--- a/bdk-ffi/src/electrum.rs
+++ b/bdk-ffi/src/electrum.rs
@@ -19,6 +19,7 @@ use bdk_wallet::bitcoin::hex::{Case, DisplayHex};
 use std::collections::BTreeMap;
 use std::convert::TryFrom;
 use std::sync::Arc;
+use std::time::Duration;
 
 /// Wrapper around an electrum_client::ElectrumApi which includes an internal in-memory transaction
 /// cache to avoid re-fetching already downloaded transactions.
@@ -29,7 +30,7 @@ pub struct ElectrumClient(BdkBdkElectrumClient<bdk_electrum::electrum_client::Cl
 impl ElectrumClient {
     /// Creates a new bdk client from a electrum_client::ElectrumApi
     /// Optional: Set the proxy of the builder
-    /// Optional: Set the timeout of the builder
+    /// Optional: Set the timeout (in seconds) of the builder
     /// Optional: Set the retry attempts number of the builder
     /// Optional: Set whether the server's TLS certificate is validated.
     #[uniffi::constructor(default(socks5 = None, timeout = None, retry = None, validate_domain = true))]
@@ -43,7 +44,7 @@ impl ElectrumClient {
         let mut config = bdk_electrum::electrum_client::ConfigBuilder::new();
         config = config.validate_domain(validate_domain);
         if let Some(timeout) = timeout {
-            config = config.timeout(Some(timeout));
+            config = config.timeout(Some(Duration::from_secs(timeout.into())));
         }
         if let Some(retry) = retry {
             config = config.retry(retry);
@@ -179,7 +180,7 @@ impl ElectrumClient {
     pub fn estimate_fee(&self, number: u64) -> Result<f64, ElectrumError> {
         self.0
             .inner
-            .estimate_fee(number as usize)
+            .estimate_fee(number as usize, None)
             .map_err(ElectrumError::from)
     }
 

--- a/bdk-ffi/src/electrum.rs
+++ b/bdk-ffi/src/electrum.rs
@@ -30,18 +30,23 @@ impl ElectrumClient {
     /// Creates a new bdk client from a electrum_client::ElectrumApi
     /// Optional: Set the proxy of the builder
     /// Optional: Set the timeout of the builder
+    /// Optional: Set the retry attempts number of the builder
     /// Optional: Set whether the server's TLS certificate is validated.
-    #[uniffi::constructor(default(socks5 = None, timeout = None, validate_domain = true))]
+    #[uniffi::constructor(default(socks5 = None, timeout = None, retry = None, validate_domain = true))]
     pub fn new(
         url: String,
         socks5: Option<String>,
         timeout: Option<u8>,
+        retry: Option<u8>,
         validate_domain: bool,
     ) -> Result<Self, ElectrumError> {
         let mut config = bdk_electrum::electrum_client::ConfigBuilder::new();
         config = config.validate_domain(validate_domain);
         if let Some(timeout) = timeout {
             config = config.timeout(Some(timeout));
+        }
+        if let Some(retry) = retry {
+            config = config.retry(retry);
         }
         if let Some(socks5) = socks5 {
             config = config.socks5(Some(bdk_electrum::electrum_client::Socks5Config::new(

--- a/bdk-ffi/src/electrum.rs
+++ b/bdk-ffi/src/electrum.rs
@@ -29,15 +29,20 @@ pub struct ElectrumClient(BdkBdkElectrumClient<bdk_electrum::electrum_client::Cl
 impl ElectrumClient {
     /// Creates a new bdk client from a electrum_client::ElectrumApi
     /// Optional: Set the proxy of the builder
+    /// Optional: Set the timeout of the builder
     /// Optional: Set whether the server's TLS certificate is validated.
-    #[uniffi::constructor(default(socks5 = None, validate_domain = true))]
+    #[uniffi::constructor(default(socks5 = None, timeout = None, validate_domain = true))]
     pub fn new(
         url: String,
         socks5: Option<String>,
+        timeout: Option<u8>,
         validate_domain: bool,
     ) -> Result<Self, ElectrumError> {
         let mut config = bdk_electrum::electrum_client::ConfigBuilder::new();
         config = config.validate_domain(validate_domain);
+        if let Some(timeout) = timeout {
+            config = config.timeout(Some(timeout));
+        }
         if let Some(socks5) = socks5 {
             config = config.socks5(Some(bdk_electrum::electrum_client::Socks5Config::new(
                 socks5.as_str(),


### PR DESCRIPTION
<!-- Erase any parts of this template not applicable to your Pull Request. -->

### Description

Adds optional timeout and retry args to ElectrumClient::new, matching electrum-client::ConfigBuilder 

Defaults remain unchanged when omitted: timeout = None, and retry keeps upstream’s default.

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Documentation

<!-- Paste the canonical docs/spec for anything this PR wraps or updates. -->

- [ ] [`bdk_wallet`](https://docs.rs/bdk_wallet/latest/bdk_wallet/)

https://docs.rs/electrum-client/0.24.1/electrum_client/struct.ConfigBuilder.html#method.timeout

https://docs.rs/electrum-client/0.24.1/electrum_client/struct.ConfigBuilder.html#method.retry

- [ ] [`bitcoin`](https://docs.rs/bitcoin/latest/bitcoin/index.html)
  <!-- Add a link below with the docs.rs page. -->
- [ ] [`uniffi`](https://github.com/mozilla/uniffi-rs) <!-- Add a link below with the version changelog or any other docs. -->
- [ ] Other: <!-- Add a link below with additional references -->

### Changelog

<!-- Add exactly one changelog label to this PR:
`changelog: added`, `changelog: changed`, `changelog: fixed`, `changelog: breaking`, or `changelog: none`.
These labels map to the Keep a Changelog categories used by `CHANGELOG.md` where possible.
GitHub generated release notes use the label plus the PR title to draft the changelog.
-->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [ ] I ran `cargo fmt` and `cargo clippy` before committing
* [ ] I've added exactly one `changelog:*` label
* [ ] I've linked the relevant upstream docs or specs above

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
