### PR TITLE
Export Display trait on errors

### DIFF
--- a/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/ErrorsTest.kt
+++ b/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/ErrorsTest.kt
@@ -1,0 +1,58 @@
+package org.bitcoindevkit
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.runner.RunWith
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+@RunWith(AndroidJUnit4::class)
+class ErrorsTest {
+    @Test
+    fun bip39ErrorDisplaysBadWordCount() {
+        val thirteenWordMnemonic = "awesome awesome awesome awesome awesome awesome awesome awesome awesome awesome awesome awesome awesome"
+
+        // Building a Mnemonic fails with BadWordCount exception
+        val exception = assertFailsWith<Bip39Exception.BadWordCount> {
+            Mnemonic.fromString(thirteenWordMnemonic)
+        }
+
+        // The toString() method on the exception is the Display trait exported from Rust
+        assertEquals(
+            expected = "the word count 13 is not supported",
+            actual = exception.toString()
+        )
+
+        // The exception contains a field `wordCount` correctly populated
+        assertEquals(
+            expected = 13uL,
+            actual = exception.wordCount
+        )
+
+        // The `message` field on the exception is the concatenation of all fields on the type
+        assertEquals(
+            expected = "wordCount=13",
+            actual = exception.message
+        )
+    }
+
+    @Test
+    fun bip32ErrorDisplaysInvalidChildNumberFormat() {
+        // A derivation path cannot contain words and fails with an InvalidChildNumberFormat exception
+        val exception = assertFailsWith<Bip32Exception.InvalidChildNumberFormat> {
+            DerivationPath("invalid/path/string")
+        }
+
+        // The toString() method on the exception is the Display trait exported from Rust
+        assertEquals(
+            expected = "invalid format for child number",
+            actual = exception.toString()
+        )
+
+        // The `message` field on the exception is the concatenation of all fields on the type (in this case none)
+        assertEquals(
+            expected = "",
+            actual = exception.message
+        )
+    }
+}

