### PR TITLE
Add SECURITY.md file to the repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ just publish-local
 
 To add new structs and functions, see the [UniFFI User Guide](https://mozilla.github.io/uniffi-rs/) and the [uniffi-examples](https://thunderbiscuit.github.io/uniffi-examples/) repository.
 
+## Security Policy
+
+To report a security issue, please refer to the [security policy](SECURITY.md).
+
 ## Goals
 
 1. Language bindings should feel idiomatic in target languages/platforms

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,20 @@
+# Security Policy
+
+To report security issues, either
+
+- send an email to `security AT bitcoindevkit DOT org` (not for support), or
+- open a security advisory on GitHub at
+[`https://github.com/bitcoindevkit/bdk-ffi/security/advisories`](https://github.com/bitcoindevkit/bdk-ffi/security/advisories).
+
+The following key may be used to communicate sensitive information to BDK via email:
+
+| Name | Fingerprint |
+| ---- | ----------- |
+| `security@bitcoindevkit.org` | `7416 BB25 5E60 E40D 482E 591B 7201 8930 A1FB 3444` |
+
+You can import the key by running the following command:
+```
+gpg --recv-keys 7416BB255E60E40D482E591B72018930A1FB3444 --keyserver hkps://keys.openpgp.org
+```
+
+You can also download it from [our website](https://bitcoindevkit.org/foundation/pgp/#security-disclosures).


### PR DESCRIPTION
This is just making sure we stay in line with other BDK repos that have this file, pointing to the same security email, and our specific advisory page.