### PR TITLE
feat: Add Wallet::all_tx_details()

### DIFF
--- a/bdk-ffi/src/tests/wallet.rs
+++ b/bdk-ffi/src/tests/wallet.rs
@@ -448,3 +448,44 @@ fn test_load_from_two_path_descriptor_with_params() {
         error => panic!("expected InvalidChangeSet error, got {:?}", error),
     }
 }
+
+#[test]
+fn test_all_tx_details_empty_wallet() {
+    let wallet = Wallet::new(
+        external_descriptor(),
+        internal_descriptor(),
+        Network::Signet,
+        Arc::new(Persister::new_in_memory().unwrap()),
+        25,
+    )
+    .unwrap();
+
+    let details = wallet.all_tx_details();
+
+    assert!(
+        details.is_empty(),
+        "Expected no tx details for a fresh wallet, got {}",
+        details.len()
+    );
+}
+
+#[test]
+fn test_all_tx_details_matches_tx_details_per_item() {
+    let wallet = Wallet::new(
+        external_descriptor(),
+        internal_descriptor(),
+        Network::Signet,
+        Arc::new(Persister::new_in_memory().unwrap()),
+        25,
+    )
+    .unwrap();
+
+    let all_details = wallet.all_tx_details();
+    let all_txs = wallet.transactions();
+
+    assert_eq!(
+        all_details.len(),
+        all_txs.len(),
+        "all_tx_details() and transactions() must return the same number of items"
+    );
+}

--- a/bdk-ffi/src/tests/wallet.rs
+++ b/bdk-ffi/src/tests/wallet.rs
@@ -470,22 +470,70 @@ fn test_all_tx_details_empty_wallet() {
 }
 
 #[test]
