### PR TITLE
Fix persistence error propagation and unexpected callback crashes

### DIFF
--- a/bdk-ffi/src/error.rs
+++ b/bdk-ffi/src/error.rs
@@ -239,7 +239,7 @@ pub enum CreateTxError {
 #[derive(Debug, thiserror::Error, uniffi::Error)]
 #[uniffi::export(Debug, Display)]
 pub enum CreateWithPersistError {
-    #[error("sqlite persistence error: {error_message}")]
+    #[error("persistence error: {error_message}")]
     Persist { error_message: String },
 
     #[error("the wallet has already been created")]
@@ -464,7 +464,7 @@ pub enum HashParseError {
 #[derive(Debug, thiserror::Error, uniffi::Error)]
 #[uniffi::export(Debug, Display)]
 pub enum LoadWithPersistError {
-    #[error("sqlite persistence error: {error_message}")]
+    #[error("persistence error: {error_message}")]
     Persist { error_message: String },
 
     #[error("the loaded changeset cannot construct wallet: {error_message}")]
@@ -1131,9 +1131,9 @@ impl From<BdkCreateWithPersistError<chain::rusqlite::Error>> for CreateWithPersi
 impl From<BdkCreateWithPersistError<PersistenceError>> for CreateWithPersistError {
     fn from(error: BdkCreateWithPersistError<PersistenceError>) -> Self {
         match error {
-            BdkCreateWithPersistError::Persist(e) => CreateWithPersistError::Persist {
-                error_message: e.to_string(),
-            },
+            BdkCreateWithPersistError::Persist(PersistenceError::Reason { error_message }) => {
+                CreateWithPersistError::Persist { error_message }
+            }
             BdkCreateWithPersistError::Descriptor(e) => CreateWithPersistError::Descriptor {
                 error_message: e.to_string(),
             },
@@ -1377,9 +1377,9 @@ impl From<BdkLoadWithPersistError<chain::rusqlite::Error>> for LoadWithPersistEr
 impl From<BdkLoadWithPersistError<PersistenceError>> for LoadWithPersistError {
     fn from(error: BdkLoadWithPersistError<PersistenceError>) -> Self {
         match error {
-            BdkLoadWithPersistError::Persist(e) => LoadWithPersistError::Persist {
-                error_message: e.to_string(),
-            },
+            BdkLoadWithPersistError::Persist(PersistenceError::Reason { error_message }) => {
+                LoadWithPersistError::Persist { error_message }
+            }
             BdkLoadWithPersistError::InvalidChangeSet(e) => {
                 LoadWithPersistError::InvalidChangeSet {
                     error_message: e.to_string(),

--- a/bdk-ffi/src/error.rs
+++ b/bdk-ffi/src/error.rs
@@ -26,8 +26,8 @@ use bdk_wallet::miniscript::psbt::Error as BdkPsbtFinalizeError;
 use bdk_wallet::signer::SignerError as BdkSignerError;
 use bdk_wallet::tx_builder::AddForeignUtxoError as BdkAddForeignUtxoError;
 use bdk_wallet::tx_builder::AddUtxoError;
+use bdk_wallet::CreateWithPersistError as BdkCreateWithPersistError;
 use bdk_wallet::LoadWithPersistError as BdkLoadWithPersistError;
-use bdk_wallet::{chain, CreateWithPersistError as BdkCreateWithPersistError};
 
 use std::convert::TryInto;
 
@@ -1111,23 +1111,6 @@ impl From<PushBytesError> for CreateTxError {
     }
 }
 
-impl From<BdkCreateWithPersistError<chain::rusqlite::Error>> for CreateWithPersistError {
-    fn from(error: BdkCreateWithPersistError<chain::rusqlite::Error>) -> Self {
-        match error {
-            BdkCreateWithPersistError::Persist(e) => CreateWithPersistError::Persist {
-                error_message: e.to_string(),
-            },
-            BdkCreateWithPersistError::Descriptor(e) => CreateWithPersistError::Descriptor {
-                error_message: e.to_string(),
-            },
-            // Objects cannot currently be used in enumerations
-            BdkCreateWithPersistError::DataAlreadyExists(_e) => {
-                CreateWithPersistError::DataAlreadyExists
-            }
-        }
-    }
-}
-
 impl From<BdkCreateWithPersistError<PersistenceError>> for CreateWithPersistError {
     fn from(error: BdkCreateWithPersistError<PersistenceError>) -> Self {
         match error {
@@ -1355,21 +1338,6 @@ impl From<BdkFromScriptError> for FromScriptError {
                 error_message: e.to_string(),
             },
             _ => FromScriptError::OtherFromScriptErr,
-        }
-    }
-}
-
-impl From<BdkLoadWithPersistError<chain::rusqlite::Error>> for LoadWithPersistError {
-    fn from(error: BdkLoadWithPersistError<chain::rusqlite::Error>) -> Self {
-        match error {
-            BdkLoadWithPersistError::Persist(e) => LoadWithPersistError::Persist {
-                error_message: e.to_string(),
-            },
-            BdkLoadWithPersistError::InvalidChangeSet(e) => {
-                LoadWithPersistError::InvalidChangeSet {
-                    error_message: e.to_string(),
-                }
-            }
         }
     }
 }

--- a/bdk-ffi/src/error.rs
+++ b/bdk-ffi/src/error.rs
@@ -1397,6 +1397,14 @@ impl From<BdkSqliteError> for PersistenceError {
     }
 }
 
+impl From<uniffi::UnexpectedUniFFICallbackError> for PersistenceError {
+    fn from(error: uniffi::UnexpectedUniFFICallbackError) -> Self {
+        PersistenceError::Reason {
+            error_message: error.reason,
+        }
+    }
+}
+
 impl From<BdkPreV1MigrationError> for PreV1MigrationError {
     fn from(error: BdkPreV1MigrationError) -> Self {
         match error {

--- a/bdk-ffi/src/tests/error.rs
+++ b/bdk-ffi/src/tests/error.rs
@@ -1,7 +1,13 @@
 use crate::error::{
-    Bip32Error, Bip39Error, CannotConnectError, DescriptorError, DescriptorKeyError, ElectrumError,
-    EsploraError, ExtractTxError, PsbtError, PsbtParseError, RequestBuilderError, SignerError,
+    Bip32Error, Bip39Error, CannotConnectError, CreateWithPersistError, DescriptorError,
+    DescriptorKeyError, ElectrumError, EsploraError, ExtractTxError, LoadWithPersistError,
+    PersistenceError, PsbtError, PsbtParseError, RequestBuilderError, SignerError,
     TransactionError, TxidParseError,
+};
+
+use bdk_wallet::{
+    CreateWithPersistError as BdkCreateWithPersistError,
+    LoadWithPersistError as BdkLoadWithPersistError,
 };
 
 #[test]
@@ -102,6 +108,78 @@ fn test_error_cannot_connect() {
     let error = CannotConnectError::Include { height: 42 };
 
     assert_eq!(format!("{}", error), "cannot include height: 42");
+}
+
+#[test]
+fn test_error_create_with_persist() {
+    let custom_error: CreateWithPersistError =
+        BdkCreateWithPersistError::Persist(PersistenceError::Reason {
+            error_message: "custom failure".to_string(),
+        })
+        .into();
+
+    match &custom_error {
+        CreateWithPersistError::Persist { error_message } => {
+            assert_eq!(error_message, "custom failure");
+        }
+        error => panic!("expected Persist error, got {:?}", error),
+    }
+    assert_eq!(
+        custom_error.to_string(),
+        "persistence error: custom failure"
+    );
+
+    let sqlite_error: CreateWithPersistError = BdkCreateWithPersistError::Persist(
+        PersistenceError::from(bdk_wallet::rusqlite::Error::InvalidQuery),
+    )
+    .into();
+
+    match &sqlite_error {
+        CreateWithPersistError::Persist { error_message } => {
+            assert_eq!(error_message, "Query is not read-only");
+        }
+        error => panic!("expected Persist error, got {:?}", error),
+    }
+    assert_eq!(
+        sqlite_error.to_string(),
+        "persistence error: Query is not read-only"
+    );
+}
+
+#[test]
+fn test_error_load_with_persist() {
+    let custom_error: LoadWithPersistError =
+        BdkLoadWithPersistError::Persist(PersistenceError::Reason {
+            error_message: "custom failure".to_string(),
+        })
+        .into();
+
+    match &custom_error {
+        LoadWithPersistError::Persist { error_message } => {
+            assert_eq!(error_message, "custom failure");
+        }
+        error => panic!("expected Persist error, got {:?}", error),
+    }
+    assert_eq!(
+        custom_error.to_string(),
+        "persistence error: custom failure"
+    );
+
+    let sqlite_error: LoadWithPersistError = BdkLoadWithPersistError::Persist(
+        PersistenceError::from(bdk_wallet::rusqlite::Error::InvalidQuery),
+    )
+    .into();
+
+    match &sqlite_error {
+        LoadWithPersistError::Persist { error_message } => {
+            assert_eq!(error_message, "Query is not read-only");
+        }
+        error => panic!("expected Persist error, got {:?}", error),
+    }
+    assert_eq!(
+        sqlite_error.to_string(),
+        "persistence error: Query is not read-only"
+    );
 }
 
 #[test]

--- a/bdk-ffi/src/tests/wallet.rs
+++ b/bdk-ffi/src/tests/wallet.rs
@@ -176,6 +176,35 @@ fn test_create_wallet() {
 }
 
 #[test]
+fn test_persist_preserves_persistence_error_message() {
+    use crate::error::PersistenceError;
+    use crate::store::Persistence;
+    use crate::types::ChangeSet;
+
+    struct FailingPersistence;
+
+    impl Persistence for FailingPersistence {
+        fn initialize(&self) -> Result<Arc<ChangeSet>, PersistenceError> {
+            Ok(Arc::new(ChangeSet::new()))
+        }
+
+        fn persist(&self, _changeset: Arc<ChangeSet>) -> Result<(), PersistenceError> {
+            Err(PersistenceError::Reason {
+                error_message: "write failed".to_string(),
+            })
+        }
+    }
+
+    let wallet = build_wallet();
+    wallet.reveal_next_address(KeychainKind::External);
+    let persister = Arc::new(Persister::custom(Arc::new(FailingPersistence)));
+
+    let error = wallet.persist(persister).unwrap_err();
+
+    assert_eq!(error.to_string(), "persistence error: write failed");
+}
+
+#[test]
 fn test_keychains() {
     let wallet = build_wallet();
 

--- a/bdk-ffi/src/wallet.rs
+++ b/bdk-ffi/src/wallet.rs
@@ -945,11 +945,7 @@ impl Wallet {
     pub fn persist(&self, persister: Arc<Persister>) -> Result<bool, PersistenceError> {
         let mut persist_lock = persister.inner.lock().unwrap();
         let deref = persist_lock.deref_mut();
-        self.get_wallet()
-            .persist(deref)
-            .map_err(|e| PersistenceError::Reason {
-                error_message: e.to_string(),
-            })
+        self.get_wallet().persist(deref)
     }
 
     /// Get a reference of the staged [`ChangeSet`] that is yet to be committed (if any).

--- a/bdk-swift/Tests/BitcoinDevKitTests/PersistenceTests.swift
+++ b/bdk-swift/Tests/BitcoinDevKitTests/PersistenceTests.swift
@@ -25,6 +25,45 @@ final class PersistenceTests: XCTestCase {
         dbFilePath = resourceUrl
     }
 
+    func testUnexpectedInitializeErrorReturnsLoadPersistenceError() {
+        struct UnexpectedInitializeError: Error, CustomStringConvertible {
+            var description: String { "unexpected initialize failure" }
+        }
+
+        final class ThrowingPersistence: Persistence, @unchecked Sendable {
+            func initialize() throws -> ChangeSet {
+                throw UnexpectedInitializeError()
+            }
+
+            func persist(changeset: ChangeSet) throws {}
+        }
+
+        let persister = Persister.custom(persistence: ThrowingPersistence())
+
+        XCTAssertThrowsError(
+            try Wallet.load(
+                descriptor: descriptor,
+                changeDescriptor: changeDescriptor,
+                persister: persister
+            )
+        ) { error in
+            guard let loadError = error as? LoadWithPersistError else {
+                XCTFail("Expected LoadWithPersistError, got \(error)")
+                return
+            }
+
+            guard case let .Persist(errorMessage) = loadError else {
+                XCTFail("Expected .Persist, got \(loadError)")
+                return
+            }
+
+            XCTAssertEqual(
+                errorMessage,
+                "persistence error: unexpected initialize failure"
+            )
+        }
+    }
+
     func testPersistence() throws {
         let persister = try Persister.newSqlite(path: dbFilePath.path)
         let wallet = try Wallet.load(

--- a/bdk-swift/Tests/BitcoinDevKitTests/PersistenceTests.swift
+++ b/bdk-swift/Tests/BitcoinDevKitTests/PersistenceTests.swift
@@ -59,7 +59,54 @@ final class PersistenceTests: XCTestCase {
 
             XCTAssertEqual(
                 errorMessage,
+                "unexpected initialize failure"
+            )
+            XCTAssertEqual(
+                loadError.description,
                 "persistence error: unexpected initialize failure"
+            )
+        }
+    }
+
+    func testUnexpectedPersistErrorReturnsCreatePersistenceError() {
+        struct UnexpectedPersistError: Error, CustomStringConvertible {
+            var description: String { "unexpected persist failure" }
+        }
+
+        final class ThrowingPersistence: Persistence, @unchecked Sendable {
+            func initialize() throws -> ChangeSet {
+                ChangeSet()
+            }
+
+            func persist(changeset: ChangeSet) throws {
+                throw UnexpectedPersistError()
+            }
+        }
+
+        let persister = Persister.custom(persistence: ThrowingPersistence())
+
+        XCTAssertThrowsError(
+            try Wallet(
+                descriptor: descriptor,
+                changeDescriptor: changeDescriptor,
+                network: .signet,
+                persister: persister
+            )
+        ) { error in
+            guard let createError = error as? CreateWithPersistError else {
+                XCTFail("Expected CreateWithPersistError, got \(error)")
+                return
+            }
+
+            guard case let .Persist(errorMessage) = createError else {
+                XCTFail("Expected .Persist, got \(createError)")
+                return
+            }
+
+            XCTAssertEqual(errorMessage, "unexpected persist failure")
+            XCTAssertEqual(
+                createError.description,
+                "persistence error: unexpected persist failure"
             )
         }
     }


### PR DESCRIPTION
<!-- Erase any parts of this template not applicable to your Pull Request. -->

### Description


Fix persistence error propagation across the Rust and foreign-binding boundaries.

Previously:

- `Wallet::persist` wrapped an existing `PersistenceError` producing messages such as `persistence error: persistence error: ...`.
- Unexpected errors thrown by custom Swift/Kotlin(?) persisters could panic the Rust callback bridge and crash the host application instead of returning a catchable error
- Create/load errors used the backend-specific prefix `sqlite persistence error:` even for custom persisters while their associated payloads contained another formatted prefix.

This PR keeps raw error causes in associated payloads and applies one backend-neutral `persistence error:` prefix when displaying them. No API types or signatures change but bindings messages + associated error payloads are corrected.

The third commit could stand as a separate PR because it adjusts create/load message semantics, but I included it here because it completes the same persistence error stuff.


### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Documentation

<!-- Paste the canonical docs/spec for anything this PR wraps or updates. -->

- [ ] [`bdk_wallet`](https://docs.rs/bdk_wallet/latest/bdk_wallet/)
  <!-- Add a link below with the docs.rs page. -->
- [ ] [`bitcoin`](https://docs.rs/bitcoin/latest/bitcoin/index.html)
  <!-- Add a link below with the docs.rs page. -->
- [ ] [`uniffi`](https://github.com/mozilla/uniffi-rs) <!-- Add a link below with the version changelog or any other docs. -->
- [ ] Other: <!-- Add a link below with additional references -->

### Changelog

<!-- Add exactly one changelog label to this PR:
`changelog: added`, `changelog: changed`, `changelog: fixed`, `changelog: breaking`, or `changelog: none`.
These labels map to the Keep a Changelog categories used by `CHANGELOG.md` where possible.
GitHub generated release notes use the label plus the PR title to draft the changelog.
-->

### Checklists

#### All Submissions:

* [ ] I've signed all my commits
* [ ] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [ ] I ran `cargo fmt` and `cargo clippy` before committing
* [ ] I've added exactly one `changelog:*` label
* [ ] I've linked the relevant upstream docs or specs above

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
