### PR TITLE
fix: handle unexpected custom persister errors

### DIFF
--- a/bdk-ffi/src/error.rs
+++ b/bdk-ffi/src/error.rs
@@ -1397,6 +1397,14 @@ impl From<BdkSqliteError> for PersistenceError {
     }
 }
 
+impl From<uniffi::UnexpectedUniFFICallbackError> for PersistenceError {
+    fn from(error: uniffi::UnexpectedUniFFICallbackError) -> Self {
+        PersistenceError::Reason {
+            error_message: error.reason,
+        }
+    }
+}
+
 impl From<BdkPreV1MigrationError> for PreV1MigrationError {
     fn from(error: BdkPreV1MigrationError) -> Self {
         match error {

--- a/bdk-swift/Tests/BitcoinDevKitTests/PersistenceTests.swift
+++ b/bdk-swift/Tests/BitcoinDevKitTests/PersistenceTests.swift
@@ -25,6 +25,45 @@ final class PersistenceTests: XCTestCase {
         dbFilePath = resourceUrl
     }
 
+    func testUnexpectedInitializeErrorReturnsLoadPersistenceError() {
+        struct UnexpectedInitializeError: Error, CustomStringConvertible {
+            var description: String { "unexpected initialize failure" }
+        }
+
+        final class ThrowingPersistence: Persistence, @unchecked Sendable {
+            func initialize() throws -> ChangeSet {
+                throw UnexpectedInitializeError()
+            }
+
+            func persist(changeset: ChangeSet) throws {}
+        }
+
+        let persister = Persister.custom(persistence: ThrowingPersistence())
+
+        XCTAssertThrowsError(
+            try Wallet.load(
+                descriptor: descriptor,
+                changeDescriptor: changeDescriptor,
+                persister: persister
+            )
+        ) { error in
+            guard let loadError = error as? LoadWithPersistError else {
+                XCTFail("Expected LoadWithPersistError, got \(error)")
+                return
+            }
+
+            guard case let .Persist(errorMessage) = loadError else {
+                XCTFail("Expected .Persist, got \(loadError)")
+                return
+            }
+
+            XCTAssertEqual(
+                errorMessage,
+                "persistence error: unexpected initialize failure"
+            )
+        }
+    }
+
     func testPersistence() throws {
         let persister = try Persister.newSqlite(path: dbFilePath.path)
         let wallet = try Wallet.load(


### PR DESCRIPTION
<!-- Erase any parts of this template not applicable to your Pull Request. -->

### Description

Convert unexpected exceptions from custom persistence callbacks into the existing `PersistenceError::Reason` instead of allowing UniFFI to panic. Adds a Swift bindings test confirming the failure is returned as `LoadWithPersistError.Persist`.

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Documentation

<!-- Paste the canonical docs/spec for anything this PR wraps or updates. -->

- [ ] [`bdk_wallet`](https://docs.rs/bdk_wallet/latest/bdk_wallet/)
  <!-- Add a link below with the docs.rs page. -->
- [ ] [`bitcoin`](https://docs.rs/bitcoin/latest/bitcoin/index.html)
  <!-- Add a link below with the docs.rs page. -->
- [ ] [`uniffi`](https://github.com/mozilla/uniffi-rs) <!-- Add a link below with the version changelog or any other docs. -->
- [ ] Other: <!-- Add a link below with additional references -->

### Changelog

<!-- Add exactly one changelog label to this PR:
`changelog: added`, `changelog: changed`, `changelog: fixed`, `changelog: breaking`, or `changelog: none`.
These labels map to the Keep a Changelog categories used by `CHANGELOG.md` where possible.
GitHub generated release notes use the label plus the PR title to draft the changelog.
-->

### Checklists

#### All Submissions:

* [ ] I've signed all my commits
* [ ] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [ ] I ran `cargo fmt` and `cargo clippy` before committing
* [ ] I've added exactly one `changelog:*` label
* [ ] I've linked the relevant upstream docs or specs above

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
