### PR TITLE
fix: return descriptor template key type errors

### DIFF
--- a/bdk-ffi/src/descriptor.rs
+++ b/bdk-ffi/src/descriptor.rs
@@ -54,25 +54,22 @@ impl Descriptor {
         secret_key: &DescriptorSecretKey,
         keychain_kind: KeychainKind,
         network_kind: NetworkKind,
-    ) -> Self {
+    ) -> Result<Self, DescriptorError> {
         let derivable_key = &secret_key.0;
 
         match derivable_key {
-            BdkDescriptorSecretKey::Single(_) => {
-                unreachable!()
+            BdkDescriptorSecretKey::Single(_) | BdkDescriptorSecretKey::MultiXPrv(_) => {
+                Err(DescriptorError::InvalidKeyType)
             }
             BdkDescriptorSecretKey::XPrv(descriptor_x_key) => {
                 let derivable_key = descriptor_x_key.xkey;
                 let (extended_descriptor, key_map, _) = Bip44(derivable_key, keychain_kind)
                     .build(network_kind)
-                    .unwrap();
-                Self {
+                    .map_err(DescriptorError::from)?;
+                Ok(Self {
                     extended_descriptor,
                     key_map,
-                }
-            }
-            BdkDescriptorSecretKey::MultiXPrv(_) => {
-                unreachable!()
+                })
             }
         }
     }
@@ -93,8 +90,8 @@ impl Descriptor {
         let derivable_key = &public_key.0;
 
         match derivable_key {
-            BdkDescriptorPublicKey::Single(_) => {
-                unreachable!()
+            BdkDescriptorPublicKey::Single(_) | BdkDescriptorPublicKey::MultiXPub(_) => {
+                Err(DescriptorError::InvalidKeyType)
             }
             BdkDescriptorPublicKey::XPub(descriptor_x_key) => {
                 let derivable_key = descriptor_x_key.xkey;
@@ -108,9 +105,6 @@ impl Descriptor {
                     key_map,
                 })
             }
-            BdkDescriptorPublicKey::MultiXPub(_) => {
-                unreachable!()
-            }
         }
     }
 
@@ -120,25 +114,22 @@ impl Descriptor {
         secret_key: &DescriptorSecretKey,
         keychain_kind: KeychainKind,
         network_kind: NetworkKind,
-    ) -> Self {
+    ) -> Result<Self, DescriptorError> {
         let derivable_key = &secret_key.0;
 
         match derivable_key {
-            BdkDescriptorSecretKey::Single(_) => {
-                unreachable!()
+            BdkDescriptorSecretKey::Single(_) | BdkDescriptorSecretKey::MultiXPrv(_) => {
+                Err(DescriptorError::InvalidKeyType)
             }
             BdkDescriptorSecretKey::XPrv(descriptor_x_key) => {
                 let derivable_key = descriptor_x_key.xkey;
                 let (extended_descriptor, key_map, _) = Bip49(derivable_key, keychain_kind)
                     .build(network_kind)
-                    .unwrap();
-                Self {
+                    .map_err(DescriptorError::from)?;
+                Ok(Self {
                     extended_descriptor,
                     key_map,
-                }
-            }
-            BdkDescriptorSecretKey::MultiXPrv(_) => {
-                unreachable!()
+                })
             }
         }
     }
@@ -159,8 +150,8 @@ impl Descriptor {
         let derivable_key = &public_key.0;
 
         match derivable_key {
-            BdkDescriptorPublicKey::Single(_) => {
-                unreachable!()
+            BdkDescriptorPublicKey::Single(_) | BdkDescriptorPublicKey::MultiXPub(_) => {
+                Err(DescriptorError::InvalidKeyType)
             }
             BdkDescriptorPublicKey::XPub(descriptor_x_key) => {
                 let derivable_key = descriptor_x_key.xkey;
@@ -174,9 +165,6 @@ impl Descriptor {
                     key_map,
                 })
             }
-            BdkDescriptorPublicKey::MultiXPub(_) => {
-                unreachable!()
-            }
         }
     }
 
@@ -186,25 +174,22 @@ impl Descriptor {
         secret_key: &DescriptorSecretKey,
         keychain_kind: KeychainKind,
         network_kind: NetworkKind,
-    ) -> Self {
+    ) -> Result<Self, DescriptorError> {
         let derivable_key = &secret_key.0;
 
         match derivable_key {
-            BdkDescriptorSecretKey::Single(_) => {
-                unreachable!()
+            BdkDescriptorSecretKey::Single(_) | BdkDescriptorSecretKey::MultiXPrv(_) => {
+                Err(DescriptorError::InvalidKeyType)
             }
             BdkDescriptorSecretKey::XPrv(descriptor_x_key) => {
                 let derivable_key = descriptor_x_key.xkey;
                 let (extended_descriptor, key_map, _) = Bip84(derivable_key, keychain_kind)
                     .build(network_kind)
-                    .unwrap();
-                Self {
+                    .map_err(DescriptorError::from)?;
+                Ok(Self {
                     extended_descriptor,
                     key_map,
-                }
-            }
-            BdkDescriptorSecretKey::MultiXPrv(_) => {
-                unreachable!()
+                })
             }
         }
     }
@@ -225,8 +210,8 @@ impl Descriptor {
         let derivable_key = &public_key.0;
 
         match derivable_key {
-            BdkDescriptorPublicKey::Single(_) => {
-                unreachable!()
+            BdkDescriptorPublicKey::Single(_) | BdkDescriptorPublicKey::MultiXPub(_) => {
+                Err(DescriptorError::InvalidKeyType)
             }
             BdkDescriptorPublicKey::XPub(descriptor_x_key) => {
                 let derivable_key = descriptor_x_key.xkey;
@@ -240,9 +225,6 @@ impl Descriptor {
                     key_map,
                 })
             }
-            BdkDescriptorPublicKey::MultiXPub(_) => {
-                unreachable!()
-            }
         }
     }
 
@@ -252,25 +234,22 @@ impl Descriptor {
         secret_key: &DescriptorSecretKey,
         keychain_kind: KeychainKind,
         network_kind: NetworkKind,
-    ) -> Self {
+    ) -> Result<Self, DescriptorError> {
         let derivable_key = &secret_key.0;
 
         match derivable_key {
-            BdkDescriptorSecretKey::Single(_) => {
-                unreachable!()
+            BdkDescriptorSecretKey::Single(_) | BdkDescriptorSecretKey::MultiXPrv(_) => {
+                Err(DescriptorError::InvalidKeyType)
             }
             BdkDescriptorSecretKey::XPrv(descriptor_x_key) => {
                 let derivable_key = descriptor_x_key.xkey;
                 let (extended_descriptor, key_map, _) = Bip86(derivable_key, keychain_kind)
                     .build(network_kind)
-                    .unwrap();
-                Self {
+                    .map_err(DescriptorError::from)?;
+                Ok(Self {
                     extended_descriptor,
                     key_map,
-                }
-            }
-            BdkDescriptorSecretKey::MultiXPrv(_) => {
-                unreachable!()
+                })
             }
         }
     }
@@ -291,8 +270,8 @@ impl Descriptor {
         let derivable_key = &public_key.0;
 
         match derivable_key {
-            BdkDescriptorPublicKey::Single(_) => {
-                unreachable!()
+            BdkDescriptorPublicKey::Single(_) | BdkDescriptorPublicKey::MultiXPub(_) => {
+                Err(DescriptorError::InvalidKeyType)
             }
             BdkDescriptorPublicKey::XPub(descriptor_x_key) => {
                 let derivable_key = descriptor_x_key.xkey;
@@ -305,9 +284,6 @@ impl Descriptor {
                     extended_descriptor,
                     key_map,
                 })
-            }
-            BdkDescriptorPublicKey::MultiXPub(_) => {
-                unreachable!()
             }
         }
     }

--- a/bdk-ffi/src/descriptor.rs
+++ b/bdk-ffi/src/descriptor.rs
@@ -7,7 +7,7 @@ use crate::keys::DescriptorPublicKey;
 use crate::keys::DescriptorSecretKey;
 use crate::types::KeychainKind;
 
-use bdk_wallet::bitcoin::bip32::Fingerprint;
+use bdk_wallet::bitcoin::bip32::{Fingerprint, Xpriv, Xpub};
 use bdk_wallet::bitcoin::key::Secp256k1;
 use bdk_wallet::bitcoin::Network;
 use bdk_wallet::chain::DescriptorExt;
@@ -34,6 +34,39 @@ pub struct Descriptor {
     pub key_map: KeyMap,
 }
 
+impl Descriptor {
+    fn require_xprv(secret_key: &DescriptorSecretKey) -> Result<Xpriv, DescriptorError> {
+        match &secret_key.0 {
+            BdkDescriptorSecretKey::XPrv(descriptor_x_key) => Ok(descriptor_x_key.xkey),
+            BdkDescriptorSecretKey::Single(_) | BdkDescriptorSecretKey::MultiXPrv(_) => {
+                Err(DescriptorError::InvalidKeyType)
+            }
+        }
+    }
+
+    fn require_xpub(public_key: &DescriptorPublicKey) -> Result<Xpub, DescriptorError> {
+        match &public_key.0 {
+            BdkDescriptorPublicKey::XPub(descriptor_x_key) => Ok(descriptor_x_key.xkey),
+            BdkDescriptorPublicKey::Single(_) | BdkDescriptorPublicKey::MultiXPub(_) => {
+                Err(DescriptorError::InvalidKeyType)
+            }
+        }
+    }
+
+    fn from_template<T: DescriptorTemplate>(
+        template: T,
+        network_kind: NetworkKind,
+    ) -> Result<Self, DescriptorError> {
+        let (extended_descriptor, key_map, _) = template
+            .build(network_kind)
+            .map_err(DescriptorError::from)?;
+        Ok(Self {
+            extended_descriptor,
+            key_map,
+        })
+    }
+}
+
 #[uniffi::export]
 impl Descriptor {
     /// Parse a string as a descriptor for the given network.
@@ -55,23 +88,8 @@ impl Descriptor {
         keychain_kind: KeychainKind,
         network_kind: NetworkKind,
     ) -> Result<Self, DescriptorError> {
-        let derivable_key = &secret_key.0;
-
-        match derivable_key {
-            BdkDescriptorSecretKey::Single(_) | BdkDescriptorSecretKey::MultiXPrv(_) => {
-                Err(DescriptorError::InvalidKeyType)
-            }
-            BdkDescriptorSecretKey::XPrv(descriptor_x_key) => {
-                let derivable_key = descriptor_x_key.xkey;
-                let (extended_descriptor, key_map, _) = Bip44(derivable_key, keychain_kind)
-                    .build(network_kind)
-                    .map_err(DescriptorError::from)?;
-                Ok(Self {
-                    extended_descriptor,
-                    key_map,
-                })
-            }
-        }
+        let derivable_key = Self::require_xprv(secret_key)?;
+        Self::from_template(Bip44(derivable_key, keychain_kind), network_kind)
     }
 
     /// Multi-account hierarchy descriptor: https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki
@@ -87,25 +105,11 @@ impl Descriptor {
                 error_message: error.to_string(),
             }
         })?;
-        let derivable_key = &public_key.0;
-
-        match derivable_key {
-            BdkDescriptorPublicKey::Single(_) | BdkDescriptorPublicKey::MultiXPub(_) => {
-                Err(DescriptorError::InvalidKeyType)
-            }
-            BdkDescriptorPublicKey::XPub(descriptor_x_key) => {
-                let derivable_key = descriptor_x_key.xkey;
-                let (extended_descriptor, key_map, _) =
-                    Bip44Public(derivable_key, fingerprint, keychain_kind)
-                        .build(network_kind)
-                        .map_err(DescriptorError::from)?;
-
-                Ok(Self {
-                    extended_descriptor,
-                    key_map,
-                })
-            }
-        }
+        let derivable_key = Self::require_xpub(public_key)?;
+        Self::from_template(
+            Bip44Public(derivable_key, fingerprint, keychain_kind),
+            network_kind,
+        )
     }
 
     /// P2SH nested P2WSH descriptor: https://github.com/bitcoin/bips/blob/master/bip-0049.mediawiki
@@ -115,23 +119,8 @@ impl Descriptor {
         keychain_kind: KeychainKind,
         network_kind: NetworkKind,
     ) -> Result<Self, DescriptorError> {
-        let derivable_key = &secret_key.0;
-
-        match derivable_key {
-            BdkDescriptorSecretKey::Single(_) | BdkDescriptorSecretKey::MultiXPrv(_) => {
-                Err(DescriptorError::InvalidKeyType)
-            }
-            BdkDescriptorSecretKey::XPrv(descriptor_x_key) => {
-                let derivable_key = descriptor_x_key.xkey;
-                let (extended_descriptor, key_map, _) = Bip49(derivable_key, keychain_kind)
-                    .build(network_kind)
-                    .map_err(DescriptorError::from)?;
-                Ok(Self {
-                    extended_descriptor,
-                    key_map,
-                })
-            }
-        }
+        let derivable_key = Self::require_xprv(secret_key)?;
+        Self::from_template(Bip49(derivable_key, keychain_kind), network_kind)
     }
 
     /// P2SH nested P2WSH descriptor: https://github.com/bitcoin/bips/blob/master/bip-0049.mediawiki
@@ -147,25 +136,11 @@ impl Descriptor {
                 error_message: error.to_string(),
             }
         })?;
