### PR TITLE
test: optimize the podman-regtest-infinity-pro service in CI

### DIFF
--- a/.github/workflows/test-android.yaml
+++ b/.github/workflows/test-android.yaml
@@ -23,19 +23,18 @@ jobs:
 
     services:
       bitcoin-regtest:
-        image: ghcr.io/thunderbiscuit/podman-regtest-infinity-pro:0.3.2
+        image: ghcr.io/thunderbiscuit/podman-regtest-infinity-pro:0.4.0
         ports:
           - 18443:18443
           - 18444:18444
           - 3002:3002
-          - 3003:3003
           - 60401:60401
         # The container initialization step will wait until everything is ready before allowing other steps to run
         options: >-
-          --health-cmd "test $(bitcoin-cli -regtest -rpcuser=regtest -rpcpassword=password getblockcount) -gt 0"
-          --health-interval 10s
+          --health-cmd "test $(bitcoin-cli -regtest -rpcuser=regtest -rpcpassword=password getblockcount) -gt 100"
+          --health-interval 3s
           --health-timeout 5s
-          --health-retries 6
+          --health-retries 20
 
     steps:
       - name: "Checkout PR branch"


### PR DESCRIPTION
This PR bumps the podman-regtest-infinity-pro image to the latest release (0.4.0), and optimizes some of the setup.

- No need to forward port 3003, that's the bitcoin explorer (only really usable in a browser)
- The container now fires much faster, and so doing the check on a quicker time loop will save time on each run
- We should really check for 100 blocks mined (which is what the container does) before continuing, because the tests use the faucet made available in the regtest environment, but that only becomes usable after block 100.

Sister PR on bdk-jvm is here: bitcoindevkit/bdk-jvm#68

### Changelog

No changelog

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I've added exactly one `changelog:*` label
