### PR TITLE
feat: Add type secpCtx for Wallet

### DIFF
--- a/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/WalletTest.kt
+++ b/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/WalletTest.kt
@@ -6,6 +6,7 @@ import kotlin.test.assertTrue
 import kotlin.test.assertFalse
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.runner.RunWith
+import kotlin.test.assertNotNull
 
 @RunWith(AndroidJUnit4::class)
 class WalletTest {
@@ -64,5 +65,18 @@ class WalletTest {
             actual = address2.address,
             "Addresses should be the same"
         )
+    }
+
+    @Test
+    fun getWalletSecpCtx() {
+        val wallet: Wallet = Wallet.createSingle(
+            descriptor = BIP84_DESCRIPTOR,
+            network = Network.TESTNET,
+            persister = conn
+        )
+        val secp = wallet.secpCtx()
+        val stringSpec = secp.toString()
+
+        assertNotNull(stringSpec, "SecpCtx should not be null")
     }
 }

--- a/bdk-ffi/src/types.rs
+++ b/bdk-ffi/src/types.rs
@@ -43,6 +43,7 @@ use bdk_esplora::esplora_client::api::MerkleProof as BdkMerkleProof;
 use bdk_esplora::esplora_client::api::OutputStatus as BdkOutputStatus;
 use bdk_esplora::esplora_client::api::Tx as BdkTx;
 use bdk_esplora::esplora_client::api::TxStatus as BdkTxStatus;
+use bdk_wallet::bitcoin::secp256k1::{All, Secp256k1};
 
 pub(crate) type KeychainKind = bdk_wallet::KeychainKind;
 
@@ -1435,6 +1436,30 @@ impl From<bdk_wallet::ChangeSet> for ChangeSet {
             indexer,
             locked_outpoints,
         }
+    }
+}
+
+/// The secp256k1 engine, used to execute all signature operations.
+#[derive(Debug, uniffi::Object)]
+#[uniffi::export(Debug, Display)]
+pub struct SecpCtx {
+    pub(crate) secp: Secp256k1<All>,
+}
+
+#[uniffi::export]
+impl SecpCtx {
+    /// Create a new SecpCtx
+    #[uniffi::constructor]
+    pub fn new() -> Self {
+        SecpCtx {
+            secp: Secp256k1::new(),
+        }
+    }
+}
+
+impl Display for SecpCtx {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self.secp)
     }
 }
 

--- a/bdk-ffi/src/wallet.rs
+++ b/bdk-ffi/src/wallet.rs
@@ -7,10 +7,11 @@ use crate::error::{
 use crate::store::{PersistenceType, Persister};
 use crate::types::{
     AddressInfo, Balance, BlockId, CanonicalTx, ChangeSet, EvictedTx, FullScanRequestBuilder,
-    KeychainAndIndex, KeychainKind, LocalOutput, Policy, SentAndReceivedValues, SignOptions,
-    SyncRequestBuilder, UnconfirmedTx, Update, WalletEvent, WalletKeychain,
+    KeychainAndIndex, KeychainKind, LocalOutput, Policy, SecpCtx, SentAndReceivedValues,
+    SignOptions, SyncRequestBuilder, UnconfirmedTx, Update, WalletEvent, WalletKeychain,
 };
 
+use bdk_wallet::bitcoin::secp256k1::{All, Secp256k1};
 use bdk_wallet::bitcoin::Network;
 use bdk_wallet::keys::KeyMap;
 #[allow(deprecated)]
@@ -769,6 +770,12 @@ impl Wallet {
     /// This can be used to build a watch-only version of a wallet.
     pub fn public_descriptor(&self, keychain: KeychainKind) -> String {
         self.get_wallet().public_descriptor(keychain).to_string()
+    }
+
+    /// Return the secp256k1 context used for all signing operations.
+    pub fn secp_ctx(&self) -> Arc<SecpCtx> {
+        let secp: Secp256k1<All> = self.get_wallet().secp_ctx().clone();
+        Arc::new(SecpCtx { secp })
     }
 }
 


### PR DESCRIPTION
<!-- Erase any parts of this template not applicable to your Pull Request. -->

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->
Addresses #1048 

### Notes to the reviewers
This exposes Secp256k1 for the purposes of using this in our psbt sign. Especially if we want the API to be as close to bdk-wallet as possible.

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Documentation

<!-- Paste the canonical docs/spec for anything this PR wraps or updates. -->

- [ ] [`bdk_wallet`](https://docs.rs/bdk_wallet/latest/bdk_wallet/)
  <!-- Add a link below with the docs.rs page. -->
- [ ] [`bitcoin`](https://docs.rs/bitcoin/latest/bitcoin/index.html)
  <!-- Add a link below with the docs.rs page. -->
- [ ] [`uniffi`](https://github.com/mozilla/uniffi-rs) <!-- Add a link below with the version changelog or any other docs. -->
- [ ] Other: <!-- Add a link below with additional references -->

### Changelog

<!-- Add exactly one changelog label to this PR:
`changelog: added`, `changelog: changed`, `changelog: fixed`, `changelog: breaking`, or `changelog: none`.
These labels map to the Keep a Changelog categories used by `CHANGELOG.md` where possible.
GitHub generated release notes use the label plus the PR title to draft the changelog.
-->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
* [ ] I've added exactly one `changelog:*` label
* [ ] I've linked the relevant upstream docs or specs above

#### New Features:

* [x] I've added tests for the new feature
* [x] I've added docs for the new feature
