### PR TITLE
fix: return psbt spend utxo errors

### DIFF
--- a/bdk-ffi/src/bitcoin.rs
+++ b/bdk-ffi/src/bitcoin.rs
@@ -1507,10 +1507,14 @@ impl Psbt {
     }
 
     /// Returns the spending utxo for this PSBT's input at `input_index`.
-    pub fn spend_utxo(&self, input_index: u64) -> String {
+    pub fn spend_utxo(&self, input_index: u64) -> Result<String, PsbtError> {
         let psbt = self.0.lock().unwrap();
-        let utxo = psbt.spend_utxo(input_index as usize).unwrap();
-        serde_json::to_string(&utxo).unwrap()
+        let utxo = psbt
+            .spend_utxo(input_index as usize)
+            .map_err(PsbtError::from)?;
+        serde_json::to_string(&utxo).map_err(|error| PsbtError::Serialization {
+            error_message: error.to_string(),
+        })
     }
 
     /// The corresponding key-value map for each input in the unsigned transaction.

--- a/bdk-ffi/src/error.rs
+++ b/bdk-ffi/src/error.rs
@@ -12,6 +12,7 @@ use bdk_wallet::bitcoin::hex::DisplayHex;
 use bdk_wallet::bitcoin::psbt::Error as BdkPsbtError;
 use bdk_wallet::bitcoin::psbt::ExtractTxError as BdkExtractTxError;
 use bdk_wallet::bitcoin::psbt::PsbtParseError as BdkPsbtParseError;
+use bdk_wallet::bitcoin::psbt::SignError as BdkPsbtSignError;
 use bdk_wallet::bitcoin::script::PushBytesError;
 use bdk_wallet::chain::local_chain::CannotConnectError as BdkCannotConnectError;
 use bdk_wallet::chain::rusqlite::Error as BdkSqliteError;
@@ -617,6 +618,18 @@ pub enum PsbtError {
 
     #[error("output index is out of bounds of non witness script output array")]
     PsbtUtxoOutOfBounds,
+
+    #[error("input index is out of bounds")]
+    InputIndexOutOfBounds,
+
+    #[error("missing spend UTXO in PSBT")]
+    MissingSpendUtxo,
+
+    #[error("PSBT serialization error: {error_message}")]
+    Serialization { error_message: String },
+
+    #[error("PSBT spend UTXO error: {error_message}")]
+    SpendUtxo { error_message: String },
 
     #[error("invalid key: {key}")]
     InvalidKey { key: String },
@@ -1538,6 +1551,18 @@ impl From<BdkPsbtError> for PsbtError {
                 error_message: e.to_string(),
             },
             _ => PsbtError::OtherPsbtErr,
+        }
+    }
+}
+
+impl From<BdkPsbtSignError> for PsbtError {
+    fn from(error: BdkPsbtSignError) -> Self {
+        match error {
+            BdkPsbtSignError::IndexOutOfBounds(_) => PsbtError::InputIndexOutOfBounds,
+            BdkPsbtSignError::MissingSpendUtxo => PsbtError::MissingSpendUtxo,
+            _ => PsbtError::SpendUtxo {
+                error_message: error.to_string(),
+            },
         }
     }
 }

--- a/bdk-ffi/src/tests/bitcoin.rs
+++ b/bdk-ffi/src/tests/bitcoin.rs
@@ -1,4 +1,5 @@
 use crate::bitcoin::{Address, AddressData, Key, Network, ProprietaryKey, Psbt};
+use crate::error::PsbtError;
 use bdk_electrum::bdk_core::bitcoin::hex::DisplayHex;
 
 #[test]
@@ -360,13 +361,21 @@ fn test_to_address_data() {
 #[test]
 fn test_psbt_spend_utxo() {
     let psbt = sample_psbt();
-    let psbt_utxo = psbt.spend_utxo(0);
+    let psbt_utxo = psbt.spend_utxo(0).unwrap();
 
     assert_eq!(
         psbt_utxo,
         r#"{"value":9536,"script_pubkey":"0020432ae79fce8bf43def0e21fde7d2896cfb9d0c773f6e9ea723d1391012d00f56"}"#,
         "Psbt utxo does not match the expected value"
     );
+}
+
+#[test]
+fn test_psbt_spend_utxo_invalid_index_returns_error() {
+    let psbt = sample_psbt();
+    let error = psbt.spend_utxo(1).unwrap_err();
+
+    assert!(matches!(error, PsbtError::InputIndexOutOfBounds));
 }
 
 #[test]

--- a/bdk-ffi/src/tests/error.rs
+++ b/bdk-ffi/src/tests/error.rs
@@ -399,6 +399,23 @@ fn test_error_psbt() {
             "output index is out of bounds of non witness script output array",
         ),
         (
+            PsbtError::InputIndexOutOfBounds,
+            "input index is out of bounds",
+        ),
+        (PsbtError::MissingSpendUtxo, "missing spend UTXO in PSBT"),
+        (
+            PsbtError::Serialization {
+                error_message: "serialization error".to_string(),
+            },
+            "PSBT serialization error: serialization error",
+        ),
+        (
+            PsbtError::SpendUtxo {
+                error_message: "spend error".to_string(),
+            },
+            "PSBT spend UTXO error: spend error",
+        ),
+        (
             PsbtError::InvalidKey {
                 key: "key".to_string(),
             },


### PR DESCRIPTION
<!-- Erase any parts of this template not applicable to your Pull Request. -->

### Description

I think it would be good for Psbt::spend_utxo to return typed PsbtErrors instead of potentially panicking when rust-bitcoin reports missing or outofbounds spend UTXOs.

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Documentation

<!-- Paste the canonical docs/spec for anything this PR wraps or updates. -->

- [ ] [`bdk_wallet`](https://docs.rs/bdk_wallet/latest/bdk_wallet/)
  <!-- Add a link below with the docs.rs page. -->
- [x] [`bitcoin`](https://docs.rs/bitcoin/latest/bitcoin/index.html)
  - [`Psbt::spend_utxo`](https://docs.rs/bitcoin/0.32.8/src/bitcoin/psbt/mod.rs.html#620-630)
  - [`SignError`](https://docs.rs/bitcoin/0.32.8/src/bitcoin/psbt/mod.rs.html#995-1059)
- [ ] [`uniffi`](https://github.com/mozilla/uniffi-rs) <!-- Add a link below with the version changelog or any other docs. -->
- [ ] Other: <!-- Add a link below with additional references -->

### Changelog

<!-- Add exactly one changelog label to this PR:
`changelog: added`, `changelog: changed`, `changelog: fixed`, `changelog: breaking`, or `changelog: none`.
These labels map to the Keep a Changelog categories used by `CHANGELOG.md` where possible.
GitHub generated release notes use the label plus the PR title to draft the changelog.
-->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
* [x] I've added exactly one `changelog:*` label
* [ ] I've linked the relevant upstream docs or specs above

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