-        let derivable_key = &public_key.0;
-
-        match derivable_key {
-            BdkDescriptorPublicKey::Single(_) | BdkDescriptorPublicKey::MultiXPub(_) => {
-                Err(DescriptorError::InvalidKeyType)
-            }
-            BdkDescriptorPublicKey::XPub(descriptor_x_key) => {
-                let derivable_key = descriptor_x_key.xkey;
-                let (extended_descriptor, key_map, _) =
-                    Bip49Public(derivable_key, fingerprint, keychain_kind)
-                        .build(network_kind)
-                        .map_err(DescriptorError::from)?;
-
-                Ok(Self {
-                    extended_descriptor,
-                    key_map,
-                })
-            }
-        }
+        let derivable_key = Self::require_xpub(public_key)?;
+        Self::from_template(
+            Bip49Public(derivable_key, fingerprint, keychain_kind),
+            network_kind,
+        )
     }
 
     /// Pay to witness PKH descriptor: https://github.com/bitcoin/bips/blob/master/bip-0084.mediawiki
@@ -175,23 +150,8 @@ impl Descriptor {
         keychain_kind: KeychainKind,
         network_kind: NetworkKind,
     ) -> Result<Self, DescriptorError> {
-        let derivable_key = &secret_key.0;
-
-        match derivable_key {
-            BdkDescriptorSecretKey::Single(_) | BdkDescriptorSecretKey::MultiXPrv(_) => {
-                Err(DescriptorError::InvalidKeyType)
-            }
-            BdkDescriptorSecretKey::XPrv(descriptor_x_key) => {
-                let derivable_key = descriptor_x_key.xkey;
-                let (extended_descriptor, key_map, _) = Bip84(derivable_key, keychain_kind)
-                    .build(network_kind)
-                    .map_err(DescriptorError::from)?;
-                Ok(Self {
-                    extended_descriptor,
-                    key_map,
-                })
-            }
-        }
+        let derivable_key = Self::require_xprv(secret_key)?;
+        Self::from_template(Bip84(derivable_key, keychain_kind), network_kind)
     }
 
     /// Pay to witness PKH descriptor: https://github.com/bitcoin/bips/blob/master/bip-0084.mediawiki
