### PR TITLE
fix: reject invalid transaction builder current heights

### DIFF
--- a/bdk-ffi/src/tests/wallet.rs
+++ b/bdk-ffi/src/tests/wallet.rs
@@ -1,10 +1,10 @@
-use crate::bitcoin::{Amount, BlockHash, Network, NetworkKind};
+use crate::bitcoin::{Amount, BlockHash, FeeRate, Network, NetworkKind};
 use crate::descriptor::Descriptor;
-use crate::error::LoadWithPersistError;
+use crate::error::{CreateTxError, LoadWithPersistError};
 use crate::signer::SignersContainer;
 use crate::store::Persister;
-use crate::tx_builder::TxBuilder;
-use crate::types::Update;
+use crate::tx_builder::{BumpFeeTxBuilder, TxBuilder};
+use crate::types::{UnconfirmedTx, Update};
 use crate::wallet::{CreateParams, LoadParams, Wallet};
 
 use bdk_wallet::bitcoin::Amount as BdkAmount;
@@ -80,6 +80,57 @@ fn funded_wallet() -> Wallet {
     wallet.apply_update(Arc::new(Update(update))).unwrap();
 
     wallet
+}
+
+#[test]
+fn test_tx_builder_invalid_current_height_returns_error() {
+    let wallet = Arc::new(funded_wallet());
+    let recipient_script = wallet
+        .next_unused_address(KeychainKind::External)
+        .address
+        .script_pubkey();
+
+    let result = TxBuilder::new()
+        .add_recipient(&recipient_script, Arc::new(Amount::from_sat(10_000)))
+        .current_height(500_000_000)
+        .finish(&wallet);
+
+    assert!(matches!(
+        result,
+        Err(CreateTxError::LockTimeConversionError)
+    ));
+}
+
+#[test]
+fn test_bump_fee_tx_builder_invalid_current_height_returns_error() {
+    let wallet = Arc::new(funded_wallet());
+    let recipient_script = wallet
+        .next_unused_address(KeychainKind::External)
+        .address
+        .script_pubkey();
+    let original_tx = TxBuilder::new()
+        .add_recipient(&recipient_script, Arc::new(Amount::from_sat(10_000)))
+        .finish(&wallet)
+        .unwrap()
+        .extract_tx()
+        .unwrap();
+
+    assert!(original_tx.is_explicitly_rbf());
+
+    let txid = original_tx.compute_txid();
+    wallet.apply_unconfirmed_txs(vec![UnconfirmedTx {
+        tx: original_tx,
+        last_seen: 2,
+    }]);
+
+    let result = BumpFeeTxBuilder::new(txid, Arc::new(FeeRate::from_sat_per_vb(2).unwrap()))
+        .current_height(500_000_000)
+        .finish(&wallet);
+
+    assert!(matches!(
+        result,
+        Err(CreateTxError::LockTimeConversionError)
+    ));
 }
 
 #[test]

--- a/bdk-ffi/src/tx_builder.rs
+++ b/bdk-ffi/src/tx_builder.rs
@@ -3,7 +3,7 @@ use crate::error::{AddForeignUtxoError, CreateTxError, SighashParseError};
 use crate::types::{KeychainKind, LockTime, ScriptAmount};
 use crate::wallet::Wallet;
 
-use bdk_wallet::bitcoin::absolute::LockTime as BdkLockTime;
+use bdk_wallet::bitcoin::absolute::{Height as BdkHeight, LockTime as BdkLockTime};
 use bdk_wallet::bitcoin::amount::Amount as BdkAmount;
 use bdk_wallet::bitcoin::psbt::Input as BdkInput;
 use bdk_wallet::bitcoin::psbt::PsbtSighashType as BdkPsbtSighashType;
