### PR TITLE
feat: expose wallet signing with provided signers

### DIFF
--- a/bdk-ffi/src/lib.rs
+++ b/bdk-ffi/src/lib.rs
@@ -6,6 +6,7 @@ mod esplora;
 mod keys;
 mod kyoto;
 mod macros;
+mod signer;
 mod store;
 mod tx_builder;
 mod types;

--- a/bdk-ffi/src/signer.rs
+++ b/bdk-ffi/src/signer.rs
@@ -40,7 +40,7 @@ impl SignersContainer {
         Self { inner }
     }
 
-    /// Returns the number of signers in the container.
+    /// Returns the number of signer entries registered in the container.
     pub fn len(&self) -> u64 {
         self.inner.signers().len() as u64
     }

--- a/bdk-ffi/src/signer.rs
+++ b/bdk-ffi/src/signer.rs
@@ -1,0 +1,58 @@
+use crate::descriptor::Descriptor;
+
+use bdk_wallet::bitcoin::key::Secp256k1;
+use bdk_wallet::signer::SignersContainer as BdkSignersContainer;
+
+use std::sync::Arc;
+
+/// Container for multiple signers.
+#[derive(Debug, uniffi::Object)]
+pub struct SignersContainer {
+    pub(crate) inner: BdkSignersContainer,
+}
+
+#[uniffi::export]
+impl SignersContainer {
+    /// Build a new signer container from a descriptor's key map.
+    ///
+    /// Also looks at the same descriptor to determine the `SignerContext` to attach to the signers.
+    #[uniffi::constructor]
+    pub fn from_descriptor(descriptor: Arc<Descriptor>) -> Self {
+        Self::from_descriptor_with_context(Arc::clone(&descriptor), descriptor)
+    }
+
+    /// Build a new signer container from a signer descriptor's key map.
+    ///
+    /// Also looks at the corresponding descriptor to determine the `SignerContext` to attach to
+    /// the signers.
+    #[uniffi::constructor]
+    pub fn from_descriptor_with_context(
+        signer_descriptor: Arc<Descriptor>,
+        context_descriptor: Arc<Descriptor>,
+    ) -> Self {
+        let secp = Secp256k1::new();
+        let inner = BdkSignersContainer::build(
+            signer_descriptor.key_map.clone(),
+            &context_descriptor.extended_descriptor,
+            &secp,
+        );
+
+        Self { inner }
+    }
+
+    /// Returns the number of signers in the container.
+    pub fn len(&self) -> u64 {
+        self.inner.signers().len() as u64
+    }
+
+    /// Returns true when the container has no signers.
+    pub fn is_empty(&self) -> bool {
+        self.inner.signers().is_empty()
+    }
+}
+
+impl From<BdkSignersContainer> for SignersContainer {
+    fn from(inner: BdkSignersContainer) -> Self {
+        Self { inner }
+    }
+}

--- a/bdk-ffi/src/signer.rs
+++ b/bdk-ffi/src/signer.rs
@@ -50,9 +50,3 @@ impl SignersContainer {
         self.inner.signers().is_empty()
     }
 }
-
-impl From<BdkSignersContainer> for SignersContainer {
-    fn from(inner: BdkSignersContainer) -> Self {
-        Self { inner }
-    }
-}

--- a/bdk-ffi/src/tests/wallet.rs
+++ b/bdk-ffi/src/tests/wallet.rs
@@ -1,8 +1,11 @@
-use crate::bitcoin::{Network, NetworkKind};
+use crate::bitcoin::{Network, NetworkKind, Psbt, Transaction};
 use crate::descriptor::Descriptor;
+use crate::signer::SignersContainer;
 use crate::store::Persister;
 use crate::wallet::Wallet;
 
+use bdk_wallet::bitcoin::Transaction as BdkTransaction;
+use bdk_wallet::bitcoin::{absolute, consensus::serialize, transaction};
 use bdk_wallet::KeychainKind;
 
 use std::sync::Arc;
@@ -33,6 +36,18 @@ fn build_wallet() -> Wallet {
         25,
     )
     .unwrap()