-fn test_all_tx_details_matches_tx_details_per_item() {
-    let wallet = Wallet::new(
-        external_descriptor(),
-        internal_descriptor(),
-        Network::Signet,
-        Arc::new(Persister::new_in_memory().unwrap()),
-        25,
-    )
-    .unwrap();
+fn test_all_tx_details_populated_wallet() {
+    let wallet = funded_wallet();
+    let address2 = wallet.reveal_next_address(KeychainKind::External).address;
 
-    let all_details = wallet.all_tx_details();
-    let all_txs = wallet.transactions();
+    let tx2 = BdkTransaction {
+        version: transaction::Version::ONE,
+        lock_time: absolute::LockTime::ZERO,
+        input: vec![],
+        output: vec![BdkTxOut {
+            value: BdkAmount::from_sat(50_000),
+            script_pubkey: address2.script_pubkey().0.clone(),
+        }],
+    };
 
-    assert_eq!(
-        all_details.len(),
-        all_txs.len(),
-        "all_tx_details() and transactions() must return the same number of items"
-    );
+    let txid2 = tx2.compute_txid();
+
+    let mut update2 = bdk_wallet::Update::default();
+    update2.tx_update.txs.push(Arc::new(tx2.clone()));
+    update2.tx_update.seen_ats.insert((txid2, 2));
+
+    wallet.apply_update(Arc::new(Update(update2))).unwrap();
+
+    let details = wallet.all_tx_details();
+
+    assert_eq!(details.len(), 2);
+
+    let expected_txids: Vec<_> = wallet
+        .transactions()
+        .into_iter()
+        .map(|tx| tx.transaction.compute_txid())
+        .collect();
+
+    let actual_txids: Vec<_> = details
+        .iter()
+        .map(|detail| detail.tx.compute_txid())
+        .collect();
+
+    assert_eq!(actual_txids, expected_txids);
+
+    for detail in &details {
+        let txid = detail.tx.compute_txid();
+
+        let expected = wallet
+            .tx_details(txid.clone().into())
+            .expect("transaction details should exist in wallet");
+
+        assert_eq!(detail.txid, expected.txid);
+        assert_eq!(detail.sent, expected.sent);
+        assert_eq!(detail.received, expected.received);
+        assert_eq!(
+            detail.fee.as_ref().map(|fee| fee.to_sat()),
+            expected.fee.as_ref().map(|fee| fee.to_sat())
+        );
+        assert_eq!(
+            detail
+                .fee_rate
+                .as_ref()
+                .map(|fee_rate| fee_rate.to_sat_per_vb_ceil()),
+            expected
+                .fee_rate
+                .as_ref()
+                .map(|fee_rate| fee_rate.to_sat_per_vb_ceil())
+        );
+        assert_eq!(detail.balance_delta, expected.balance_delta);
+        assert_eq!(detail.tx, expected.tx);
+    }
 }

--- a/bdk-ffi/src/wallet.rs
+++ b/bdk-ffi/src/wallet.rs
@@ -999,20 +999,32 @@ impl Wallet {
     pub fn all_tx_details(&self) -> Vec<crate::types::TxDetails> {
         let wallet = self.get_wallet();
 
-        let txids: Vec<bdk_wallet::bitcoin::Txid> = wallet
+        wallet
             .transactions_sort_by(|tx1, tx2| tx2.chain_position.cmp(&tx1.chain_position))
             .into_iter()
-            .map(|tx| tx.tx_node.txid)
-            .collect();
+            .map(|canonical_tx| {
+                let tx = canonical_tx.tx_node.tx;
+                let txid = canonical_tx.tx_node.txid;
 
-        if txids.is_empty() {
-            return Vec::new();
-        }
+                let (sent, received) = wallet.sent_and_received(&tx);
+                let fee = wallet.calculate_fee(&tx).ok();
+                let fee_rate = wallet.calculate_fee_rate(&tx).ok();
 
-        txids
-            .into_iter()
-            .filter_map(|txid| wallet.tx_details(txid))
-            .map(crate::types::TxDetails::from)
+                let balance_delta = received.to_signed().expect("valid SignedAmount")
+                    - sent.to_signed().expect("valid SignedAmount");
+
+                bdk_wallet::TxDetails {
+                    txid,
+                    sent,
+                    received,
+                    fee,
+                    fee_rate,
+                    balance_delta,
+                    chain_position: canonical_tx.chain_position,
+                    tx,
+                }
+                .into()
+            })
             .collect()
     }
 

--- a/bdk-ffi/src/wallet.rs
+++ b/bdk-ffi/src/wallet.rs
@@ -986,6 +986,32 @@ impl Wallet {
             .map(|details| details.into())
     }
 
+    /// Get [`TxDetails`] for all canonical transactions in a wallet,
+    /// sorted from newest to oldest by chain position.
+    ///
+    /// This is a convenience method that combines [`Wallet::transactions`] and
+    /// [`Wallet::tx_details`] into a single call, avoiding multiple FFI
+    /// round-trips when building a transaction history view.
+    ///
+    /// Note that `fee` and `fee_rate` fields may be `None` for transactions
+    /// that include inputs not owned by this wallet, unless those inputs were
+    /// previously inserted via [`Wallet::insert_txout`].
+    pub fn all_tx_details(&self) -> Vec<crate::types::TxDetails> {
+        let wallet = self.get_wallet();
+
+        let txids: Vec<bdk_wallet::bitcoin::Txid> = wallet
+            .transactions_sort_by(|tx1, tx2| tx2.chain_position.cmp(&tx1.chain_position))
+            .into_iter()
+            .map(|tx| tx.tx_node.txid)
+            .collect();
+
+        txids
+            .into_iter()
+            .filter_map(|txid| wallet.tx_details(txid))
+            .map(crate::types::TxDetails::from)
+            .collect()
+    }
+
     /// Returns the descriptor used to create addresses for a particular `keychain`.
     ///
     /// It's the "public" version of the wallet's descriptor, meaning a new descriptor that has

--- a/bdk-ffi/src/wallet.rs
+++ b/bdk-ffi/src/wallet.rs
@@ -1005,6 +1005,10 @@ impl Wallet {
             .map(|tx| tx.tx_node.txid)
             .collect();
 
+        if txids.is_empty() {
+            return Vec::new();
+        }
+
         txids
             .into_iter()
             .filter_map(|txid| wallet.tx_details(txid))

--- a/bdk-ffi/src/wallet.rs
+++ b/bdk-ffi/src/wallet.rs
@@ -989,9 +989,9 @@ impl Wallet {
     /// Get [`TxDetails`] for all canonical transactions in a wallet,
     /// sorted from newest to oldest by chain position.
     ///
-    /// This is a convenience method that combines [`Wallet::transactions`] and
-    /// [`Wallet::tx_details`] into a single call, avoiding multiple FFI
-    /// round-trips when building a transaction history view.
+    /// This derives transaction details directly from the [`WalletTx`]s returned
+    /// by `transactions_sort_by`, avoiding multiple FFI round-trips and repeated
+    /// transaction-history scans performed by [`Wallet::tx_details`].
     ///
     /// Note that `fee` and `fee_rate` fields may be `None` for transactions
     /// that include inputs not owned by this wallet, unless those inputs were


### PR DESCRIPTION
<!-- Erase any parts of this template not applicable to your Pull Request. -->

### Description
Wallet currently exposes two methods for querying transactions:

transactions(&self) -> Vec<CanonicalTx>: Returns all canonical transactions, but only provides basic information (txid, chain position, raw transaction). It lacks rich metadata such as fee, fee_rate, sent, received, and balance_delta.

tx_details(&self, txid: Arc<Txid>) -> Option<TxDetails>: Returns rich transaction details, but only for a single transaction at a time.

When building user interfaces like a transaction history screen in foreign language bindings (e.g. Dart), consumers are forced into an N+1 FFI round-trips for every transaction, this creates unnecessary overhead across language boundaries and inflates boilerplate in down-stream bindings.

`all_tx_details()` does this in a single call from the caller's perspective.

### Notes to the reviewers
If maintainers are aligned with this approach, I would be happy to add tests and docs.
<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Additional implementation finding

While implementing the this API, it was found that it only solve first part of the performance issue. The original Rust-side approach of calling wallet.tx_details() once per transaction also introduces repeated transaction-history scans.

In bdk_wallet 3.1.0, Wallet::tx_details(txid) locates the requested transaction by scanning self.transactions()

#### This means the optimization has two dimensions:
1. FFI boundary: reduce N + 1 FFI calls to a single bulk call. 
2. Rust implementation: avoid repeatedly scanning the wallet transaction history for each transaction. 

The implementation now derives TxDetails directly from the already-fetched WalletTx values returned by transactions_sort_by() without performing the repeated lookup.

### Documentation

<!-- Paste the canonical docs/spec for anything this PR wraps or updates. -->

- [ ] [`bdk_wallet`](https://docs.rs/bdk_wallet/latest/bdk_wallet/)
  <!-- Add a link below with the docs.rs page. -->
- [ ] [`bitcoin`](https://docs.rs/bitcoin/latest/bitcoin/index.html)
  <!-- Add a link below with the docs.rs page. -->
- [ ] [`uniffi`](https://github.com/mozilla/uniffi-rs) <!-- Add a link below with the version changelog or any other docs. -->
- [ ] Other: <!-- Add a link below with additional references -->

### Changelog

<!-- Add exactly one changelog label to this PR:
`changelog: added`, `changelog: changed`, `changelog: fixed`, `changelog: breaking`, or `changelog: none`.
These labels map to the Keep a Changelog categories used by `CHANGELOG.md` where possible.
GitHub generated release notes use the label plus the PR title to draft the changelog.
-->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
* [x] I've added exactly one `changelog:*` label
* [ ] I've linked the relevant upstream docs or specs above

#### New Features:

* [x] I've added tests for the new feature
* [x] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