@@ -637,7 +637,9 @@ impl TxBuilder {
             tx_builder.add_data(&push_bytes);
         }
         if let Some(height) = self.current_height {
-            tx_builder.current_height(height);
+            let height = BdkHeight::from_consensus(height)
+                .map_err(|_| CreateTxError::LockTimeConversionError)?;
+            tx_builder.current_height(height.to_consensus_u32());
         }
         if let Some(locktime) = &self.locktime {
             let bdk_locktime: BdkLockTime = locktime.try_into()?;
@@ -817,7 +819,9 @@ impl BumpFeeTxBuilder {
             tx_builder.set_exact_sequence(Sequence(sequence));
         }
         if let Some(height) = self.current_height {
-            tx_builder.current_height(height);
+            let height = BdkHeight::from_consensus(height)
+                .map_err(|_| CreateTxError::LockTimeConversionError)?;
+            tx_builder.current_height(height.to_consensus_u32());
         }
         if let Some(locktime) = &self.locktime {
             let bdk_locktime: BdkLockTime = locktime.try_into()?;

--- a/bdk-ffi/src/tx_builder.rs
+++ b/bdk-ffi/src/tx_builder.rs
@@ -343,8 +343,9 @@ impl TxBuilder {
     /// 1. Set the `nLockTime` for preventing fee sniping. Note: This will be ignored if you manually specify a
     ///    `nlocktime` using `TxBuilder::nlocktime`.
     ///
-    /// 2. Decide whether coinbase outputs are mature or not. If the coinbase outputs are not mature at `current_height`,
-    ///    we ignore them in the coin selection. If you want to create a transaction that spends immature coinbase inputs,
+    /// 2. Decide whether coinbase outputs are mature or not. If the coinbase outputs are not mature
+    ///    at spending height, which is `current_height` + 1, we ignore them in the coin selection.
+    ///    If you want to create a transaction that spends immature coinbase inputs,
     ///    manually add them using `TxBuilder::add_utxos`.
     ///    In both cases, if you don’t provide a current height, we use the last sync height.
     pub fn current_height(&self, height: u32) -> Arc<Self> {
@@ -735,8 +736,9 @@ impl BumpFeeTxBuilder {
     /// 1. Set the `nLockTime` for preventing fee sniping. Note: This will be ignored if you manually specify a
     ///    `nlocktime` using `TxBuilder::nlocktime`.
     ///
-    /// 2. Decide whether coinbase outputs are mature or not. If the coinbase outputs are not mature at `current_height`,
-    ///    we ignore them in the coin selection. If you want to create a transaction that spends immature coinbase inputs,
+    /// 2. Decide whether coinbase outputs are mature or not. If the coinbase outputs are not mature
+    ///    at spending height, which is `current_height` + 1, we ignore them in the coin selection.
+    ///    If you want to create a transaction that spends immature coinbase inputs,
     ///    manually add them using `TxBuilder::add_utxos`.
     ///    In both cases, if you don’t provide a current height, we use the last sync height.
     pub fn current_height(&self, height: u32) -> Arc<Self> {


### PR DESCRIPTION
<!-- Erase any parts of this template not applicable to your Pull Request. -->

### Description

Validates the current height values in both transaction builders, invalid heights now return `CreateTxError::LockTimeConversionError` from `finish()` instead of panicking

### Notes to the reviewers

Added a 2nd commit just trying to match upstream docs:

https://github.com/bitcoindevkit/bdk_wallet/blob/v3.1.0/src/wallet/tx_builder.rs#L642-L643

... doesnt have to be in this PR, but thought it made sense.

### Documentation

<!-- Paste the canonical docs/spec for anything this PR wraps or updates. -->

- [ ] [`bdk_wallet`](https://docs.rs/bdk_wallet/latest/bdk_wallet/)
  <!-- Add a link below with the docs.rs page. -->
- [ ] [`bitcoin`](https://docs.rs/bitcoin/latest/bitcoin/index.html)
  <!-- Add a link below with the docs.rs page. -->
- [ ] [`uniffi`](https://github.com/mozilla/uniffi-rs) <!-- Add a link below with the version changelog or any other docs. -->
- [ ] Other: <!-- Add a link below with additional references -->

### Changelog

<!-- Add exactly one changelog label to this PR:
`changelog: added`, `changelog: changed`, `changelog: fixed`, `changelog: breaking`, or `changelog: none`.
These labels map to the Keep a Changelog categories used by `CHANGELOG.md` where possible.
GitHub generated release notes use the label plus the PR title to draft the changelog.
-->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
* [x] I've added exactly one `changelog:*` label
* [ ] I've linked the relevant upstream docs or specs above

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