@@ -207,25 +167,11 @@ impl Descriptor {
                 error_message: error.to_string(),
             }
         })?;
-        let derivable_key = &public_key.0;
-
-        match derivable_key {
-            BdkDescriptorPublicKey::Single(_) | BdkDescriptorPublicKey::MultiXPub(_) => {
-                Err(DescriptorError::InvalidKeyType)
-            }
-            BdkDescriptorPublicKey::XPub(descriptor_x_key) => {
-                let derivable_key = descriptor_x_key.xkey;
-                let (extended_descriptor, key_map, _) =
-                    Bip84Public(derivable_key, fingerprint, keychain_kind)
-                        .build(network_kind)
-                        .map_err(DescriptorError::from)?;
-
-                Ok(Self {
-                    extended_descriptor,
-                    key_map,
-                })
-            }
-        }
+        let derivable_key = Self::require_xpub(public_key)?;
+        Self::from_template(
+            Bip84Public(derivable_key, fingerprint, keychain_kind),
+            network_kind,
+        )
     }
 
     /// Single key P2TR descriptor: https://github.com/bitcoin/bips/blob/master/bip-0086.mediawiki
@@ -235,23 +181,8 @@ impl Descriptor {
         keychain_kind: KeychainKind,
         network_kind: NetworkKind,
     ) -> Result<Self, DescriptorError> {
-        let derivable_key = &secret_key.0;
-
-        match derivable_key {
-            BdkDescriptorSecretKey::Single(_) | BdkDescriptorSecretKey::MultiXPrv(_) => {
-                Err(DescriptorError::InvalidKeyType)
-            }
-            BdkDescriptorSecretKey::XPrv(descriptor_x_key) => {
-                let derivable_key = descriptor_x_key.xkey;
-                let (extended_descriptor, key_map, _) = Bip86(derivable_key, keychain_kind)
-                    .build(network_kind)
-                    .map_err(DescriptorError::from)?;
-                Ok(Self {
-                    extended_descriptor,
-                    key_map,
-                })
-            }
-        }
+        let derivable_key = Self::require_xprv(secret_key)?;
+        Self::from_template(Bip86(derivable_key, keychain_kind), network_kind)
     }
 
     /// Single key P2TR descriptor: https://github.com/bitcoin/bips/blob/master/bip-0086.mediawiki
