### PR TITLE
fix(kyoto): honor recovery birthdays on non mainnet networks

### DIFF
--- a/bdk-ffi/src/kyoto.rs
+++ b/bdk-ffi/src/kyoto.rs
@@ -207,31 +207,33 @@ impl CbfBuilder {
                 checkpoint,
             } => {
                 let network = wallet.network();
-                // Any other network has taproot and segwit baked in since the genesis block.
-                if !matches!(network, Network::Bitcoin) {
-                    bdk_kyoto::ScanType::Recovery {
+                match checkpoint {
+                    RecoveryPoint::GenesisBlock => bdk_kyoto::ScanType::Recovery {
                         used_script_index,
                         checkpoint: HashCheckpoint::from_genesis(network),
-                    }
-                } else {
-                    match checkpoint {
-                        RecoveryPoint::GenesisBlock => bdk_kyoto::ScanType::Recovery {
-                            used_script_index,
-                            checkpoint: HashCheckpoint::from_genesis(wallet.network()),
-                        },
-                        RecoveryPoint::SegwitActivation => bdk_kyoto::ScanType::Recovery {
+                    },
+                    RecoveryPoint::SegwitActivation if matches!(network, Network::Bitcoin) => {
+                        bdk_kyoto::ScanType::Recovery {
                             used_script_index,
                             checkpoint: HashCheckpoint::segwit_activation(),
-                        },
-                        RecoveryPoint::TaprootActivation => bdk_kyoto::ScanType::Recovery {
+                        }
+                    }
+                    RecoveryPoint::TaprootActivation if matches!(network, Network::Bitcoin) => {
+                        bdk_kyoto::ScanType::Recovery {
                             used_script_index,
                             checkpoint: HashCheckpoint::taproot_activation(),
-                        },
-                        RecoveryPoint::Other { birthday } => bdk_kyoto::ScanType::Recovery {
-                            used_script_index,
-                            checkpoint: HashCheckpoint::new(birthday.height, birthday.hash.0),
-                        },
+                        }
                     }
+                    RecoveryPoint::SegwitActivation | RecoveryPoint::TaprootActivation => {
+                        bdk_kyoto::ScanType::Recovery {
+                            used_script_index,
+                            checkpoint: HashCheckpoint::from_genesis(network),
+                        }
+                    }
+                    RecoveryPoint::Other { birthday } => bdk_kyoto::ScanType::Recovery {
+                        used_script_index,
+                        checkpoint: HashCheckpoint::new(birthday.height, birthday.hash.0),
+                    },
                 }
             }
         };


### PR DESCRIPTION
<!-- Erase any parts of this template not applicable to your Pull Request. -->

### Description

Honors explicit Kyoto recovery birthdays on every network (previously we had non mainnet birthdays fall back to genesis)

We had a non mainnet guard that predated `RecoveryPoint::Other` so I thought this might just be an oversight to fix now, but let me know if I'm wrong!

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Documentation

<!-- Paste the canonical docs/spec for anything this PR wraps or updates. -->

- [ ] [`bdk_wallet`](https://docs.rs/bdk_wallet/latest/bdk_wallet/)
  <!-- Add a link below with the docs.rs page. -->
- [ ] [`bitcoin`](https://docs.rs/bitcoin/latest/bitcoin/index.html)
  <!-- Add a link below with the docs.rs page. -->
- [ ] [`uniffi`](https://github.com/mozilla/uniffi-rs) <!-- Add a link below with the version changelog or any other docs. -->
- [ ] Other: <!-- Add a link below with additional references -->

### Changelog

<!-- Add exactly one changelog label to this PR:
`changelog: added`, `changelog: changed`, `changelog: fixed`, `changelog: breaking`, or `changelog: none`.
These labels map to the Keep a Changelog categories used by `CHANGELOG.md` where possible.
GitHub generated release notes use the label plus the PR title to draft the changelog.
-->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
* [x] I've added exactly one `changelog:*` label
* [ ] I've linked the relevant upstream docs or specs above

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
