### PR TITLE
fix: reject trailing bytes when decoding transactions

### DIFF
--- a/bdk-ffi/src/bitcoin.rs
+++ b/bdk-ffi/src/bitcoin.rs
@@ -14,10 +14,8 @@ use bdk_wallet::bitcoin::blockdata::block::Block as BdkBlock;
 use bdk_wallet::bitcoin::blockdata::block::Header as BdkHeader;
 use bdk_wallet::bitcoin::consensus::encode::deserialize;
 use bdk_wallet::bitcoin::consensus::encode::serialize;
-use bdk_wallet::bitcoin::consensus::Decodable;
 use bdk_wallet::bitcoin::hashes::sha256::Hash as BitcoinSha256Hash;
 use bdk_wallet::bitcoin::hashes::sha256d::Hash as BitcoinDoubleSha256Hash;
-use bdk_wallet::bitcoin::io::Cursor;
 use bdk_wallet::bitcoin::psbt::Input as BdkInput;
 use bdk_wallet::bitcoin::psbt::Output as BdkOutput;
 use bdk_wallet::bitcoin::secp256k1::Secp256k1;
@@ -443,8 +441,7 @@ impl Transaction {
     /// Creates a new `Transaction` instance from serialized transaction bytes.
     #[uniffi::constructor]
     pub fn new(transaction_bytes: Vec<u8>) -> Result<Self, TransactionError> {
-        let mut decoder = Cursor::new(transaction_bytes);
-        let tx: BdkTransaction = BdkTransaction::consensus_decode(&mut decoder)?;
+        let tx: BdkTransaction = deserialize(&transaction_bytes)?;
         Ok(Transaction(tx))
     }
 

--- a/bdk-ffi/src/tests/bitcoin.rs
+++ b/bdk-ffi/src/tests/bitcoin.rs
@@ -1,4 +1,5 @@
-use crate::bitcoin::{Address, AddressData, Key, Network, ProprietaryKey, Psbt};
+use crate::bitcoin::{Address, AddressData, Key, Network, ProprietaryKey, Psbt, Transaction};
+use crate::error::TransactionError;
 use bdk_electrum::bdk_core::bitcoin::hex::DisplayHex;
 
 #[test]
@@ -355,6 +356,31 @@ fn test_to_address_data() {
     assert!(matches!(p2pkh_data, AddressData::P2pkh { .. }));
     assert!(matches!(p2sh_data, AddressData::P2sh { .. }));
     assert!(matches!(segwit_data, AddressData::Segwit { .. }));
+}
+
+#[test]
+fn test_transaction_new_rejects_trailing_bytes() {
+    let transaction = bdk_wallet::bitcoin::Transaction {
+        version: bdk_wallet::bitcoin::transaction::Version::TWO,
+        lock_time: bdk_wallet::bitcoin::absolute::LockTime::ZERO,
+        input: vec![bdk_wallet::bitcoin::TxIn::default()],
+        output: vec![bdk_wallet::bitcoin::TxOut {
+            value: bdk_wallet::bitcoin::Amount::from_sat(50_000),
+            script_pubkey: bdk_wallet::bitcoin::ScriptBuf::new(),
+        }],
+    };
+    let transaction_bytes = bdk_wallet::bitcoin::consensus::serialize(&transaction);
+
+    let parsed_transaction = Transaction::new(transaction_bytes.clone()).unwrap();
+    assert_eq!(parsed_transaction.serialize(), transaction_bytes);
+
+    let mut transaction_bytes_with_trailing_garbage = transaction_bytes;
+    transaction_bytes_with_trailing_garbage.extend_from_slice(&[0xde, 0xad, 0xbe, 0xef]);
+
+    assert!(matches!(
+        Transaction::new(transaction_bytes_with_trailing_garbage),
+        Err(TransactionError::ParseFailed)
+    ));
 }
 
 #[test]


### PR DESCRIPTION
<!-- Erase any parts of this template not applicable to your Pull Request. -->

### Description

Previously we used Cursor + consensus_decode which decodes one transaction but could leave trailing bytes. 

We now use upstream deserialize which requires the entire array to be consumed (matching Transaction::new’s expectation that its input contains one complete transaction)

### Notes to the reviewers

One thing to note is that consensus_decode had a rust-bitcoin 4 MB read limit, while deserialize can process the full byte array passed to it. (Very large inputs could therefore take more work to process than before but this does not change Bitcoin consensus behavior or affect valid onchain transactions from what I'm thinking but let me know otherwise?!)

### Documentation

<!-- Paste the canonical docs/spec for anything this PR wraps or updates. -->

- [ ] [`bdk_wallet`](https://docs.rs/bdk_wallet/latest/bdk_wallet/)
  <!-- Add a link below with the docs.rs page. -->
- [ ] [`bitcoin`](https://docs.rs/bitcoin/latest/bitcoin/index.html)
  <!-- Add a link below with the docs.rs page. -->
- [ ] [`uniffi`](https://github.com/mozilla/uniffi-rs) <!-- Add a link below with the version changelog or any other docs. -->
- [x] Other: <!-- Add a link below with additional references -->
https://docs.rs/bitcoin/0.32.8/bitcoin/consensus/fn.deserialize.html

### Changelog

<!-- Add exactly one changelog label to this PR:
`changelog: added`, `changelog: changed`, `changelog: fixed`, `changelog: breaking`, or `changelog: none`.
These labels map to the Keep a Changelog categories used by `CHANGELOG.md` where possible.
GitHub generated release notes use the label plus the PR title to draft the changelog.
-->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
* [x] I've added exactly one `changelog:*` label
* [ ] I've linked the relevant upstream docs or specs above

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