@@ -267,25 +198,11 @@ impl Descriptor {
                 error_message: error.to_string(),
             }
         })?;
-        let derivable_key = &public_key.0;
-
-        match derivable_key {
-            BdkDescriptorPublicKey::Single(_) | BdkDescriptorPublicKey::MultiXPub(_) => {
-                Err(DescriptorError::InvalidKeyType)
-            }
-            BdkDescriptorPublicKey::XPub(descriptor_x_key) => {
-                let derivable_key = descriptor_x_key.xkey;
-                let (extended_descriptor, key_map, _) =
-                    Bip86Public(derivable_key, fingerprint, keychain_kind)
-                        .build(network_kind)
-                        .map_err(DescriptorError::from)?;
-
-                Ok(Self {
-                    extended_descriptor,
-                    key_map,
-                })
-            }
-        }
+        let derivable_key = Self::require_xpub(public_key)?;
+        Self::from_template(
+            Bip86Public(derivable_key, fingerprint, keychain_kind),
+            network_kind,
+        )
     }
 
     /// Create a new wsh sorted multi descriptor

--- a/bdk-ffi/src/error.rs
+++ b/bdk-ffi/src/error.rs
@@ -264,6 +264,9 @@ pub enum DescriptorError {
     #[error("the descriptor contains multipath keys, which are not supported yet")]
     MultiPath,
 
+    #[error("invalid descriptor key type for template")]
+    InvalidKeyType,
+
     #[error("key error: {error_message}")]
     Key { error_message: String },
 

--- a/bdk-ffi/src/tests/descriptor.rs
+++ b/bdk-ffi/src/tests/descriptor.rs
@@ -11,6 +11,89 @@ fn get_descriptor_secret_key() -> DescriptorSecretKey {
     DescriptorSecretKey::new(NetworkKind::Test, &mnemonic, None)
 }
 
+fn assert_invalid_secret_template_key(key: &DescriptorSecretKey) {
+    assert_matches!(
+        Descriptor::new_bip44(key, KeychainKind::External, NetworkKind::Test),
+        Err(DescriptorError::InvalidKeyType)
+    );
+    assert_matches!(
+        Descriptor::new_bip49(key, KeychainKind::External, NetworkKind::Test),
+        Err(DescriptorError::InvalidKeyType)
+    );
+    assert_matches!(
+        Descriptor::new_bip84(key, KeychainKind::External, NetworkKind::Test),
+        Err(DescriptorError::InvalidKeyType)
+    );
+    assert_matches!(
+        Descriptor::new_bip86(key, KeychainKind::External, NetworkKind::Test),
+        Err(DescriptorError::InvalidKeyType)
+    );
+}
+
+fn assert_invalid_public_template_key(key: &crate::keys::DescriptorPublicKey) {
+    assert_matches!(
+        Descriptor::new_bip44_public(
+            key,
+            "00000000".to_string(),
+            KeychainKind::External,
+            NetworkKind::Test,
+        ),
+        Err(DescriptorError::InvalidKeyType)
+    );
+    assert_matches!(
+        Descriptor::new_bip49_public(
+            key,
+            "00000000".to_string(),
+            KeychainKind::External,
+            NetworkKind::Test,
+        ),
+        Err(DescriptorError::InvalidKeyType)
+    );
+    assert_matches!(
+        Descriptor::new_bip84_public(
+            key,
+            "00000000".to_string(),
+            KeychainKind::External,
+            NetworkKind::Test,
+        ),
+        Err(DescriptorError::InvalidKeyType)
+    );
+    assert_matches!(
+        Descriptor::new_bip86_public(
+            key,
+            "00000000".to_string(),
+            KeychainKind::External,
+            NetworkKind::Test,
+        ),
+        Err(DescriptorError::InvalidKeyType)
+    );
+}
+
+#[test]
+fn test_descriptor_templates_reject_single_keys() {
+    let secret = DescriptorSecretKey::from_string(
+        "L2wTu6hQrnDMiFNWA5na6jB12ErGQqtXwqpSL7aWquJaZG8Ai3ch".to_string(),
+    )
+    .unwrap();
+    let public = secret.as_public();
+
+    assert_invalid_secret_template_key(&secret);
+    assert_invalid_public_template_key(&public);
+}
+
+#[test]
+fn test_descriptor_templates_reject_multipath_keys() {
+    let base_xprv = "tprv8ZgxMBicQKsPcwcD4gSnMti126ZiETsuX7qwrtMypr6FBwAP65puFn4v6c3jrN9VwtMRMph6nyT63NrfUL4C3nBzPcduzVSuHD7zbX2JKVc";
+    let secret = DescriptorSecretKey::from_string(format!("{base_xprv}/<0;1>/*")).unwrap();
+    let public = crate::keys::DescriptorPublicKey::from_string(
+        "tpubDDnGNapGEY6AZAdQbfRJgMg9fvz8pUBrLwvyvUqEgcUfgzM6zc2eVK4vY9x9L5FJWdX8WumXuLEDV5zDZnTfbn87vLe9XceCFwTu9so9Kks/<0;1>/*".to_string(),
+    )
+    .unwrap();
+
+    assert_invalid_secret_template_key(&secret);
+    assert_invalid_public_template_key(&public);
+}
+
 #[test]
 fn test_descriptor_templates() {
     let master: DescriptorSecretKey = get_descriptor_secret_key();
@@ -36,13 +119,13 @@ fn test_descriptor_templates() {
         .as_public();
     // Public 86: [d1d04177/86'/1'/0']tpubDCJzjbcGbdEfXMWaL6QmgVmuSfXkrue7m2YNoacWwyc7a2XjXaKojRqNEbo41CFL3PyYmKdhwg2fkGpLX4SQCbQjCGxAkWHJTw9WEeenrJb/*
     let template_private_44 =
-        Descriptor::new_bip44(&master, KeychainKind::External, NetworkKind::Test);
+        Descriptor::new_bip44(&master, KeychainKind::External, NetworkKind::Test).unwrap();
     let template_private_49 =
-        Descriptor::new_bip49(&master, KeychainKind::External, NetworkKind::Test);
+        Descriptor::new_bip49(&master, KeychainKind::External, NetworkKind::Test).unwrap();
     let template_private_84 =
-        Descriptor::new_bip84(&master, KeychainKind::External, NetworkKind::Test);
+        Descriptor::new_bip84(&master, KeychainKind::External, NetworkKind::Test).unwrap();
     let template_private_86 =
-        Descriptor::new_bip86(&master, KeychainKind::External, NetworkKind::Test);
+        Descriptor::new_bip86(&master, KeychainKind::External, NetworkKind::Test).unwrap();
     // the extended public keys are the same when creating them manually as they are with the templates
     let template_public_44 = Descriptor::new_bip44_public(
         &handmade_public_44,
@@ -155,7 +238,8 @@ fn test_descriptor_derive_address() {
         &get_descriptor_secret_key(),
         KeychainKind::External,
         NetworkKind::Test,
-    );
+    )
+    .unwrap();
 
     let derived = descriptor
         .derive_address(0, Network::Testnet)

--- a/bdk-swift/Tests/BitcoinDevKitTests/DescriptorTests.swift
+++ b/bdk-swift/Tests/BitcoinDevKitTests/DescriptorTests.swift
@@ -9,7 +9,7 @@ final class DescriptorTests: XCTestCase {
             mnemonic: mnemonic,
             password: nil
         )
-        let descriptor: Descriptor = Descriptor.newBip86(
+        let descriptor: Descriptor = try Descriptor.newBip86(
             secretKey: descriptorSecretKey,
             keychainKind: KeychainKind.external,
             networkKind: NetworkKind.test


### PR DESCRIPTION
### Description

Closes #1071.

The BIP44, BIP49, BIP84, and BIP86 descriptor constructors accepted descriptor key objects whose underlying single or multipath variants were handled with `unreachable!()`. This allowed generated binding callers to trigger a Rust panic after successfully parsing a WIF or other valid descriptor key.

This change makes every BIP template constructor return `DescriptorError::InvalidKeyType` for unsupported variants. The secret-key constructors now return `Result`, and their template build errors are propagated instead of unwrapped.

### Breaking change

The four secret BIP template constructors are now throwable in generated bindings.

### Validation

- `cargo fmt --all -- --config format_code_in_doc_comments=true --check`
- `cargo clippy --all-targets --features "uniffi/bindgen-tests"`
- `CLASSPATH=./tests/jna/jna-5.14.0.jar cargo test --features uniffi/bindgen-tests`
