### PR TITLE
feat: expose Display trait on Amount and Psbt types

### DIFF
--- a/bdk-ffi/src/bitcoin.rs
+++ b/bdk-ffi/src/bitcoin.rs
@@ -217,6 +217,7 @@ impl_into_core_type!(FeeRate, BdkFeeRate);
 /// underflow occurs. Also note that since the internal representation of amounts is unsigned,
 /// subtracting below zero is considered an underflow and will cause a panic.
 #[derive(Debug, Clone, PartialEq, Eq, uniffi::Object)]
+#[uniffi::export(Display)]
 pub struct Amount(pub(crate) BdkAmount);
 
 #[uniffi::export]
@@ -248,6 +249,12 @@ impl Amount {
 
 impl_from_core_type!(BdkAmount, Amount);
 impl_into_core_type!(Amount, BdkAmount);
+
+impl Display for Amount {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
 
 /// A bitcoin script: https://en.bitcoin.it/wiki/Script
 #[derive(Clone, Debug, uniffi::Object)]
@@ -1389,6 +1396,7 @@ impl From<&BdkOutput> for Output {
 
 /// A Partially Signed Transaction.
 #[derive(uniffi::Object)]
+#[uniffi::export(Display)]
 pub struct Psbt(pub(crate) Mutex<BdkPsbt>);
 
 #[uniffi::export]
@@ -1529,6 +1537,12 @@ impl Psbt {
 impl From<BdkPsbt> for Psbt {
     fn from(psbt: BdkPsbt) -> Self {
         Psbt(Mutex::new(psbt))
+    }
+}
+
+impl Display for Psbt {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", self.0.lock().unwrap())
     }
 }
 


### PR DESCRIPTION
### Description

Add #[uniffi::export(Display)] and implement the Display trait on the Amount and Psbt types, exposing them to the FFI bindings (Kotlin, Swift, Python).

### Notes to the reviewers

This follows the same pattern used by other types in the codebase (FeeRate, Script, Address, Transaction, WalletEvent, etc.) that already expose Display to bindings. Part of issue #1020.

### Documentation

- [x] [bitcoin](https://docs.rs/bitcoin/latest/bitcoin/index.html) — [Amount](https://docs.rs/bitcoin/latest/bitcoin/amount/struct.Amount.html#impl-Display-for-Amount) and [Psbt](https://docs.rs/bitcoin/latest/bitcoin/psbt/struct.Psbt.html#impl-Display-for-Psbt) already implement Display upstream.

### Changelog

changelog: none

### Checklists

#### All Submissions:

- [x] I've signed all my commits
- [x] I followed the contribution guidelines
- [x] I ran cargo fmt and cargo clippy before committing
- [x] I've added exactly one changelog:* label
- [x] I've linked the relevant upstream docs or specs above

#### New Features:

- [ ] I've added tests for the new feature
- [ ] I've added docs for the new feature