### PR TITLE
(4.0) fix: return structured insufficient funds errors

### DIFF
--- a/bdk-ffi/src/error.rs
+++ b/bdk-ffi/src/error.rs
@@ -1082,9 +1082,11 @@ impl From<BdkCreateTxError> for CreateTxError {
             BdkCreateTxError::OutputBelowDustLimit(index) => CreateTxError::OutputBelowDustLimit {
                 index: index as u64,
             },
-            BdkCreateTxError::CoinSelection(e) => CreateTxError::CoinSelection {
-                error_message: e.to_string(),
-            },
+            BdkCreateTxError::CoinSelection(e) => {
+                let needed = e.needed.to_sat();
+                let available = e.available.to_sat();
+                CreateTxError::InsufficientFunds { needed, available }
+            }
             BdkCreateTxError::NoRecipients => CreateTxError::NoRecipients,
             BdkCreateTxError::Psbt(e) => CreateTxError::Psbt {
                 error_message: e.to_string(),

--- a/bdk-ffi/src/tests/error.rs
+++ b/bdk-ffi/src/tests/error.rs
@@ -1,8 +1,11 @@
 use crate::error::{
-    Bip32Error, Bip39Error, CannotConnectError, DescriptorError, DescriptorKeyError, ElectrumError,
-    EsploraError, ExtractTxError, PsbtError, PsbtParseError, RequestBuilderError, SignerError,
-    TransactionError, TxidParseError,
+    Bip32Error, Bip39Error, CannotConnectError, CreateTxError, DescriptorError, DescriptorKeyError,
+    ElectrumError, EsploraError, ExtractTxError, PsbtError, PsbtParseError, RequestBuilderError,
+    SignerError, TransactionError, TxidParseError,
 };
+use bdk_wallet::bitcoin::Amount;
+use bdk_wallet::coin_selection::InsufficientFunds as BdkInsufficientFunds;
+use bdk_wallet::error::CreateTxError as BdkCreateTxError;
 
 #[test]
 fn test_error_bip32() {
@@ -102,6 +105,22 @@ fn test_error_cannot_connect() {
     let error = CannotConnectError::Include { height: 42 };
 
     assert_eq!(format!("{}", error), "cannot include height: 42");
+}
+
+#[test]
+fn test_error_create_tx_insufficient_funds_conversion() {
+    let error = BdkCreateTxError::CoinSelection(BdkInsufficientFunds {
+        needed: Amount::from_sat(50_000),
+        available: Amount::from_sat(30_000),
+    });
+
+    match CreateTxError::from(error) {
+        CreateTxError::InsufficientFunds { needed, available } => {
+            assert_eq!(needed, 50_000);
+            assert_eq!(available, 30_000);
+        }
+        other => panic!("expected insufficient funds error, got {:?}", other),
+    }
 }
 
 #[test]


### PR DESCRIPTION
<!-- Erase any parts of this template not applicable to your Pull Request. -->

### Description

We already expose a structured `CreateTxError::InsufficientFunds` containing `needed` and `available` amounts. 

Currently are converting the errors into the generic string based CoinSelection variant though.

So this PR just maps the upstream amounts to the existing `InsufficientFunds` and adds regression coverage. 

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Documentation

<!-- Paste the canonical docs/spec for anything this PR wraps or updates. -->

- [x] [`bdk_wallet`](https://docs.rs/bdk_wallet/latest/bdk_wallet/)

https://docs.rs/bdk_wallet/3.1.0/bdk_wallet/coin_selection/struct.InsufficientFunds.html

https://docs.rs/bdk_wallet/3.1.0/src/bdk_wallet/wallet/coin_selection.rs.html#123-132

https://docs.rs/bdk_wallet/3.1.0/bdk_wallet/error/enum.CreateTxError.html#variant.CoinSelection

- [ ] [`bitcoin`](https://docs.rs/bitcoin/latest/bitcoin/index.html)
  <!-- Add a link below with the docs.rs page. -->
- [ ] [`uniffi`](https://github.com/mozilla/uniffi-rs) <!-- Add a link below with the version changelog or any other docs. -->
- [ ] Other: <!-- Add a link below with additional references -->

### Changelog

<!-- Add exactly one changelog label to this PR:
`changelog: added`, `changelog: changed`, `changelog: fixed`, `changelog: breaking`, or `changelog: none`.
These labels map to the Keep a Changelog categories used by `CHANGELOG.md` where possible.
GitHub generated release notes use the label plus the PR title to draft the changelog.
-->

### Checklists

#### All Submissions:

* [ ] I've signed all my commits
* [ ] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [ ] I ran `cargo fmt` and `cargo clippy` before committing
* [ ] I've added exactly one `changelog:*` label
* [ ] I've linked the relevant upstream docs or specs above

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
