### PR TITLE
feat: expose two path descriptor wallet loading

### DIFF
--- a/bdk-ffi/src/tests/wallet.rs
+++ b/bdk-ffi/src/tests/wallet.rs
@@ -150,3 +150,41 @@ fn test_create_two_path_wallet() {
     assert_eq!(wallet.derivation_index(KeychainKind::External), Some(0));
     assert_eq!(wallet.derivation_index(KeychainKind::Internal), Some(0));
 }
+
+#[test]
+fn test_load_from_two_path_descriptor() {
+    let persister = Arc::new(Persister::new_in_memory().unwrap());
+    let wallet = Wallet::create_from_two_path_descriptor(
+        two_path_descriptor(),
+        Network::Signet,
+        Arc::clone(&persister),
+        25,
+    )
+    .unwrap();
+
+    wallet.reveal_next_address(KeychainKind::External);
+    wallet.reveal_next_address(KeychainKind::Internal);
+    assert!(wallet.persist(Arc::clone(&persister)).unwrap());
+
+    let loaded_wallet =
+        Wallet::load_from_two_path_descriptor(two_path_descriptor(), Arc::clone(&persister), 25)
+            .unwrap();
+
+    assert_eq!(loaded_wallet.network(), Network::Signet);
+    assert_eq!(
+        loaded_wallet.derivation_index(KeychainKind::External),
+        Some(0)
+    );
+    assert_eq!(
+        loaded_wallet.derivation_index(KeychainKind::Internal),
+        Some(0)
+    );
+    assert_eq!(
+        loaded_wallet.next_derivation_index(KeychainKind::External),
+        1
+    );
+    assert_eq!(
+        loaded_wallet.next_derivation_index(KeychainKind::Internal),
+        1
+    );
+}

--- a/bdk-ffi/src/wallet.rs
+++ b/bdk-ffi/src/wallet.rs
@@ -168,6 +168,36 @@ impl Wallet {
         })
     }
 
+    /// Build a two-path descriptor `Wallet` by loading from persistence.
+    ///
+    /// Checks that the provided two-path descriptor matches exactly what is loaded
+    /// for both the external and internal keychains.
+    ///
+    /// Note that descriptor secret keys are not persisted to the db. This method
+    /// extracts keys from the provided descriptor while loading.
+    #[uniffi::constructor(default(lookahead = 25))]
+    pub fn load_from_two_path_descriptor(
+        two_path_descriptor: Arc<Descriptor>,
+        persister: Arc<Persister>,
+        lookahead: u32,
+    ) -> Result<Wallet, LoadWithPersistError> {
+        let descriptor = two_path_descriptor.to_string_with_secret();
+        let mut persist_lock = persister.inner.lock().unwrap();
+        let deref = persist_lock.deref_mut();
+
+        let wallet: PersistedWallet<PersistenceType> = BdkWallet::load()
+            .two_path_descriptor(descriptor)
+            .lookahead(lookahead)
+            .extract_keys()
+            .load_wallet(deref)
+            .map_err(LoadWithPersistError::from)?
+            .ok_or(LoadWithPersistError::CouldNotLoad)?;
+
+        Ok(Wallet {
+            inner_mutex: Mutex::new(wallet),
+        })
+    }
+
     /// Build a single-descriptor Wallet by loading from persistence.
     ///
     /// Note that the descriptor secret keys are not persisted to the db.

