### PR TITLE
fix(ci): fail unsuccessful external binding dispatches

### DIFF
--- a/.github/workflows/trigger-external-bindings.yml
+++ b/.github/workflows/trigger-external-bindings.yml
@@ -42,6 +42,7 @@ jobs:
 
       # Trigger trigger-bdk-python-test workflow in bdk-python repository
       - name: Trigger tests in bdk-python repository
+        if: ${{ !cancelled() }}
         env:
           BDK_PYTHON_ACCESS_TOKEN: ${{ secrets.BDK_PYTHON_ACCESS_TOKEN }}
         run: |

--- a/.github/workflows/trigger-external-bindings.yml
+++ b/.github/workflows/trigger-external-bindings.yml
@@ -24,7 +24,7 @@ jobs:
         env:
           BDK_JVM_ACCESS_TOKEN: ${{ secrets.BDK_JVM_ACCESS_TOKEN }}
         run: |
-          curl --silent --show-error \
+          curl --fail-with-body --silent --show-error \
             --output /tmp/resp.txt \
             --write-out "HTTP Status: %{http_code}\n" \
             --request POST \
@@ -45,7 +45,7 @@ jobs:
         env:
           BDK_PYTHON_ACCESS_TOKEN: ${{ secrets.BDK_PYTHON_ACCESS_TOKEN }}
         run: |
-          curl --silent --show-error \
+          curl --fail-with-body --silent --show-error \
             --output /tmp/resp_bdk-python.txt \
             --write-out "HTTP Status: %{http_code}\n" \
             --request POST \

--- a/.github/workflows/trigger-external-bindings.yml
+++ b/.github/workflows/trigger-external-bindings.yml
@@ -24,6 +24,7 @@ jobs:
         env:
           BDK_JVM_ACCESS_TOKEN: ${{ secrets.BDK_JVM_ACCESS_TOKEN }}
         run: |
+          curl_status=0
           curl --fail-with-body --silent --show-error \
             --output /tmp/resp.txt \
             --write-out "HTTP Status: %{http_code}\n" \
@@ -32,13 +33,14 @@ jobs:
             --header "Content-Type: application/json" \
             --header "Authorization: Bearer $BDK_JVM_ACCESS_TOKEN" \
             --data '{"event_type":"trigger-bdk-jvm-test"}' \
-            https://api.github.com/repos/bitcoindevkit/bdk-jvm/dispatches
+            https://api.github.com/repos/bitcoindevkit/bdk-jvm/dispatches || curl_status=$?
           echo "Response body:"
           if [ -s /tmp/resp.txt ]; then
             jq . /tmp/resp.txt || cat /tmp/resp.txt
           else
             echo "(empty)"
           fi
+          exit "$curl_status"
 
       # Trigger trigger-bdk-python-test workflow in bdk-python repository
       - name: Trigger tests in bdk-python repository
@@ -46,6 +48,7 @@ jobs:
         env:
           BDK_PYTHON_ACCESS_TOKEN: ${{ secrets.BDK_PYTHON_ACCESS_TOKEN }}
         run: |
+          curl_status=0
           curl --fail-with-body --silent --show-error \
             --output /tmp/resp_bdk-python.txt \
             --write-out "HTTP Status: %{http_code}\n" \
@@ -54,10 +57,11 @@ jobs:
             --header "Content-Type: application/json" \
             --header "Authorization: Bearer $BDK_PYTHON_ACCESS_TOKEN" \
             --data '{"event_type":"trigger-bdk-python-test"}' \
-            https://api.github.com/repos/bitcoindevkit/bdk-python/dispatches
+            https://api.github.com/repos/bitcoindevkit/bdk-python/dispatches || curl_status=$?
           echo "Response body:"
           if [ -s /tmp/resp_bdk-python.txt ]; then
             jq . /tmp/resp_bdk-python.txt || cat /tmp/resp_bdk-python.txt
           else
             echo "(empty)"
           fi
+          exit "$curl_status"


### PR DESCRIPTION
<!-- Erase any parts of this template not applicable to your Pull Request. -->

### Description

Updates external binding dispatches to fail on unsuccessful HTTP responses which prevents downstream CI failures from silently passing. But someone let me know if that's intended for a reason I'm not remembering?

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Documentation

<!-- Paste the canonical docs/spec for anything this PR wraps or updates. -->

- [ ] [`bdk_wallet`](https://docs.rs/bdk_wallet/latest/bdk_wallet/)
  <!-- Add a link below with the docs.rs page. -->
- [ ] [`bitcoin`](https://docs.rs/bitcoin/latest/bitcoin/index.html)
  <!-- Add a link below with the docs.rs page. -->
- [ ] [`uniffi`](https://github.com/mozilla/uniffi-rs) <!-- Add a link below with the version changelog or any other docs. -->
- [ ] Other: <!-- Add a link below with additional references -->

### Changelog

<!-- Add exactly one changelog label to this PR:
`changelog: added`, `changelog: changed`, `changelog: fixed`, `changelog: breaking`, or `changelog: none`.
These labels map to the Keep a Changelog categories used by `CHANGELOG.md` where possible.
GitHub generated release notes use the label plus the PR title to draft the changelog.
-->

### Checklists

#### All Submissions:

* [ ] I've signed all my commits
* [ ] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [ ] I ran `cargo fmt` and `cargo clippy` before committing
* [ ] I've added exactly one `changelog:*` label
* [ ] I've linked the relevant upstream docs or specs above

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
