### PR TITLE
chore: remove mnemonic entropy TODO comment

### DIFF
--- a/bdk-ffi/src/keys.rs
+++ b/bdk-ffi/src/keys.rs
@@ -29,7 +29,6 @@ impl Mnemonic {
     /// Generate a mnemonic given a word count.
     #[uniffi::constructor]
     pub fn new(word_count: WordCount) -> Self {
-        // TODO 4: I DON'T KNOW IF THIS IS A DECENT WAY TO GENERATE ENTROPY PLEASE CONFIRM
         let mut rng = rand::thread_rng();
         let mut entropy = [0u8; 32];
         rng.fill(&mut entropy);
@@ -39,6 +38,7 @@ impl Mnemonic {
         let mnemonic = BdkMnemonic::parse_in(Language::English, generated_key.to_string()).unwrap();
         Mnemonic(mnemonic)
     }
+
     /// Parse a string as a mnemonic seed phrase.
     #[uniffi::constructor]
     pub fn from_string(mnemonic: String) -> Result<Self, Bip39Error> {


### PR DESCRIPTION
Backport b54a112d6336a7cab654443a2453041a5cac03aa (`chore: remove todo comment`) to the maintained 2.2 release branch.

This removes an obsolete TODO comment only; mnemonic generation behavior is unchanged.

## Test plan
- [x] Verified the cherry-pick applies cleanly to `release/2.2`.
- [x] Ran `git show --check`.

Co-authored-by: thunderbiscuit <thunderbiscuit@protonmail.com>