### PR TITLE
feat: expose Wallet create and load params

### DIFF
--- a/bdk-ffi/src/tests/wallet.rs
+++ b/bdk-ffi/src/tests/wallet.rs
@@ -413,3 +413,37 @@ fn test_load_from_two_path_descriptor() {
         1
     );
 }
+
+#[test]
+fn test_load_from_two_path_descriptor_with_params() {
+    let persister = Arc::new(Persister::new_in_memory().unwrap());
+    Wallet::create_from_two_path_descriptor(
+        two_path_descriptor(),
+        Network::Signet,
+        Arc::clone(&persister),
+        25,
+    )
+    .unwrap();
+
+    let params = LoadParams {
+        check_network: Some(Network::Bitcoin),
+        check_genesis_hash: None,
+        lookahead: 25,
+        use_spk_cache: false,
+    };
+    let error = match Wallet::load_from_two_path_descriptor_with_params(
+        two_path_descriptor(),
+        persister,
+        params,
+    ) {
+        Ok(_) => panic!("loading with mismatched network should fail"),
+        Err(error) => error,
+    };
+
+    match error {
+        LoadWithPersistError::InvalidChangeSet { error_message } => {
+            assert!(error_message.contains("Network mismatch"));
+        }
+        error => panic!("expected InvalidChangeSet error, got {:?}", error),
+    }
+}

--- a/bdk-ffi/src/tests/wallet.rs
+++ b/bdk-ffi/src/tests/wallet.rs
@@ -1,10 +1,11 @@
-use crate::bitcoin::{Amount, Network, NetworkKind};
+use crate::bitcoin::{Amount, BlockHash, Network, NetworkKind};
 use crate::descriptor::Descriptor;
+use crate::error::LoadWithPersistError;
 use crate::signer::SignersContainer;
 use crate::store::Persister;
 use crate::tx_builder::TxBuilder;
 use crate::types::Update;
-use crate::wallet::Wallet;
+use crate::wallet::{CreateParams, LoadParams, Wallet};
 
 use bdk_wallet::bitcoin::Amount as BdkAmount;
 use bdk_wallet::bitcoin::Transaction as BdkTransaction;
