### PR TITLE
fix: enforce last call wins fee policy

### DIFF
--- a/bdk-ffi/src/tx_builder.rs
+++ b/bdk-ffi/src/tx_builder.rs
@@ -275,6 +275,7 @@ impl TxBuilder {
     pub fn fee_rate(&self, fee_rate: &FeeRate) -> Arc<Self> {
         Arc::new(TxBuilder {
             fee_rate: Some(fee_rate.clone()),
+            fee_absolute: None,
             ..self.clone()
         })
     }
@@ -286,6 +287,7 @@ impl TxBuilder {
     /// Note that this is really a minimum absolute fee – it’s possible to overshoot it slightly since adding a change output to drain the remaining excess might not be viable.
     pub fn fee_absolute(&self, fee_amount: Arc<Amount>) -> Arc<Self> {
         Arc::new(TxBuilder {
+            fee_rate: None,
             fee_absolute: Some(fee_amount),
             ..self.clone()
         })
@@ -906,6 +908,8 @@ fn parse_sighash_type(sighash: &str) -> Result<BdkPsbtSighashType, SighashParseE
 #[cfg(test)]
 mod tests {
     use super::{CoinSelectionAlgorithm, TxBuilder};
+    use crate::bitcoin::{Amount, FeeRate};
+    use std::sync::Arc;
 
     #[test]
     fn tx_builder_defaults_to_upstream_coin_selection() {
@@ -938,5 +942,36 @@ mod tests {
             let tx_builder = TxBuilder::new().coin_selection(algorithm);
             assert_eq!(tx_builder.coin_selection, Some(algorithm));
         }
+    }
+
+    #[test]
+    fn tx_builder_fee_absolute_overrides_fee_rate() {
+        let fee_rate = FeeRate::from_sat_per_vb(2).unwrap();
+        let tx_builder = TxBuilder::new()
+            .fee_rate(&fee_rate)
+            .fee_absolute(Arc::new(Amount::from_sat(500)));
+
+        assert!(tx_builder.fee_rate.is_none());
+        assert_eq!(
+            tx_builder.fee_absolute.as_ref().map(|fee| fee.to_sat()),
+            Some(500)
+        );
+    }
+
+    #[test]
+    fn tx_builder_fee_rate_overrides_fee_absolute() {
+        let fee_rate = FeeRate::from_sat_per_vb(2).unwrap();
+        let tx_builder = TxBuilder::new()
+            .fee_absolute(Arc::new(Amount::from_sat(500)))
+            .fee_rate(&fee_rate);
+
+        assert!(tx_builder.fee_absolute.is_none());
+        assert_eq!(
+            tx_builder
+                .fee_rate
+                .as_ref()
+                .map(FeeRate::to_sat_per_vb_ceil),
+            Some(2)
+        );
     }
 }


### PR DESCRIPTION
<!-- Erase any parts of this template not applicable to your Pull Request. -->

### Description

Clear the competing fee setting whenever fee_rate or fee_absolute is called, enforcing documented last-call-wins behavior.

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Documentation

<!-- Paste the canonical docs/spec for anything this PR wraps or updates. -->

- [x] [`bdk_wallet`](https://docs.rs/bdk_wallet/latest/bdk_wallet/)
https://docs.rs/bdk_wallet/3.1.0/bdk_wallet/struct.TxBuilder.html#method.fee_absolute

- [ ] [`bitcoin`](https://docs.rs/bitcoin/latest/bitcoin/index.html)
  <!-- Add a link below with the docs.rs page. -->
- [ ] [`uniffi`](https://github.com/mozilla/uniffi-rs) <!-- Add a link below with the version changelog or any other docs. -->
- [ ] Other: <!-- Add a link below with additional references -->

### Changelog

<!-- Add exactly one changelog label to this PR:
`changelog: added`, `changelog: changed`, `changelog: fixed`, `changelog: breaking`, or `changelog: none`.
These labels map to the Keep a Changelog categories used by `CHANGELOG.md` where possible.
GitHub generated release notes use the label plus the PR title to draft the changelog.
-->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
* [ ] I've added exactly one `changelog:*` label
* [ ] I've linked the relevant upstream docs or specs above

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
