### PR TITLE
fix(keys): return secret bytes for single descriptor keys

### DIFF
--- a/bdk-ffi/src/keys.rs
+++ b/bdk-ffi/src/keys.rs
@@ -266,15 +266,17 @@ impl DescriptorSecretKey {
     pub fn secret_bytes(&self) -> Vec<u8> {
         let inner = &self.0;
         let secret_bytes: Vec<u8> = match inner {
-            BdkDescriptorSecretKey::Single(_) => {
-                unreachable!()
+            BdkDescriptorSecretKey::Single(single_key) => {
+                single_key.key.inner.secret_bytes().to_vec()
             }
             BdkDescriptorSecretKey::XPrv(descriptor_x_key) => {
                 descriptor_x_key.xkey.private_key.secret_bytes().to_vec()
             }
-            BdkDescriptorSecretKey::MultiXPrv(_) => {
-                unreachable!()
-            }
+            BdkDescriptorSecretKey::MultiXPrv(descriptor_multi_x_key) => descriptor_multi_x_key
+                .xkey
+                .private_key
+                .secret_bytes()
+                .to_vec(),
         };
 
         secret_bytes

--- a/bdk-ffi/src/tests/keys.rs
+++ b/bdk-ffi/src/tests/keys.rs
@@ -2,6 +2,7 @@ use crate::bitcoin::NetworkKind;
 use crate::error::DescriptorKeyError;
 use crate::keys::{DerivationPath, DescriptorPublicKey, DescriptorSecretKey, Mnemonic};
 use crate::types::WildcardType;
+use bdk_wallet::bitcoin::PrivateKey as BdkPrivateKey;
 use std::sync::Arc;
 
 fn get_inner() -> DescriptorSecretKey {
@@ -91,6 +92,23 @@ fn test_from_str_inner() {
     // Should error out because you can't produce a DescriptorSecretKey from an xpub
     let key0 = "tpubDBrgjcxBxnXyL575sHdkpKohWu5qHKoQ7TJXKNrYznh5fVEGBv89hA8ENW7A8MFVpFUSvgLqc4Nj1WZcpePX6rrxviVtPowvMuGF5rdT2Vi";
     assert!(DescriptorSecretKey::from_string(key0.to_string()).is_err());
+}
+
+#[test]
+fn test_secret_bytes_from_single_and_multipath_keys() {
+    let wif = "L2wTu6hQrnDMiFNWA5na6jB12ErGQqtXwqpSL7aWquJaZG8Ai3ch";
+    let single_key = DescriptorSecretKey::from_string(wif.to_string()).unwrap();
+    let expected_single_bytes = BdkPrivateKey::from_wif(wif)
+        .unwrap()
+        .inner
+        .secret_bytes()
+        .to_vec();
+    assert_eq!(single_key.secret_bytes(), expected_single_bytes);
+
+    let base_xprv = "tprv8ZgxMBicQKsPcwcD4gSnMti126ZiETsuX7qwrtMypr6FBwAP65puFn4v6c3jrN9VwtMRMph6nyT63NrfUL4C3nBzPcduzVSuHD7zbX2JKVc";
+    let multipath_key = DescriptorSecretKey::from_string(format!("{base_xprv}/<0;1>/*")).unwrap();
+    let base_key = DescriptorSecretKey::from_string(base_xprv.to_string()).unwrap();
+    assert_eq!(multipath_key.secret_bytes(), base_key.secret_bytes());
 }
 
 #[test]


### PR DESCRIPTION
<!-- Erase any parts of this template not applicable to your Pull Request. -->

### Description

`DescriptorSecretKey::from_string()` accepts both extended private keys and single private keys encoded as WIF. 

`secret_bytes()` only handled the extended private key case and treated single keys as unreachable, which caused a panic when called with a valid WIF-derived `DescriptorSecretKey`.

This updates `secret_bytes()` to return bytes for single private keys directly, while preserving existing behavior for extended private keys. It also handles multipath extended private keys by returning the underlying xprv secret bytes.

### Documentation

- [x] [`bdk_wallet`](https://docs.rs/bdk_wallet/latest/bdk_wallet/)
  - [`bdk_wallet::keys`](https://docs.rs/bdk_wallet/3.0.0/bdk_wallet/keys/index.html) documents `DescriptorSecretKey` as either a single private key or an xprv.

- [x] [`bitcoin`](https://docs.rs/bitcoin/latest/bitcoin/index.html)
  - [`bitcoin::PrivateKey`](https://docs.rs/bitcoin/0.32.8/bitcoin/struct.PrivateKey.html) covers WIF parsing and the underlying private key representation used for single-key bytes.

- [x] Other:
  - [`miniscript::descriptor::DescriptorSecretKey`](https://docs.rs/miniscript/12.3.7/miniscript/descriptor/enum.DescriptorSecretKey.html) is the upstream enum with `Single`, `XPrv`, and `MultiXPrv` variants.
  - [`secp256k1::SecretKey::secret_bytes`](https://docs.rs/secp256k1/0.29.1/secp256k1/struct.SecretKey.html#method.secret_bytes) is the upstream byte extraction method used for the returned secret bytes.
  

### Changelog

<!-- Add exactly one changelog label to this PR:
`changelog: added`, `changelog: changed`, `changelog: fixed`, `changelog: breaking`, or `changelog: none`.
These labels map to the Keep a Changelog categories used by `CHANGELOG.md` where possible.
GitHub generated release notes use the label plus the PR title to draft the changelog.
-->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
* [x] I've added exactly one `changelog:*` label
* [x] I've linked the relevant upstream docs or specs above

#### New Features:

* [x] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