@@ -28,6 +29,15 @@ fn internal_descriptor() -> Arc<Descriptor> {
 
 fn two_path_descriptor() -> Arc<Descriptor> {
     Arc::new(Descriptor::new(TWO_PATH_DESCRIPTOR.to_string(), NetworkKind::Test).unwrap())
+}
+
+fn custom_genesis_hash() -> Arc<BlockHash> {
+    Arc::new(
+        BlockHash::from_string(
+            "0000000000000000000000000000000000000000000000000000000000000000".to_string(),
+        )
+        .unwrap(),
+    )
 }
 
 fn build_wallet() -> Wallet {
@@ -70,6 +80,88 @@ fn funded_wallet() -> Wallet {
     wallet.apply_update(Arc::new(Update(update))).unwrap();
 
     wallet
+}
+
+#[test]
+fn test_create_wallet_with_params_sets_custom_genesis_hash() {
+    let genesis_hash = custom_genesis_hash();
+    let params = CreateParams {
+        genesis_hash: Some(Arc::clone(&genesis_hash)),
+        lookahead: 25,
+        use_spk_cache: true,
+    };
+
+    let wallet = Wallet::create_with_params(
+        external_descriptor(),
+        internal_descriptor(),
+        Network::Signet,
+        Arc::new(Persister::new_in_memory().unwrap()),
+        params,
+    )
+    .unwrap();
+
+    assert_eq!(wallet.network(), Network::Signet);
+    assert_eq!(wallet.latest_checkpoint().hash, genesis_hash);
+}
+
+#[test]
+fn test_load_wallet_with_params_checks_network_and_genesis_hash() {
+    let persister = Arc::new(Persister::new_in_memory().unwrap());
+    let genesis_hash = custom_genesis_hash();
+    let create_params = CreateParams {
+        genesis_hash: Some(Arc::clone(&genesis_hash)),
+        lookahead: 25,
+        use_spk_cache: true,
+    };
+
+    Wallet::create_with_params(
+        external_descriptor(),
+        internal_descriptor(),
+        Network::Signet,
+        Arc::clone(&persister),
+        create_params,
+    )
+    .unwrap();
+
+    let load_params = LoadParams {
+        check_network: Some(Network::Signet),
+        check_genesis_hash: Some(Arc::clone(&genesis_hash)),
+        lookahead: 25,
+        use_spk_cache: true,
+    };
+    let wallet = Wallet::load_with_params(
+        external_descriptor(),
+        internal_descriptor(),
+        Arc::clone(&persister),
+        load_params,
+    )
+    .unwrap();
+
+    assert_eq!(wallet.network(), Network::Signet);
+    assert_eq!(wallet.latest_checkpoint().hash, genesis_hash);
+
+    let mismatched_params = LoadParams {
+        check_network: Some(Network::Bitcoin),
+        check_genesis_hash: Some(custom_genesis_hash()),
+        lookahead: 25,
+        use_spk_cache: true,
+    };
+    let error = match Wallet::load_with_params(
+        external_descriptor(),
+        internal_descriptor(),
+        persister,
+        mismatched_params,
+    ) {
+        Ok(_) => panic!("loading with mismatched network should fail"),
+        Err(error) => error,
+    };
+
+    match error {
+        LoadWithPersistError::InvalidChangeSet { error_message } => {
+            assert!(error_message.contains("Network mismatch"));
+        }
+        error => panic!("expected InvalidChangeSet error, got {:?}", error),
+    }
 }
 
 #[test]

--- a/bdk-ffi/src/wallet.rs
+++ b/bdk-ffi/src/wallet.rs
@@ -341,13 +341,34 @@ impl Wallet {
         persister: Arc<Persister>,
         lookahead: u32,
     ) -> Result<Wallet, LoadWithPersistError> {
+        Self::load_from_two_path_descriptor_with_params(
+            two_path_descriptor,
+            persister,
+            LoadParams::with_lookahead(lookahead),
+        )
+    }
+
+    /// Build a two-path descriptor `Wallet` by loading from persistence with explicit load
+    /// parameters.
+    ///
+    /// Checks that the provided two-path descriptor matches exactly what is loaded
+    /// for both the external and internal keychains.
+    ///
+    /// The provided descriptor may only contain extended public keys (`xpub`) with exactly 2 paths.
+    #[uniffi::constructor]
+    pub fn load_from_two_path_descriptor_with_params(
+        two_path_descriptor: Arc<Descriptor>,
+        persister: Arc<Persister>,
+        params: LoadParams,
+    ) -> Result<Wallet, LoadWithPersistError> {
         let descriptor = two_path_descriptor.to_string();
         let mut persist_lock = persister.inner.lock().unwrap();
         let deref = persist_lock.deref_mut();
 
-        let wallet: PersistedWallet<PersistenceType> = BdkWallet::load()
-            .two_path_descriptor(descriptor)
-            .lookahead(lookahead)
+        let bdk_params = BdkWallet::load().two_path_descriptor(descriptor);
+        let bdk_params = params.apply_to(bdk_params);
+
+        let wallet: PersistedWallet<PersistenceType> = bdk_params
             .load_wallet(deref)
             .map_err(LoadWithPersistError::from)?
             .ok_or(LoadWithPersistError::CouldNotLoad)?;

--- a/bdk-ffi/src/wallet.rs
+++ b/bdk-ffi/src/wallet.rs
@@ -1,4 +1,6 @@
-use crate::bitcoin::{Amount, FeeRate, OutPoint, Psbt, Script, Transaction, TxOut, Txid};
+use crate::bitcoin::{
+    Amount, BlockHash, FeeRate, OutPoint, Psbt, Script, Transaction, TxOut, Txid,
+};
 use crate::descriptor::Descriptor;
 use crate::error::{
     CalculateFeeError, CannotConnectError, CreateWithPersistError, DescriptorError,
@@ -16,7 +18,10 @@ use bdk_wallet::bitcoin::Network;
 use bdk_wallet::keys::KeyMap;
 #[allow(deprecated)]
 use bdk_wallet::signer::SignOptions as BdkSignOptions;
-use bdk_wallet::{PersistedWallet, Wallet as BdkWallet};
+use bdk_wallet::{
+    CreateParams as BdkCreateParams, LoadParams as BdkLoadParams, PersistedWallet,
+    Wallet as BdkWallet,
+};
 
 use std::ops::DerefMut;
 use std::sync::{Arc, Mutex, MutexGuard};
@@ -38,6 +43,79 @@ pub struct Wallet {
     inner_mutex: Mutex<PersistedWallet<PersistenceType>>,
 }
 
+/// Parameters for `Wallet` creation.
+#[derive(Clone, Debug, uniffi::Record)]
+pub struct CreateParams {
+    /// Use a custom `genesis_hash`.
+    pub genesis_hash: Option<Arc<BlockHash>>,
+    /// Use a custom `lookahead` value.
+    pub lookahead: u32,
+    /// Use a persistent cache of indexed script pubkeys (SPKs).
+    pub use_spk_cache: bool,
+}
+
+impl CreateParams {
+    fn with_lookahead(lookahead: u32) -> Self {
+        Self {
+            genesis_hash: None,
+            lookahead,
+            use_spk_cache: false,
+        }
+    }
+
+    fn apply_to(self, params: BdkCreateParams) -> BdkCreateParams {
+        let mut params = params
+            .lookahead(self.lookahead)
+            .use_spk_cache(self.use_spk_cache);
+
+        if let Some(genesis_hash) = self.genesis_hash {
+            params = params.genesis_hash(genesis_hash.as_ref().0);
+        }
+
+        params
+    }
+}
+
+/// Parameters for `Wallet` loading.
+#[derive(Clone, Debug, uniffi::Record)]
+pub struct LoadParams {
+    /// Checks that the given network matches the one loaded from persistence.
+    pub check_network: Option<Network>,
+    /// Checks that the given `genesis_hash` matches the one loaded from persistence.
+    pub check_genesis_hash: Option<Arc<BlockHash>>,
+    /// Use a custom `lookahead` value.
+    pub lookahead: u32,
+    /// Use a persistent cache of indexed script pubkeys (SPKs).
+    pub use_spk_cache: bool,
+}
+
+impl LoadParams {
+    fn with_lookahead(lookahead: u32) -> Self {
+        Self {
+            check_network: None,
+            check_genesis_hash: None,
+            lookahead,
+            use_spk_cache: false,
+        }
+    }
+
+    fn apply_to(self, params: BdkLoadParams) -> BdkLoadParams {
+        let mut params = params
+            .lookahead(self.lookahead)
+            .use_spk_cache(self.use_spk_cache);
+
+        if let Some(network) = self.check_network {
+            params = params.check_network(network);
+        }
+
+        if let Some(genesis_hash) = self.check_genesis_hash {
+            params = params.check_genesis_hash(genesis_hash.as_ref().0);
+        }
+
+        params
+    }
+}
+
 #[uniffi::export]
 impl Wallet {
     /// Build a new Wallet.
@@ -51,17 +129,37 @@ impl Wallet {
         persister: Arc<Persister>,
         lookahead: u32,
     ) -> Result<Self, CreateWithPersistError> {
+        Self::create_with_params(
+            descriptor,
+            change_descriptor,
+            network,
+            persister,
+            CreateParams::with_lookahead(lookahead),
+        )
+    }
+
+    /// Build a new Wallet with explicit create parameters.
+    ///
+    /// If you have previously created a wallet, use load instead.
+    #[uniffi::constructor]
+    pub fn create_with_params(
+        descriptor: Arc<Descriptor>,
+        change_descriptor: Arc<Descriptor>,
+        network: Network,
+        persister: Arc<Persister>,
+        params: CreateParams,
+    ) -> Result<Self, CreateWithPersistError> {
         let descriptor = descriptor.to_string_with_secret();
         let change_descriptor = change_descriptor.to_string_with_secret();
         let mut persist_lock = persister.inner.lock().unwrap();
         let deref = persist_lock.deref_mut();
 
-        let wallet: PersistedWallet<PersistenceType> =
-            BdkWallet::create(descriptor, change_descriptor)
-                .network(network)
-                .lookahead(lookahead)
-                .create_wallet(deref)
-                .map_err(CreateWithPersistError::from)?;
+        let bdk_params = BdkWallet::create(descriptor, change_descriptor).network(network);
+        let bdk_params = params.apply_to(bdk_params);
+
+        let wallet: PersistedWallet<PersistenceType> = bdk_params
+            .create_wallet(deref)
+            .map_err(CreateWithPersistError::from)?;
 
         Ok(Wallet {
             inner_mutex: Mutex::new(wallet),
@@ -93,13 +191,32 @@ impl Wallet {
         persister: Arc<Persister>,
         lookahead: u32,
     ) -> Result<Self, CreateWithPersistError> {
+        Self::create_single_with_params(
+            descriptor,
+            network,
+            persister,
+            CreateParams::with_lookahead(lookahead),
+        )
+    }
+
+    /// Build a new single descriptor `Wallet` with explicit create parameters.
+    ///
+    /// If you have previously created a wallet, use `Wallet::load` instead.
+    #[uniffi::constructor]
+    pub fn create_single_with_params(
+        descriptor: Arc<Descriptor>,
+        network: Network,
+        persister: Arc<Persister>,
+        params: CreateParams,
+    ) -> Result<Self, CreateWithPersistError> {
         let descriptor = descriptor.to_string_with_secret();
         let mut persist_lock = persister.inner.lock().unwrap();
         let deref = persist_lock.deref_mut();
 
-        let wallet: PersistedWallet<PersistenceType> = BdkWallet::create_single(descriptor)
-            .network(network)
-            .lookahead(lookahead)
+        let bdk_params = BdkWallet::create_single(descriptor).network(network);
+        let bdk_params = params.apply_to(bdk_params);
+
+        let wallet: PersistedWallet<PersistenceType> = bdk_params
             .create_wallet(deref)
             .map_err(CreateWithPersistError::from)?;
 
@@ -129,16 +246,34 @@ impl Wallet {
         persister: Arc<Persister>,
         lookahead: u32,
     ) -> Result<Self, CreateWithPersistError> {
+        Self::create_from_two_path_descriptor_with_params(
+            two_path_descriptor,
+            network,
+            persister,
+            CreateParams::with_lookahead(lookahead),
+        )
+    }
+
+    /// Build a new `Wallet` from a two-path descriptor with explicit create parameters.
+    ///
+    /// If you have previously created a wallet, use load instead.
+    #[uniffi::constructor]
+    pub fn create_from_two_path_descriptor_with_params(
+        two_path_descriptor: Arc<Descriptor>,
+        network: Network,
+        persister: Arc<Persister>,
+        params: CreateParams,
+    ) -> Result<Self, CreateWithPersistError> {
         let descriptor = two_path_descriptor.to_string_with_secret();
         let mut persist_lock = persister.inner.lock().unwrap();
         let deref = persist_lock.deref_mut();
 
-        let wallet: PersistedWallet<PersistenceType> =
-            BdkWallet::create_from_two_path_descriptor(descriptor)
-                .network(network)
-                .lookahead(lookahead)
-                .create_wallet(deref)
-                .map_err(CreateWithPersistError::from)?;
+        let bdk_params = BdkWallet::create_from_two_path_descriptor(descriptor).network(network);
+        let bdk_params = params.apply_to(bdk_params);
+
+        let wallet: PersistedWallet<PersistenceType> = bdk_params
+            .create_wallet(deref)
+            .map_err(CreateWithPersistError::from)?;
 
         Ok(Wallet {
             inner_mutex: Mutex::new(wallet),
@@ -155,16 +290,36 @@ impl Wallet {
         persister: Arc<Persister>,
         lookahead: u32,
     ) -> Result<Wallet, LoadWithPersistError> {
+        Self::load_with_params(
+            descriptor,
+            change_descriptor,
+            persister,
+            LoadParams::with_lookahead(lookahead),
+        )
+    }
+
+    /// Build Wallet by loading from persistence with explicit load parameters.
+    ///
+    /// Note that the descriptor secret keys are not persisted to the db.
+    #[uniffi::constructor]
+    pub fn load_with_params(
+        descriptor: Arc<Descriptor>,
+        change_descriptor: Arc<Descriptor>,
+        persister: Arc<Persister>,
+        params: LoadParams,
+    ) -> Result<Wallet, LoadWithPersistError> {
         let descriptor = descriptor.to_string_with_secret();
         let change_descriptor = change_descriptor.to_string_with_secret();
         let mut persist_lock = persister.inner.lock().unwrap();
         let deref = persist_lock.deref_mut();
 
-        let wallet: PersistedWallet<PersistenceType> = BdkWallet::load()
+        let bdk_params = BdkWallet::load()
             .descriptor(KeychainKind::External, Some(descriptor))
             .descriptor(KeychainKind::Internal, Some(change_descriptor))
-            .lookahead(lookahead)
-            .extract_keys()
+            .extract_keys();
+        let bdk_params = params.apply_to(bdk_params);
+
+        let wallet: PersistedWallet<PersistenceType> = bdk_params
             .load_wallet(deref)
             .map_err(LoadWithPersistError::from)?
             .ok_or(LoadWithPersistError::CouldNotLoad)?;
@@ -211,14 +366,28 @@ impl Wallet {
         persister: Arc<Persister>,
         lookahead: u32,
     ) -> Result<Wallet, LoadWithPersistError> {
+        Self::load_single_with_params(descriptor, persister, LoadParams::with_lookahead(lookahead))
+    }
+
+    /// Build a single-descriptor Wallet by loading from persistence with explicit load parameters.
+    ///
+    /// Note that the descriptor secret keys are not persisted to the db.
+    #[uniffi::constructor]
+    pub fn load_single_with_params(
+        descriptor: Arc<Descriptor>,
+        persister: Arc<Persister>,
+        params: LoadParams,
+    ) -> Result<Wallet, LoadWithPersistError> {
         let descriptor = descriptor.to_string_with_secret();
         let mut persist_lock = persister.inner.lock().unwrap();
         let deref = persist_lock.deref_mut();
 
-        let wallet: PersistedWallet<PersistenceType> = BdkWallet::load()
+        let bdk_params = BdkWallet::load()
             .descriptor(KeychainKind::External, Some(descriptor))
-            .lookahead(lookahead)
-            .extract_keys()
+            .extract_keys();
+        let bdk_params = params.apply_to(bdk_params);
+
+        let wallet: PersistedWallet<PersistenceType> = bdk_params
             .load_wallet(deref)
             .map_err(LoadWithPersistError::from)?
             .ok_or(LoadWithPersistError::CouldNotLoad)?;


### PR DESCRIPTION
https://github.com/bitcoindevkit/bdk-ffi/pull/1030 first

### Description

Exposes CreateParams and LoadParams so callers can configure genesis hash, lookahead, SPK cache, and loadtime checks when creating or loading wallets.

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Documentation

<!-- Paste the canonical docs/spec for anything this PR wraps or updates. -->

- [ ] [`bdk_wallet`](https://docs.rs/bdk_wallet/latest/bdk_wallet/)

- [x] [`CreateParams`](https://docs.rs/bdk_wallet/3.1.0/bdk_wallet/struct.CreateParams.html)
- [x] [`LoadParams`](https://docs.rs/bdk_wallet/3.1.0/bdk_wallet/struct.LoadParams.html)
- [x] [`LoadParams::two_path_descriptor`](https://docs.rs/bdk_wallet/3.1.0/bdk_wallet/struct.LoadParams.html#method.two_path_descriptor)

- [ ] [`bitcoin`](https://docs.rs/bitcoin/latest/bitcoin/index.html)
  <!-- Add a link below with the docs.rs page. -->
- [ ] [`uniffi`](https://github.com/mozilla/uniffi-rs) <!-- Add a link below with the version changelog or any other docs. -->
- [ ] Other: <!-- Add a link below with additional references -->

### Changelog

<!-- Add exactly one changelog label to this PR:
`changelog: added`, `changelog: changed`, `changelog: fixed`, `changelog: breaking`, or `changelog: none`.
These labels map to the Keep a Changelog categories used by `CHANGELOG.md` where possible.
GitHub generated release notes use the label plus the PR title to draft the changelog.
-->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
* [x] I've added exactly one `changelog:*` label
* [ ] I've linked the relevant upstream docs or specs above

#### New Features:

* [x] I've added tests for the new feature
* [x] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
