### PR TITLE
fix: generate correct BIP39 entropy size in Mnemonic::new()

### DIFF
--- a/bdk-ffi/src/keys.rs
+++ b/bdk-ffi/src/keys.rs
@@ -11,10 +11,9 @@ use bdk_wallet::keys::bip39::WordCount;
 use bdk_wallet::keys::bip39::{Language, Mnemonic as BdkMnemonic};
 use bdk_wallet::keys::{
     DerivableKey, DescriptorPublicKey as BdkDescriptorPublicKey,
-    DescriptorSecretKey as BdkDescriptorSecretKey, ExtendedKey, GeneratableKey, GeneratedKey,
+    DescriptorSecretKey as BdkDescriptorSecretKey, ExtendedKey,
 };
 use bdk_wallet::miniscript::descriptor::{DescriptorXKey, Wildcard};
-use bdk_wallet::miniscript::BareCtx;
 
 use crate::types::WildcardType;
 use std::convert::TryFrom;
@@ -32,15 +31,15 @@ impl Mnemonic {
     /// Generate a mnemonic given a word count.
     #[uniffi::constructor]
     pub fn new(word_count: WordCount) -> Self {
-        // TODO 4: I DON'T KNOW IF THIS IS A DECENT WAY TO GENERATE ENTROPY PLEASE CONFIRM
+        // Entropy size = word_count in bits / 8 (WordCount values are 128, 160, 192, 224, 256)
+        let entropy_size = word_count as usize / 8;
+        let mut entropy = vec![0u8; entropy_size];
         let mut rng = rand::thread_rng();
-        let mut entropy = [0u8; 32];
-        rng.fill(&mut entropy);
+        rng.fill_bytes(&mut entropy);
 
-        let generated_key: GeneratedKey<_, BareCtx> =
-            BdkMnemonic::generate_with_entropy((word_count, Language::English), entropy).unwrap();
-        let mnemonic = BdkMnemonic::parse_in(Language::English, generated_key.to_string()).unwrap();
-        Mnemonic(mnemonic)
+        BdkMnemonic::from_entropy(&entropy)
+            .map(Mnemonic)
+            .expect("valid entropy size for BIP39 mnemonic")
     }
     /// Parse a string as a mnemonic seed phrase.
     #[uniffi::constructor]

--- a/bdk-ffi/src/tests/keys.rs
+++ b/bdk-ffi/src/tests/keys.rs
@@ -2,6 +2,7 @@ use crate::bitcoin::NetworkKind;
 use crate::error::DescriptorKeyError;
 use crate::keys::{DerivationPath, DescriptorPublicKey, DescriptorSecretKey, Mnemonic};
 use crate::types::WildcardType;
+use bdk_wallet::keys::bip39::WordCount;
 use std::sync::Arc;
 
 fn get_inner() -> DescriptorSecretKey {
@@ -196,4 +197,15 @@ fn test_add_wildcard() {
         dpk_hardened.add_wildcard(),
         Err(DescriptorKeyError::CannotChangeWildcardType)
     ));
+}
+
+#[test]
+fn test_mnemonic_generation_word_count() {
+    let mnemonic_12 = Mnemonic::new(WordCount::Words12);
+    let words_12: Vec<&str> = mnemonic_12.to_string().split_whitespace().collect();
+    assert_eq!(words_12.len(), 12);
+
+    let mnemonic_24 = Mnemonic::new(WordCount::Words24);
+    let words_24: Vec<&str> = mnemonic_24.to_string().split_whitespace().collect();
+    assert_eq!(words_24.len(), 24);
 }


### PR DESCRIPTION
## Description

Mnemonic::new() was always generating 32 bytes of entropy regardless of the requested word count, with an explicit TODO expressing uncertainty about the approach.

### Changes
- Generate entropy of the correct size based on word count (16 bytes for 12-words, 24 for 18-words, 32 for 24-words)
- Replace the redundant generate_with_entropy → 	o_string() → parse_in() round-trip with a direct rom_entropy() call
- Remove unused imports (GeneratableKey, GeneratedKey, BareCtx)

### Testing
- Added 	est_mnemonic_generation_word_count to verify generated mnemonics have the correct word count