### PR TITLE
Return an error when CbfNode is started twice

### DIFF
--- a/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/CbfSyncTest.kt
+++ b/bdk-android/lib/src/androidTest/kotlin/org/bitcoindevkit/CbfSyncTest.kt
@@ -1,6 +1,7 @@
 package org.bitcoindevkit
 
 import kotlin.test.Test
+import kotlin.test.assertFailsWith
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import kotlinx.coroutines.launch
@@ -53,6 +54,9 @@ class CbfSyncTest {
                 .build(wallet)
 
             node.run()
+            assertFailsWith<CbfException.NodeAlreadyStarted> {
+                node.run()
+            }
 
             val warningJob = launch {
                 try {

--- a/bdk-ffi/src/error.rs
+++ b/bdk-ffi/src/error.rs
@@ -164,6 +164,9 @@ pub enum CannotConnectError {
 pub enum CbfError {
     #[error("the node is no longer running")]
     NodeStopped,
+
+    #[error("the node has already been started")]
+    NodeAlreadyStarted,
 }
 
 #[derive(Debug, thiserror::Error, uniffi::Error)]

--- a/bdk-ffi/src/kyoto.rs
+++ b/bdk-ffi/src/kyoto.rs
@@ -67,12 +67,10 @@ pub struct CbfNode {
 #[uniffi::export]
 impl CbfNode {
     /// Start the node on a detached OS thread and immediately return.
-    /// Subsequent calls have no effect.
-    pub fn run(self: Arc<Self>) {
+    /// Returns an error if the node has already been started.
+    pub fn run(self: Arc<Self>) -> Result<(), CbfError> {
         let mut lock = self.node.lock().unwrap();
-        let Some(node) = lock.take() else {
-            return;
-        };
+        let node = lock.take().ok_or(CbfError::NodeAlreadyStarted)?;
         std::thread::spawn(|| {
             tokio::runtime::Builder::new_multi_thread()
                 .enable_all()
@@ -82,6 +80,7 @@ impl CbfNode {
                     let _ = node.run().await;
                 })
         });
+        Ok(())
     }
 }
 
@@ -619,15 +618,65 @@ impl DisplayExt for RejectReason {
 
 #[cfg(test)]
 mod tests {
-    use super::CbfNode;
-    use std::sync::{Arc, Mutex};
+    use super::{bip157, BDKCbfBuilder, CbfError, CbfNode, Network};
+    use std::sync::{Arc, Barrier, Mutex};
+
+    fn node() -> (Arc<CbfNode>, bip157::Client) {
+        let (node, client) = BDKCbfBuilder::new(Network::Regtest)
+            .whitelist_only()
+            .build();
+        (
+            Arc::new(CbfNode {
+                node: Mutex::new(Some(node)),
+            }),
+            client,
+        )
+    }
 
     #[test]
-    fn running_a_consumed_node_is_a_no_op() {
+    fn running_a_consumed_node_returns_an_error() {
         let node = Arc::new(CbfNode {
             node: Mutex::new(None),
         });
 
-        node.run();
+        assert!(matches!(node.run(), Err(CbfError::NodeAlreadyStarted)));
+    }
+
+    #[test]
+    fn running_a_node_twice_returns_an_error() {
+        let (node, _client) = node();
+
+        assert!(Arc::clone(&node).run().is_ok());
+        assert!(matches!(node.run(), Err(CbfError::NodeAlreadyStarted)));
+    }
+
+    #[test]
+    fn concurrent_run_calls_allow_one_caller() {
+        let (node, _client) = node();
+        let barrier = Arc::new(Barrier::new(2));
+
+        let handles: Vec<_> = (0..2)
+            .map(|_| {
+                let node = Arc::clone(&node);
+                let barrier = Arc::clone(&barrier);
+                std::thread::spawn(move || {
+                    barrier.wait();
+                    node.run()
+                })
+            })
+            .collect();
+
+        let results: Vec<_> = handles
+            .into_iter()
+            .map(|handle| handle.join().unwrap())
+            .collect();
+        assert_eq!(results.iter().filter(|result| result.is_ok()).count(), 1);
+        assert_eq!(
+            results
+                .iter()
+                .filter(|result| matches!(result, Err(CbfError::NodeAlreadyStarted)))
+                .count(),
+            1
+        );
     }
 }


### PR DESCRIPTION
### Description

Closes #1084.

Changes the exported `CbfNode::run()` method to return `Result<(), CbfError>` and adds the binding-visible `NodeAlreadyStarted` error. The first caller starts the node; later or racing callers receive the typed error instead of silently succeeding.

Regression coverage exercises consumed, sequential, and concurrent calls in Rust. The Android binding test also verifies the generated `CbfException.NodeAlreadyStarted` exception.

### Notes to the reviewers

This intentionally covers only duplicate lifecycle calls. Reporting Tokio runtime construction or Kyoto node-exit failures remains tracked separately in #1089.

Binding verification completed with Kotlin generation plus `:lib:compileDebugAndroidTestKotlin`, and Swift generation plus `swift test`.

### Documentation

- [x] Other: lifecycle semantics and acceptance criteria are defined in #1084

### Changelog

Breaking API change: `CbfNode.run()` now throws/returns an error. Please apply `changelog: breaking`.

### Checklists

#### All Submissions:

* [x] I have signed all my commits
* [x] I followed the contribution guidelines
* [x] I ran `cargo fmt` and `cargo clippy` before committing
* [ ] I have added exactly one `changelog:*` label
* [x] I have linked the relevant upstream docs or specs above

#### Bugfixes:

* [x] This pull request breaks the existing API
* [x] I have added tests to reproduce the issue which are now passing
* [x] I am linking the issue being fixed by this PR