### PR TITLE
fix: prevent maximum fee rate overflow

### DIFF
--- a/bdk-ffi/src/bitcoin.rs
+++ b/bdk-ffi/src/bitcoin.rs
@@ -163,7 +163,7 @@ impl FeeRate {
 
     /// Converts to sat/vB rounding up.
     pub fn to_sat_per_vb_ceil(&self) -> u64 {
-        self.0.to_sat_per_vb_ceil()
+        self.0.to_sat_per_kwu().div_ceil(250)
     }
 
     /// Converts to sat/vB rounding down.
@@ -203,7 +203,7 @@ impl FeeRate {
 
 impl Display for FeeRate {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{:#}", self.0)
+        write!(f, "{}.00 sat/vbyte", self.to_sat_per_vb_ceil())
     }
 }
 

--- a/bdk-ffi/src/error.rs
+++ b/bdk-ffi/src/error.rs
@@ -1332,6 +1332,7 @@ impl From<BdkExtractTxError> for ExtractTxError {
     fn from(error: BdkExtractTxError) -> Self {
         match error {
             BdkExtractTxError::AbsurdFeeRate { fee_rate, .. } => {
+                let fee_rate = crate::bitcoin::FeeRate::from(fee_rate);
                 let sat_per_vbyte = fee_rate.to_sat_per_vb_ceil();
                 ExtractTxError::AbsurdFeeRate {
                     fee_rate: sat_per_vbyte,

--- a/bdk-ffi/src/tests/bitcoin.rs
+++ b/bdk-ffi/src/tests/bitcoin.rs
@@ -1,6 +1,16 @@
-use crate::bitcoin::{Address, AddressData, Key, Network, ProprietaryKey, Psbt, Transaction};
+use crate::bitcoin::{
+    Address, AddressData, FeeRate, Key, Network, ProprietaryKey, Psbt, Transaction,
+};
 use crate::error::TransactionError;
 use bdk_electrum::bdk_core::bitcoin::hex::DisplayHex;
+
+#[test]
+fn maximum_fee_rate_converts_and_displays_without_overflow() {
+    let fee_rate = FeeRate::from_sat_per_kwu(u64::MAX);
+
+    assert_eq!(fee_rate.to_sat_per_vb_ceil(), u64::MAX / 250 + 1);
+    assert_eq!(fee_rate.to_string(), "73786976294838207.00 sat/vbyte");
+}
 
 #[test]
 fn test_is_valid_for_network() {

--- a/bdk-ffi/src/tests/error.rs
+++ b/bdk-ffi/src/tests/error.rs
@@ -1,7 +1,13 @@
+use crate::bitcoin::Psbt;
 use crate::error::{
     Bip32Error, Bip39Error, CannotConnectError, DescriptorError, DescriptorKeyError, ElectrumError,
     EsploraError, ExtractTxError, PsbtError, PsbtParseError, RequestBuilderError, SignerError,
     TransactionError, TxidParseError,
+};
+
+use bdk_wallet::bitcoin::{
+    absolute, transaction, Amount as BdkAmount, Psbt as BdkPsbt, ScriptBuf as BdkScriptBuf,
+    Transaction as BdkTransaction, TxOut as BdkTxOut,
 };
 
 #[test]
@@ -371,6 +377,34 @@ fn test_error_extract_tx() {
     for (error, expected_message) in cases {
         assert_eq!(error.to_string(), expected_message);
     }
+}
+
+#[test]
+fn test_extract_tx_fee_overflow_maps_to_maximum_fee_rate() {
+    let transaction = BdkTransaction {
+        version: transaction::Version::TWO,
+        lock_time: absolute::LockTime::ZERO,
+        input: vec![],
+        output: vec![
+            BdkTxOut {
+                value: BdkAmount::MAX,
+                script_pubkey: BdkScriptBuf::new(),
+            },
+            BdkTxOut {
+                value: BdkAmount::MAX,
+                script_pubkey: BdkScriptBuf::new(),
+            },
+        ],
+    };
+    let psbt = BdkPsbt::from_unsigned_tx(transaction).unwrap();
+
+    let error = Psbt::from(psbt).extract_tx().unwrap_err();
+
+    assert!(matches!(
+        error,
+        ExtractTxError::AbsurdFeeRate { fee_rate }
+            if fee_rate == u64::MAX / 250 + 1
+    ));
 }
 
 #[test]


### PR DESCRIPTION
<!-- Erase any parts of this template not applicable to your Pull Request. -->

### Description

Fixes overflow when converting and displaying extremely large FeeRate values (including PSBT fee overflow errors), and adds regression coverage for both paths.

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Documentation

<!-- Paste the canonical docs/spec for anything this PR wraps or updates. -->

- [ ] [`bdk_wallet`](https://docs.rs/bdk_wallet/latest/bdk_wallet/)
  <!-- Add a link below with the docs.rs page. -->
- [ ] [`bitcoin`](https://docs.rs/bitcoin/latest/bitcoin/index.html)
  <!-- Add a link below with the docs.rs page. -->
- [ ] [`uniffi`](https://github.com/mozilla/uniffi-rs) <!-- Add a link below with the version changelog or any other docs. -->
- [ ] Other: <!-- Add a link below with additional references -->

### Changelog

<!-- Add exactly one changelog label to this PR:
`changelog: added`, `changelog: changed`, `changelog: fixed`, `changelog: breaking`, or `changelog: none`.
These labels map to the Keep a Changelog categories used by `CHANGELOG.md` where possible.
GitHub generated release notes use the label plus the PR title to draft the changelog.
-->

### Checklists

#### All Submissions:

* [ ] I've signed all my commits
* [ ] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [ ] I ran `cargo fmt` and `cargo clippy` before committing
* [ ] I've added exactly one `changelog:*` label
* [ ] I've linked the relevant upstream docs or specs above

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