--- a/bdk-ffi/src/wallet.rs
+++ b/bdk-ffi/src/wallet.rs
@@ -181,7 +181,7 @@ impl Wallet {
         persister: Arc<Persister>,
         lookahead: u32,
     ) -> Result<Wallet, LoadWithPersistError> {
-        let descriptor = two_path_descriptor.to_string_with_secret();
+        let descriptor = two_path_descriptor.to_string();
         let mut persist_lock = persister.inner.lock().unwrap();
         let deref = persist_lock.deref_mut();
 

--- a/bdk-ffi/src/wallet.rs
+++ b/bdk-ffi/src/wallet.rs
@@ -109,13 +109,18 @@ impl Wallet {
 
     /// Build a new `Wallet` from a two-path descriptor.
     ///
-    /// This function parses a multipath descriptor with exactly 2 paths and creates a wallet using the existing receive and change wallet creation logic.
+    /// This function parses a multipath descriptor with exactly 2 paths and creates a wallet
+    /// using the existing receive and change wallet creation logic. Use this method with public
+    /// extended keys (`xpub` prefix) to create watch-only wallets.
     ///
-    /// Multipath descriptors follow [BIP-389](https://github.com/bitcoin/bips/blob/master/bip-0389.mediawiki) and allow defining both receive and change derivation paths in a single descriptor using the <0;1> syntax.
+    /// Multipath descriptors follow [BIP-389](https://github.com/bitcoin/bips/blob/master/bip-0389.mediawiki)
+    /// and allow defining both receive and change derivation paths in a single descriptor using
+    /// the `<0;1>` syntax.
     ///
     /// If you have previously created a wallet, use load instead.
     ///
-    /// Returns an error if the descriptor is invalid or not a 2-path multipath descriptor.
+    /// Returns an error if the descriptor is not a 2-path multipath descriptor. Private multipath
+    /// descriptors cannot be constructed as `Descriptor` values for this API.
     #[uniffi::constructor(default(lookahead = 25))]
     pub fn create_from_two_path_descriptor(
         two_path_descriptor: Arc<Descriptor>,
@@ -172,6 +177,9 @@ impl Wallet {
     ///
     /// Checks that the provided two-path descriptor matches exactly what is loaded
     /// for both the external and internal keychains.
+    ///
+    /// Use this method with public extended keys (`xpub` prefix) to load watch-only wallets.
+    /// Private multipath descriptors cannot be constructed as `Descriptor` values for this API.
     ///
     /// Note that descriptor secret keys are not persisted to the db. This method
     /// extracts keys from the provided descriptor while loading.

--- a/bdk-ffi/src/wallet.rs
+++ b/bdk-ffi/src/wallet.rs
@@ -196,7 +196,6 @@ impl Wallet {
         let wallet: PersistedWallet<PersistenceType> = BdkWallet::load()
             .two_path_descriptor(descriptor)
             .lookahead(lookahead)
-            .extract_keys()
             .load_wallet(deref)
             .map_err(LoadWithPersistError::from)?
             .ok_or(LoadWithPersistError::CouldNotLoad)?;

--- a/bdk-ffi/src/wallet.rs
+++ b/bdk-ffi/src/wallet.rs
@@ -110,8 +110,9 @@ impl Wallet {
     /// Build a new `Wallet` from a two-path descriptor.
     ///
     /// This function parses a multipath descriptor with exactly 2 paths and creates a wallet
-    /// using the existing receive and change wallet creation logic. Use this method with public
-    /// extended keys (`xpub` prefix) to create watch-only wallets.
+    /// using the existing receive and change wallet creation logic.
+    ///
+    /// The provided descriptor may only contain extended public keys (`xpub`) with exactly 2 paths.
     ///
     /// Multipath descriptors follow [BIP-389](https://github.com/bitcoin/bips/blob/master/bip-0389.mediawiki)
     /// and allow defining both receive and change derivation paths in a single descriptor using
@@ -119,8 +120,7 @@ impl Wallet {
     ///
     /// If you have previously created a wallet, use load instead.
     ///
-    /// Returns an error if the descriptor is not a 2-path multipath descriptor. Private multipath
-    /// descriptors cannot be constructed as `Descriptor` values for this API.
+    /// Returns an error if the descriptor is not a 2-path multipath descriptor.
     #[uniffi::constructor(default(lookahead = 25))]
     pub fn create_from_two_path_descriptor(
         two_path_descriptor: Arc<Descriptor>,
@@ -178,11 +178,7 @@ impl Wallet {
     /// Checks that the provided two-path descriptor matches exactly what is loaded
     /// for both the external and internal keychains.
     ///
-    /// Use this method with public extended keys (`xpub` prefix) to load watch-only wallets.
-    /// Private multipath descriptors cannot be constructed as `Descriptor` values for this API.
-    ///
-    /// Note that descriptor secret keys are not persisted to the db. This method
-    /// extracts keys from the provided descriptor while loading.
+    /// The provided descriptor may only contain extended public keys (`xpub`) with exactly 2 paths.
     #[uniffi::constructor(default(lookahead = 25))]
     pub fn load_from_two_path_descriptor(
         two_path_descriptor: Arc<Descriptor>,


### PR DESCRIPTION

https://github.com/bitcoindevkit/bdk-ffi/pull/1030 needs to go in first

### Description

Adds `Wallet::load_from_two_path_descriptor`, allowing bindings consumers to load a persisted wallet from a BIP 389 two-path descriptor while checking both external and internal keychains.

This mirrors the upstream `bdk_wallet` load flow using `Wallet::load().two_path_descriptor(...).load_wallet(...)`.

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Documentation

<!-- Paste the canonical docs/spec for anything this PR wraps or updates. -->

- [ ] [`bdk_wallet`](https://docs.rs/bdk_wallet/latest/bdk_wallet/)
https://docs.rs/bdk_wallet/latest/bdk_wallet/struct.LoadParams.html#method.two_path_descriptor
- [ ] [`bitcoin`](https://docs.rs/bitcoin/latest/bitcoin/index.html)
  <!-- Add a link below with the docs.rs page. -->
- [ ] [`uniffi`](https://github.com/mozilla/uniffi-rs) <!-- Add a link below with the version changelog or any other docs. -->
- [ ] Other: <!-- Add a link below with additional references -->

### Changelog

<!-- Add exactly one changelog label to this PR:
`changelog: added`, `changelog: changed`, `changelog: fixed`, `changelog: breaking`, or `changelog: none`.
These labels map to the Keep a Changelog categories used by `CHANGELOG.md` where possible.
GitHub generated release notes use the label plus the PR title to draft the changelog.
-->

### Checklists

#### All Submissions:

* [ ] I've signed all my commits
* [ ] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [ ] I ran `cargo fmt` and `cargo clippy` before committing
* [ ] I've added exactly one `changelog:*` label
* [ ] I've linked the relevant upstream docs or specs above

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