+}
+
+fn empty_psbt() -> Arc<Psbt> {
+    let tx = BdkTransaction {
+        version: transaction::Version::TWO,
+        lock_time: absolute::LockTime::ZERO,
+        input: vec![],
+        output: vec![],
+    };
+    let tx = Arc::new(Transaction::new(serialize(&tx)).unwrap());
+
+    Psbt::from_unsigned_tx(tx).unwrap()
 }
 
 #[test]
@@ -88,6 +103,41 @@ fn test_reveal_next_address() {
     assert_eq!(address_info.index, 0);
     assert_eq!(address_info.keychain, KeychainKind::External);
     assert_eq!(address_info.address.to_string(), EXPECTED_FIRST_ADDRESS);
+}
+
+#[test]
+fn test_signers_container_from_descriptor() {
+    let signers = SignersContainer::from_descriptor(external_descriptor());
+
+    assert!(!signers.is_empty());
+    assert_eq!(signers.len(), 1);
+}
+
+#[test]
+fn test_get_signers() {
+    let wallet = build_wallet();
+
+    let external_signers = wallet.get_signers(KeychainKind::External);
+    let internal_signers = wallet.get_signers(KeychainKind::Internal);
+
+    assert!(!external_signers.is_empty());
+    assert!(!internal_signers.is_empty());
+    assert_eq!(external_signers.len(), 1);
+    assert_eq!(internal_signers.len(), 1);
+}
+
+#[test]
+fn test_sign_with_signers() {
+    let wallet = build_wallet();
+    let psbt = empty_psbt();
+    let signers = vec![
+        wallet.get_signers(KeychainKind::External),
+        wallet.get_signers(KeychainKind::Internal),
+    ];
+
+    let finalized = wallet.sign_with_signers(psbt, signers, None).unwrap();
+
+    assert!(finalized);
 }
 
 #[test]

--- a/bdk-ffi/src/tests/wallet.rs
+++ b/bdk-ffi/src/tests/wallet.rs
@@ -1,11 +1,14 @@
-use crate::bitcoin::{Network, NetworkKind, Psbt, Transaction};
+use crate::bitcoin::{Amount, Network, NetworkKind};
 use crate::descriptor::Descriptor;
 use crate::signer::SignersContainer;
 use crate::store::Persister;
+use crate::tx_builder::TxBuilder;
+use crate::types::Update;
 use crate::wallet::Wallet;
 
+use bdk_wallet::bitcoin::Amount as BdkAmount;
 use bdk_wallet::bitcoin::Transaction as BdkTransaction;
-use bdk_wallet::bitcoin::{absolute, consensus::serialize, transaction};
+use bdk_wallet::bitcoin::{absolute, transaction, TxOut as BdkTxOut};
 use bdk_wallet::KeychainKind;
 
 use std::sync::Arc;
@@ -38,16 +41,35 @@ fn build_wallet() -> Wallet {
     .unwrap()
 }
 
