### PR TITLE
feat: expose extract_tx_with_fee_rate_limit and extract_tx_unchecked_fee_rate on Psbt

### DIFF
--- a/bdk-ffi/src/bitcoin.rs
+++ b/bdk-ffi/src/bitcoin.rs
@@ -1447,6 +1447,38 @@ impl Psbt {
         Ok(Arc::new(transaction))
     }
 
+    /// Extracts the `Transaction` from a `Psbt` by filling in the available signature information.
+    ///
+    /// #### Errors
+    ///
+    /// See `extract_tx`.
+    pub fn extract_tx_with_fee_rate_limit(
+        &self,
+        max_fee_rate: Arc<FeeRate>,
+    ) -> Result<Arc<Transaction>, ExtractTxError> {
+        let tx: BdkTransaction = self
+            .0
+            .lock()
+            .unwrap()
+            .clone()
+            .extract_tx_with_fee_rate_limit(max_fee_rate.0)?;
+        let transaction: Transaction = tx.into();
+        Ok(Arc::new(transaction))
+    }
+
+    /// Perform `extract_tx` without the fee rate check.
+    ///
+    /// This can result in a transaction with absurdly high fees. Use with caution.
+    pub fn extract_tx_unchecked_fee_rate(&self) -> Arc<Transaction> {
+        let tx: BdkTransaction = self
+            .0
+            .lock()
+            .unwrap()
+            .clone()
+            .extract_tx_unchecked_fee_rate();
+        Arc::new(tx.into())
+    }
+
     /// Calculates transaction fee.
     ///
     /// 'Fee' being the amount that will be paid for mining a transaction with the current inputs


### PR DESCRIPTION
### Description

Exposes two `Psbt` transaction-extraction variants that already exist in rust-bitcoin:

- `extract_tx_with_fee_rate_limit(max_fee_rate: FeeRate)` — same as `extract_tx`, but with a caller-provided maximum fee rate instead of the hardcoded 25,000 sat/vB cap
- `extract_tx_unchecked_fee_rate()` — no fee rate check at all

The default cap makes `extract_tx` unusable on networks with low coin value: e.g. on Dogecoin a typical fee rate is 50,000–120,000 sat/vB, so every regular transaction fails with `ExtractTxError::AbsurdFeeRate` despite being perfectly valid on the network.

Fixes #1053

### Notes to the reviewers

- Both wrappers follow the existing `extract_tx` pattern in `bdk-ffi/src/bitcoin.rs`; `FeeRate` is already exposed, and the `ExtractTxError` mapping already covers all variants, so the change is pure delegation.
- I didn't add tests since the wrappers delegate directly to rust-bitcoin, where this logic is already covered — happy to add binding-level tests if you'd prefer.

### Documentation

- [x] [`bitcoin`](https://docs.rs/bitcoin/latest/bitcoin/index.html)
  - [`Psbt::extract_tx_with_fee_rate_limit`](https://docs.rs/bitcoin/0.32.8/bitcoin/struct.Psbt.html#method.extract_tx_with_fee_rate_limit)
  - [`Psbt::extract_tx_unchecked_fee_rate`](https://docs.rs/bitcoin/0.32.8/bitcoin/struct.Psbt.html#method.extract_tx_unchecked_fee_rate)

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [ ] I ran `cargo fmt` and `cargo clippy` before committing (no local Rust toolchain — relying on CI)
* [ ] I've added exactly one `changelog:*` label (`changelog: added` — I don't have permission to add labels)
* [x] I've linked the relevant upstream docs or specs above

#### New Features:

* [ ] I've added tests for the new feature
* [x] I've added docs for the new feature