--- a/bdk-ffi/src/error.rs
+++ b/bdk-ffi/src/error.rs
@@ -161,6 +161,13 @@ pub enum CannotConnectError {
 
 #[derive(Debug, thiserror::Error, uniffi::Error)]
 #[uniffi::export(Debug, Display)]
+pub enum CbfError {
+    #[error("the node is no longer running")]
+    NodeStopped,
+}
+
+#[derive(Debug, thiserror::Error, uniffi::Error)]
+#[uniffi::export(Debug, Display)]
 pub enum CreateTxError {
     #[error("descriptor error: {error_message}")]
     Descriptor { error_message: String },
@@ -446,9 +453,12 @@ pub enum FromScriptError {
 
 #[derive(Debug, thiserror::Error, uniffi::Error)]
 #[uniffi::export(Debug, Display)]
-pub enum RequestBuilderError {
-    #[error("the request has already been consumed")]
-    RequestAlreadyConsumed,
+pub enum HashParseError {
+    #[error("invalid hash: expected length 32 bytes, got {len} bytes")]
+    InvalidHash { len: u32 },
+
+    #[error("invalid hex string: {hex}")]
+    InvalidHexString { hex: String },
 }
 
 #[derive(Debug, thiserror::Error, uniffi::Error)]
@@ -732,6 +742,17 @@ pub enum PsbtError {
 
 #[derive(Debug, thiserror::Error, uniffi::Error)]
 #[uniffi::export(Debug, Display)]
+pub enum PsbtFinalizeError {
+    #[error("an input at index {index} is invalid: {reason}")]
+    InputError { reason: String, index: u32 },
+    #[error("wrong input count; expected: {in_tx}, got: {in_map}")]
+    WrongInputCount { in_tx: u32, in_map: u32 },
+    #[error("input index out of bounds; inputs: {psbt_inp}, requested: {requested}")]
+    InputIdxOutofBounds { psbt_inp: u32, requested: u32 },
+}
+
+#[derive(Debug, thiserror::Error, uniffi::Error)]
+#[uniffi::export(Debug, Display)]
 pub enum PsbtParseError {
     #[error("error in internal psbt data structure: {error_message}")]
     PsbtEncoding { error_message: String },
@@ -742,20 +763,16 @@ pub enum PsbtParseError {
 
 #[derive(Debug, thiserror::Error, uniffi::Error)]
 #[uniffi::export(Debug, Display)]
-pub enum SighashParseError {
-    #[error("invalid sighash type: {error_message}")]
-    Invalid { error_message: String },
+pub enum RequestBuilderError {
+    #[error("the request has already been consumed")]
+    RequestAlreadyConsumed,
 }
 
 #[derive(Debug, thiserror::Error, uniffi::Error)]
 #[uniffi::export(Debug, Display)]
-pub enum PsbtFinalizeError {
-    #[error("an input at index {index} is invalid: {reason}")]
-    InputError { reason: String, index: u32 },
-    #[error("wrong input count; expected: {in_tx}, got: {in_map}")]
-    WrongInputCount { in_tx: u32, in_map: u32 },
-    #[error("input index out of bounds; inputs: {psbt_inp}, requested: {requested}")]
-    InputIdxOutofBounds { psbt_inp: u32, requested: u32 },
+pub enum SighashParseError {
+    #[error("invalid sighash type: {error_message}")]
+    Invalid { error_message: String },
 }
 
 #[derive(Debug, thiserror::Error, uniffi::Error)]
@@ -844,13 +861,6 @@ pub enum TransactionError {
 pub enum TxidParseError {
     #[error("invalid txid: {txid}")]
     InvalidTxid { txid: String },
-}
-
-#[derive(Debug, thiserror::Error, uniffi::Error)]
-#[uniffi::export(Debug, Display)]
-pub enum CbfError {
-    #[error("the node is no longer running")]
-    NodeStopped,
 }
 
 // ------------------------------------------------------------------------
@@ -1676,16 +1686,6 @@ impl From<BdkEncodeError> for TransactionError {
             _ => TransactionError::OtherTransactionErr,
         }
     }
-}
-
-#[derive(Debug, thiserror::Error, uniffi::Error)]
-#[uniffi::export(Debug, Display)]
-pub enum HashParseError {
-    #[error("invalid hash: expected length 32 bytes, got {len} bytes")]
-    InvalidHash { len: u32 },
-
-    #[error("invalid hex string: {hex}")]
-    InvalidHexString { hex: String },
 }
 
 impl From<bdk_kyoto::bip157::ClientError> for CbfError {

--- a/bdk-ffi/src/error.rs
+++ b/bdk-ffi/src/error.rs
@@ -23,7 +23,6 @@ use bdk_wallet::keys::bip39::Error as BdkBip39Error;
 use bdk_wallet::migration::PreV1MigrationError as BdkPreV1MigrationError;
 use bdk_wallet::miniscript::descriptor::DescriptorKeyParseError as BdkDescriptorKeyParseError;
 use bdk_wallet::miniscript::psbt::Error as BdkPsbtFinalizeError;
-#[allow(deprecated)]
 use bdk_wallet::signer::SignerError as BdkSignerError;
 use bdk_wallet::tx_builder::AddForeignUtxoError as BdkAddForeignUtxoError;
 use bdk_wallet::tx_builder::AddUtxoError;
@@ -37,6 +36,7 @@ use std::convert::TryInto;
 // ------------------------------------------------------------------------
 
 #[derive(Debug, thiserror::Error, uniffi::Error)]
+#[uniffi::export(Debug, Display)]
 pub enum AddForeignUtxoError {
     #[error("foreign utxo outpoint txid does not match PSBT input txid")]
     InvalidTxid,
@@ -52,6 +52,7 @@ pub enum AddForeignUtxoError {
 }
 
 #[derive(Debug, thiserror::Error, uniffi::Error)]
+#[uniffi::export(Debug, Display)]
 pub enum AddressParseError {
     #[error("base58 address encoding error")]
     Base58,
@@ -86,6 +87,7 @@ pub enum AddressParseError {
 }
 
 #[derive(Debug, thiserror::Error, uniffi::Error)]
+#[uniffi::export(Debug, Display)]
 pub enum Bip32Error {
     #[error("cannot derive from a hardened key")]
     CannotDeriveFromHardenedKey,
@@ -122,6 +124,7 @@ pub enum Bip32Error {
 }
 
 #[derive(Debug, thiserror::Error, uniffi::Error)]
+#[uniffi::export(Debug, Display)]
 pub enum Bip39Error {
     #[error("the word count {word_count} is not supported")]
     BadWordCount { word_count: u64 },
@@ -140,6 +143,7 @@ pub enum Bip39Error {
 }
 
 #[derive(Debug, thiserror::Error, uniffi::Error)]
+#[uniffi::export(Debug, Display)]
 pub enum CalculateFeeError {
     #[error("missing transaction output: {out_points:?}")]
     MissingTxOut { out_points: Vec<OutPoint> },
@@ -149,12 +153,14 @@ pub enum CalculateFeeError {
 }
 
 #[derive(Debug, thiserror::Error, uniffi::Error)]
+#[uniffi::export(Debug, Display)]
 pub enum CannotConnectError {
     #[error("cannot include height: {height}")]
     Include { height: u32 },
 }
 
 #[derive(Debug, thiserror::Error, uniffi::Error)]
+#[uniffi::export(Debug, Display)]
 pub enum CreateTxError {
     #[error("descriptor error: {error_message}")]
     Descriptor { error_message: String },
@@ -224,6 +230,7 @@ pub enum CreateTxError {
 }
 
 #[derive(Debug, thiserror::Error, uniffi::Error)]
+#[uniffi::export(Debug, Display)]
 pub enum CreateWithPersistError {
     #[error("sqlite persistence error: {error_message}")]
     Persist { error_message: String },
@@ -236,6 +243,7 @@ pub enum CreateWithPersistError {
 }
 
 #[derive(Debug, thiserror::Error, uniffi::Error)]
+#[uniffi::export(Debug, Display)]
 pub enum DescriptorError {
     #[error("invalid hd key path")]
     InvalidHdKeyPath,
@@ -278,6 +286,7 @@ pub enum DescriptorError {
 }
 
 #[derive(Debug, thiserror::Error, uniffi::Error)]
+#[uniffi::export(Debug, Display)]
 pub enum DescriptorKeyError {
     #[error("error parsing descriptor key: {error_message}")]
     Parse { error_message: String },
@@ -293,6 +302,7 @@ pub enum DescriptorKeyError {
 }
 
 #[derive(Debug, thiserror::Error, uniffi::Error)]
+#[uniffi::export(Debug, Display)]
 pub enum ElectrumError {
     #[error("{error_message}")]
     IOError { error_message: String },
@@ -347,6 +357,7 @@ pub enum ElectrumError {
 }
 
 #[derive(Debug, thiserror::Error, uniffi::Error)]
+#[uniffi::export(Debug, Display)]
 pub enum EsploraError {
     #[error("minreq error: {error_message}")]
     Minreq { error_message: String },
@@ -392,6 +403,7 @@ pub enum EsploraError {
 }
 
 #[derive(Debug, thiserror::Error, uniffi::Error)]
+#[uniffi::export(Debug, Display)]
 pub enum ExtractTxError {
     #[error("an absurdly high fee rate of {fee_rate} sat/vbyte")]
     AbsurdFeeRate { fee_rate: u64 },
@@ -407,13 +419,16 @@ pub enum ExtractTxError {
     )]
     OtherExtractTxErr,
 }
+
 #[derive(Debug, thiserror::Error, uniffi::Error)]
+#[uniffi::export(Debug, Display)]
 pub enum FeeRateError {
     #[error("arithmetic overflow")]
     ArithmeticOverflow,
 }
 
 #[derive(Debug, thiserror::Error, uniffi::Error)]
+#[uniffi::export(Debug, Display)]
 pub enum FromScriptError {
     #[error("script is not a p2pkh, p2sh or witness program")]
     UnrecognizedScript,
@@ -430,12 +445,14 @@ pub enum FromScriptError {
 }
 
 #[derive(Debug, thiserror::Error, uniffi::Error)]
+#[uniffi::export(Debug, Display)]
 pub enum RequestBuilderError {
     #[error("the request has already been consumed")]
     RequestAlreadyConsumed,
 }
 
 #[derive(Debug, thiserror::Error, uniffi::Error)]
+#[uniffi::export(Debug, Display)]
 pub enum LoadWithPersistError {
     #[error("sqlite persistence error: {error_message}")]
     Persist { error_message: String },
@@ -448,6 +465,7 @@ pub enum LoadWithPersistError {
 }
 
 #[derive(Debug, thiserror::Error, uniffi::Error)]
+#[uniffi::export(Debug, Display)]
 pub enum MiniscriptError {
     #[error("absolute locktime error")]
     AbsoluteLockTime,
@@ -562,6 +580,7 @@ pub enum MiniscriptError {
 }
 
 #[derive(Debug, thiserror::Error, uniffi::Error)]
+#[uniffi::export(Debug, Display)]
 pub enum ParseAmountError {
     #[error("amount out of range")]
     OutOfRange,
@@ -584,12 +603,14 @@ pub enum ParseAmountError {
 }
 
 #[derive(Debug, thiserror::Error, uniffi::Error)]
+#[uniffi::export(Debug, Display)]
 pub enum PersistenceError {
     #[error("persistence error: {error_message}")]
     Reason { error_message: String },
 }
 
 #[derive(Debug, thiserror::Error, uniffi::Error)]
+#[uniffi::export(Debug, Display)]
 pub enum PreV1MigrationError {
     #[error("migration helper is only available for sqlite-backed persisters")]
     SqliteOnly,
@@ -605,6 +626,7 @@ pub enum PreV1MigrationError {
 }
 
 #[derive(Debug, thiserror::Error, uniffi::Error)]
+#[uniffi::export(Debug, Display)]
 pub enum PsbtError {
     #[error("invalid magic")]
     InvalidMagic,
@@ -709,6 +731,7 @@ pub enum PsbtError {
 }
 
 #[derive(Debug, thiserror::Error, uniffi::Error)]
+#[uniffi::export(Debug, Display)]
 pub enum PsbtParseError {
     #[error("error in internal psbt data structure: {error_message}")]
     PsbtEncoding { error_message: String },
@@ -718,12 +741,14 @@ pub enum PsbtParseError {
 }
 
 #[derive(Debug, thiserror::Error, uniffi::Error)]
+#[uniffi::export(Debug, Display)]
 pub enum SighashParseError {
     #[error("invalid sighash type: {error_message}")]
     Invalid { error_message: String },
 }
 
 #[derive(Debug, thiserror::Error, uniffi::Error)]
+#[uniffi::export(Debug, Display)]
 pub enum PsbtFinalizeError {
     #[error("an input at index {index} is invalid: {reason}")]
     InputError { reason: String, index: u32 },
@@ -734,6 +759,7 @@ pub enum PsbtFinalizeError {
 }
 
 #[derive(Debug, thiserror::Error, uniffi::Error)]
+#[uniffi::export(Debug, Display)]
 pub enum SignerError {
     #[error("missing key for signing")]
     MissingKey,
@@ -788,6 +814,7 @@ pub enum SignerError {
 }
 
 #[derive(Debug, thiserror::Error, uniffi::Error)]
+#[uniffi::export(Debug, Display)]
 pub enum TransactionError {
     #[error("io error")]
     Io,
@@ -813,12 +840,14 @@ pub enum TransactionError {
 }
 
 #[derive(Debug, thiserror::Error, uniffi::Error)]
+#[uniffi::export(Debug, Display)]
 pub enum TxidParseError {
     #[error("invalid txid: {txid}")]
     InvalidTxid { txid: String },
 }
 
 #[derive(Debug, thiserror::Error, uniffi::Error)]
+#[uniffi::export(Debug, Display)]
 pub enum CbfError {
     #[error("the node is no longer running")]
     NodeStopped,
@@ -1650,6 +1679,7 @@ impl From<BdkEncodeError> for TransactionError {
 }
 
 #[derive(Debug, thiserror::Error, uniffi::Error)]
+#[uniffi::export(Debug, Display)]
 pub enum HashParseError {
     #[error("invalid hash: expected length 32 bytes, got {len} bytes")]
     InvalidHash { len: u32 },


### PR DESCRIPTION
This brings the Display trait we create using the `thiserror::Error` macro to the bindings. We've been implementing the Display trait for all this time, but not passing it on to the bindings!

Note that the draft version of this PR implements this just for the `CreateWithPersistError` enum.

See related issues #509 and #964.

## Todo

- [ ] Export Display and Debug on all errors
- [ ] Look at the messages to make sure they are what we want (for example I think a nice addition would be to add quotes around the message given from upstream, so that the string reads: `http error with status code 404 and message 'Block not found'` instead of `http error with status code 404 and message Block not found`. Just an idea.

## In Practice

Here is what this means in practice:

### Kotlin

The default toString() method on Exceptions (`className + ": " + message`) is overriden by the Display trait. You loose the className when the exception is printed out, but you gain the human-readable message we maintain in the crate. If you want the Exception type, you can still print it. You keep the strongly typed fields (in the example below your `status` field is a `UShort`), and the `message` field is just a stringified concatenation of all the fields. This means you have to know that on BDK exceptions, the human-readable message is not in fact in the `message` field like you expect on typical Kotlin errors, but instead in the `toString()` method.

```kotlin
@Test  
fun `Esplora header height exception`() {  
    try {  
        val esploraClient = EsploraClient(ESPLORA_REGTEST_URL)  
        esploraClient.getBlockHash(10000000u)  
    } catch (e: Exception) {
	    println("Type:     ${e::class.qualifiedName}") 
        println("Message:  ${e.message}")  
        println("toString: ${e.toString()}")  
    }
}
// The exception type is:
// org.bitcoindevkit.EsploraException.HttpResponse

// The exception.message field is:
// status=404, errorMessage=Block not found
   
// The exception.toString() method returns:
// http error with status code 404 and message Block not found
```

### Swift
In Swift, two new fields are added to the errors: `description` and `debugDescription`. The `description` field now holds the human-readable messages we craft on the structs using `thiserror`. The `debugDescription is just the Debug trait on Rust. Note that this is not available in Kotlin, as there is not equivalent "debug" print method or field.

```swift
    func testNewAddress() throws {
        do {
            let persister = try Persister.newInMemory()
            let _ = try Wallet(
                descriptor: descriptor,
                changeDescriptor: changeDescriptor,
                network: .regtest,
                persister: persister
            )
        } catch let error as CreateWithPersistError {
        print("\n========================================")
        print("🔴 CAUGHT ERROR")
        print("========================================")
        print("print(error):         \(error)")
        print("----------------------------------------")
        print("localizedDescription: \(error.localizedDescription)")
        print("----------------------------------------")
        print("errorDescription:     \(error.errorDescription)")
        print("----------------------------------------")
        print("description:          \(error.description)")
        print("----------------------------------------")
        print("debugDescription:     \(error.debugDescription)")
        print("----------------------------------------")
        print("dump(error):")
        dump(error)
        print("========================================\n")
        throw error
        }
    }
```

```shell
========================================
🔴 CAUGHT ERROR
========================================
print(error):         Descriptor(errorMessage: "External and internal descriptors are the same")
----------------------------------------
localizedDescription: BitcoinDevKit.CreateWithPersistError.Descriptor(errorMessage: "External and internal descriptors are the same")
----------------------------------------
errorDescription:     Optional("BitcoinDevKit.CreateWithPersistError.Descriptor(errorMessage: \"External and internal descriptors are the same\")")
----------------------------------------
description:          the loaded changeset cannot construct wallet: External and internal descriptors are the same
----------------------------------------
debugDescription:     Descriptor { error_message: "External and internal descriptors are the same" }
----------------------------------------
dump(error):
▿ BitcoinDevKit.CreateWithPersistError.Descriptor
  ▿ Descriptor: (1 element)
    - errorMessage: "External and internal descriptors are the same"
========================================
```


### Changelog

```md
## Added
- [Swift]: Errors get new `description` and `debugDescription` fields. `description` defers to the Display trait and `debugDescription` defers to the `Debug` trait.
- [Kotlin]: Exceptions now use a customized `toString()` method with a human-readable message populated by the `Display` trait.
```


### Checklists

#### All Submissions:

* [ ] I've signed all my commits
* [ ] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [ ] I ran `cargo fmt` and `cargo clippy` before committing
* [ ] I've added exactly one `changelog:*` label
* [ ] I've linked the relevant upstream docs or specs above

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