-fn empty_psbt() -> Arc<Psbt> {
-    let tx = BdkTransaction {
-        version: transaction::Version::TWO,
+fn funded_wallet() -> Wallet {
+    let wallet = Wallet::new(
+        external_descriptor(),
+        internal_descriptor(),
+        Network::Regtest,
+        Arc::new(Persister::new_in_memory().unwrap()),
+        25,
+    )
+    .unwrap();
+
+    let address = wallet.reveal_next_address(KeychainKind::External).address;
+    let funding_tx = BdkTransaction {
+        version: transaction::Version::ONE,
         lock_time: absolute::LockTime::ZERO,
         input: vec![],
-        output: vec![],
+        output: vec![BdkTxOut {
+            value: BdkAmount::from_sat(76_000),
+            script_pubkey: address.script_pubkey().0.clone(),
+        }],
     };
-    let tx = Arc::new(Transaction::new(serialize(&tx)).unwrap());
+    let txid = funding_tx.compute_txid();
+    let mut update = bdk_wallet::Update::default();
+    update.last_active_indices.insert(KeychainKind::External, 0);
+    update.tx_update.txs.push(Arc::new(funding_tx));
+    update.tx_update.seen_ats.insert((txid, 1));
 
-    Psbt::from_unsigned_tx(tx).unwrap()
+    wallet.apply_update(Arc::new(Update(update))).unwrap();
+
+    wallet
 }
 
 #[test]
@@ -115,16 +137,26 @@ fn test_signers_container_from_descriptor() {
 
 #[test]
 fn test_sign_with_signers() {
-    let wallet = build_wallet();
-    let psbt = empty_psbt();
-    let signers = vec![
-        Arc::new(SignersContainer::from_descriptor(external_descriptor())),
-        Arc::new(SignersContainer::from_descriptor(internal_descriptor())),
-    ];
+    let wallet = Arc::new(funded_wallet());
+    let recipient_script = wallet
+        .next_unused_address(KeychainKind::External)
+        .address
+        .script_pubkey();
+    let psbt = TxBuilder::new()
+        .add_recipient(&recipient_script, Arc::new(Amount::from_sat(10_000)))
+        .finish(&wallet)
+        .unwrap();
+    let signers = vec![Arc::new(SignersContainer::from_descriptor(
+        external_descriptor(),
+    ))];
 
-    let finalized = wallet.sign_with_signers(psbt, signers, None).unwrap();
+    let finalized = wallet
+        .sign_with_signers(Arc::clone(&psbt), signers, None)
+        .unwrap();
+    let signed_tx = psbt.extract_tx().unwrap();
 
     assert!(finalized);
+    assert!(!signed_tx.input()[0].witness.is_empty());
 }
 
 #[test]

--- a/bdk-ffi/src/tests/wallet.rs
+++ b/bdk-ffi/src/tests/wallet.rs
@@ -114,25 +114,12 @@ fn test_signers_container_from_descriptor() {
 }
 
 #[test]
-fn test_get_signers() {
-    let wallet = build_wallet();
-
-    let external_signers = wallet.get_signers(KeychainKind::External);
-    let internal_signers = wallet.get_signers(KeychainKind::Internal);
-
-    assert!(!external_signers.is_empty());
-    assert!(!internal_signers.is_empty());
-    assert_eq!(external_signers.len(), 1);
-    assert_eq!(internal_signers.len(), 1);
-}
-
-#[test]
 fn test_sign_with_signers() {
     let wallet = build_wallet();
     let psbt = empty_psbt();
     let signers = vec![
-        wallet.get_signers(KeychainKind::External),
-        wallet.get_signers(KeychainKind::Internal),
+        Arc::new(SignersContainer::from_descriptor(external_descriptor())),
+        Arc::new(SignersContainer::from_descriptor(internal_descriptor())),
     ];
 
     let finalized = wallet.sign_with_signers(psbt, signers, None).unwrap();

--- a/bdk-ffi/src/tests/wallet.rs
+++ b/bdk-ffi/src/tests/wallet.rs
@@ -160,6 +160,64 @@ fn test_sign_with_signers() {
 }
 
 #[test]
+fn test_sign_with_signers_for_public_wallet() {
+    let external_signer_descriptor = external_descriptor();
+    let external_public_descriptor = Arc::new(
+        Descriptor::new(external_signer_descriptor.to_string(), NetworkKind::Test).unwrap(),
+    );
+    let internal_public_descriptor =
+        Arc::new(Descriptor::new(internal_descriptor().to_string(), NetworkKind::Test).unwrap());
+    let wallet = Arc::new(
+        Wallet::new(
+            Arc::clone(&external_public_descriptor),
+            internal_public_descriptor,
+            Network::Regtest,
+            Arc::new(Persister::new_in_memory().unwrap()),
+            25,
+        )
+        .unwrap(),
+    );
+
+    let address = wallet.reveal_next_address(KeychainKind::External).address;
+    let funding_tx = BdkTransaction {
+        version: transaction::Version::ONE,
+        lock_time: absolute::LockTime::ZERO,
+        input: vec![],
+        output: vec![BdkTxOut {
+            value: BdkAmount::from_sat(76_000),
+            script_pubkey: address.script_pubkey().0.clone(),
+        }],
+    };
+    let txid = funding_tx.compute_txid();
+    let mut update = bdk_wallet::Update::default();
+    update.last_active_indices.insert(KeychainKind::External, 0);
+    update.tx_update.txs.push(Arc::new(funding_tx));
+    update.tx_update.seen_ats.insert((txid, 1));
+    wallet.apply_update(Arc::new(Update(update))).unwrap();
+
+    let recipient_script = wallet
+        .next_unused_address(KeychainKind::External)
+        .address
+        .script_pubkey();
+    let psbt = TxBuilder::new()
+        .add_recipient(&recipient_script, Arc::new(Amount::from_sat(10_000)))
+        .finish(&wallet)
+        .unwrap();
+    let signers = vec![Arc::new(SignersContainer::from_descriptor_with_context(
+        external_signer_descriptor,
+        external_public_descriptor,
+    ))];
+
+    let finalized = wallet
+        .sign_with_signers(Arc::clone(&psbt), signers, None)
+        .unwrap();
+    let signed_tx = psbt.extract_tx().unwrap();
+
+    assert!(finalized);
+    assert!(!signed_tx.input()[0].witness.is_empty());
+}
+
+#[test]
 fn test_create_single_wallet() {
     let wallet = Wallet::create_single(
         external_descriptor(),

--- a/bdk-ffi/src/tests/wallet.rs
+++ b/bdk-ffi/src/tests/wallet.rs
@@ -129,10 +129,16 @@ fn test_reveal_next_address() {
 
 #[test]
 fn test_signers_container_from_descriptor() {
-    let signers = SignersContainer::from_descriptor(external_descriptor());
+    let secret_descriptor = external_descriptor();
+    let public_descriptor =
+        Arc::new(Descriptor::new(secret_descriptor.to_string(), NetworkKind::Test).unwrap());
+    let secret_signers = SignersContainer::from_descriptor(secret_descriptor);
+    let public_signers = SignersContainer::from_descriptor(public_descriptor);
 
-    assert!(!signers.is_empty());
-    assert_eq!(signers.len(), 1);
+    assert!(!secret_signers.is_empty());
+    assert_eq!(secret_signers.len(), 1);
+    assert!(public_signers.is_empty());
+    assert_eq!(public_signers.len(), 0);
 }
 
 #[test]

--- a/bdk-ffi/src/wallet.rs
+++ b/bdk-ffi/src/wallet.rs
@@ -486,13 +486,6 @@ impl Wallet {
         self.get_wallet().is_mine(script.0.clone())
     }
 
-    /// Get the signers.
-    pub fn get_signers(&self, keychain: KeychainKind) -> Arc<SignersContainer> {
-        let signers = self.get_wallet().get_signers(keychain).as_ref().clone();
-
-        Arc::new(SignersContainer::from(signers))
-    }
-
     /// Sign a transaction with all the wallet's signers, in the order specified by every signer's
     /// [`SignerOrdering`]. This function returns the `Result` type with an encapsulated `bool` that
     /// has the value true if the PSBT was finalized, or false otherwise.

--- a/bdk-ffi/src/wallet.rs
+++ b/bdk-ffi/src/wallet.rs
@@ -4,6 +4,7 @@ use crate::error::{
     CalculateFeeError, CannotConnectError, CreateWithPersistError, DescriptorError,
     LoadWithPersistError, PersistenceError, SignerError, TxidParseError,
 };
+use crate::signer::SignersContainer;
 use crate::store::{PersistenceType, Persister};
 use crate::types::{
     AddressInfo, Balance, BlockId, CanonicalTx, ChangeSet, EvictedTx, FullScanRequestBuilder,
@@ -485,6 +486,13 @@ impl Wallet {
         self.get_wallet().is_mine(script.0.clone())
     }
 
+    /// Get the signers.
+    pub fn get_signers(&self, keychain: KeychainKind) -> Arc<SignersContainer> {
+        let signers = self.get_wallet().get_signers(keychain).as_ref().clone();
+
+        Arc::new(SignersContainer::from(signers))
+    }
+
     /// Sign a transaction with all the wallet's signers, in the order specified by every signer's
     /// [`SignerOrdering`]. This function returns the `Result` type with an encapsulated `bool` that
     /// has the value true if the PSBT was finalized, or false otherwise.
@@ -508,6 +516,40 @@ impl Wallet {
 
         self.get_wallet()
             .sign(&mut psbt, bdk_sign_options)
+            .map_err(SignerError::from)
+    }
+
+    /// Sign a transaction with the provided signer containers.
+    ///
+    /// Signer containers are processed in the order provided. Signers inside each container are
+    /// processed according to their `SignerOrdering`.
+    ///
+    /// The `SignOptions` can be used to tweak the behavior of the software signers, and the way
+    /// the transaction is finalized at the end. Note that it can't be guaranteed that every signer
+    /// will follow the options, but the "software signers" (WIF keys and `xprv`) defined in this
+    /// library will.
+    ///
+    /// Returns true if the PSBT was finalized, or false otherwise.
+    #[uniffi::method(default(sign_options = None))]
+    #[allow(deprecated)]
+    pub fn sign_with_signers(
+        &self,
+        psbt: Arc<Psbt>,
+        signers: Vec<Arc<SignersContainer>>,
+        sign_options: Option<SignOptions>,
+    ) -> Result<bool, SignerError> {
+        let mut psbt = psbt.0.lock().unwrap();
+        let bdk_sign_options: BdkSignOptions = match sign_options {
+            Some(sign_options) => BdkSignOptions::from(sign_options),
+            None => BdkSignOptions::default(),
+        };
+        let signers = signers
+            .iter()
+            .map(|container| &container.inner)
+            .collect::<Vec<_>>();
+
+        self.get_wallet()
+            .sign_with_signers(&mut psbt, &signers, bdk_sign_options)
             .map_err(SignerError::from)
     }
 

--- a/bdk-ffi/src/wallet.rs
+++ b/bdk-ffi/src/wallet.rs
@@ -524,7 +524,6 @@ impl Wallet {
     ///
     /// Returns true if the PSBT was finalized, or false otherwise.
     #[uniffi::method(default(sign_options = None))]
-    #[allow(deprecated)]
     pub fn sign_with_signers(
         &self,
         psbt: Arc<Psbt>,


### PR DESCRIPTION
https://github.com/bitcoindevkit/bdk-ffi/pull/1030 first

### Description

Adds wrapper for `bdk_wallet::Wallet::sign_with_signers`, allowing bindings consumers to sign a PSBT with explicit `SignersContainer` values instead of only the wallet-owned signers.

This also adds a `SignersContainer` wrapper that can be constructed from descriptor key material and passed into the new wallet signing method.

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Documentation

<!-- Paste the canonical docs/spec for anything this PR wraps or updates. -->

- [x] [`bdk_wallet`](https://docs.rs/bdk_wallet/latest/bdk_wallet/)
https://docs.rs/bdk_wallet/3.1.0/bdk_wallet/struct.Wallet.html#method.sign_with_signers
- [ ] [`bitcoin`](https://docs.rs/bitcoin/latest/bitcoin/index.html)
  <!-- Add a link below with the docs.rs page. -->
- [ ] [`uniffi`](https://github.com/mozilla/uniffi-rs) <!-- Add a link below with the version changelog or any other docs. -->
- [ ] Other: <!-- Add a link below with additional references -->

### Changelog

<!-- Add exactly one changelog label to this PR:
`changelog: added`, `changelog: changed`, `changelog: fixed`, `changelog: breaking`, or `changelog: none`.
These labels map to the Keep a Changelog categories used by `CHANGELOG.md` where possible.
GitHub generated release notes use the label plus the PR title to draft the changelog.
-->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
* [x] I've added exactly one `changelog:*` label
* [x] I've linked the relevant upstream docs or specs above

#### New Features:

* [x] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
