### PR TITLE
fix(descriptor): make descriptor_id fallible for unsupported derivations

### DIFF
--- a/bdk-ffi/src/descriptor.rs
+++ b/bdk-ffi/src/descriptor.rs
@@ -7,15 +7,16 @@ use crate::keys::DescriptorPublicKey;
 use crate::keys::DescriptorSecretKey;
 use crate::types::KeychainKind;
 
-use bdk_wallet::bitcoin::bip32::Fingerprint;
+use bdk_wallet::bitcoin::bip32::{ChildNumber, Fingerprint};
 use bdk_wallet::bitcoin::key::Secp256k1;
 use bdk_wallet::bitcoin::Network;
 use bdk_wallet::chain::DescriptorExt;
 use bdk_wallet::descriptor::{ExtendedDescriptor, IntoWalletDescriptor};
 use bdk_wallet::keys::DescriptorPublicKey as BdkDescriptorPublicKey;
 use bdk_wallet::keys::{DescriptorSecretKey as BdkDescriptorSecretKey, KeyMap};
-use bdk_wallet::miniscript::descriptor::{ConversionError, TapTree};
+use bdk_wallet::miniscript::descriptor::{ConversionError, DescriptorXKey, TapTree, Wildcard};
 use bdk_wallet::miniscript::Descriptor as BdkDescriptor;
+use bdk_wallet::miniscript::ForEachKey;
 use bdk_wallet::miniscript::Miniscript as BdkMiniscript;
 use bdk_wallet::template::{
     Bip44, Bip44Public, Bip49, Bip49Public, Bip84, Bip84Public, Bip86, Bip86Public,
@@ -699,9 +700,36 @@ impl Descriptor {
     }
 
     /// A unique identifier for the descriptor.
-    pub fn descriptor_id(&self) -> Arc<DescriptorId> {
+    ///
+    /// Returns an error for multipath descriptors, and for descriptors retaining hardened public
+    /// key derivations or hardened wildcards.
+    pub fn descriptor_id(&self) -> Result<Arc<DescriptorId>, DescriptorError> {
+        if self.extended_descriptor.is_multipath() {
+            return Err(DescriptorError::MultiPath);
+        }
+
+        // Miniscript 12.3.7 panics before returning `ConversionError` for these paths, and
+        // `bdk_chain`'s `descriptor_id` unwraps the result — so this check is still needed
+        // even once a fixed Miniscript release is pinned.
+        let contains_hardened_public_key_derivation = self.extended_descriptor.for_any_key(|key| {
+            if let BdkDescriptorPublicKey::XPub(DescriptorXKey {
+                derivation_path,
+                wildcard,
+                ..
+            }) = key
+            {
+                return *wildcard == Wildcard::Hardened
+                    || derivation_path.into_iter().any(ChildNumber::is_hardened);
+            }
+
+            false
+        });
+        if contains_hardened_public_key_derivation {
+            return Err(DescriptorError::HardenedDerivationXpub);
+        }
+
         let d_id = self.extended_descriptor.descriptor_id();
-        Arc::new(DescriptorId(d_id.0))
+        Ok(Arc::new(DescriptorId(d_id.0)))
     }
 
     /// Return descriptors for all valid paths.

--- a/bdk-ffi/src/tests/descriptor.rs
+++ b/bdk-ffi/src/tests/descriptor.rs
@@ -184,3 +184,53 @@ fn test_descriptor_derive_address_multipath_error() {
 
     assert_matches!(error, DescriptorError::MultiPath);
 }
+
+#[test]
+fn test_descriptor_id_multipath_error() {
+    let descriptor = Descriptor::new(
+        "wpkh([9a6a2580/84'/1'/0']tpubDDnGNapGEY6AZAdQbfRJgMg9fvz8pUBrLwvyvUqEgcUfgzM6zc2eVK4vY9x9L5FJWdX8WumXuLEDV5zDZnTfbn87vLe9XceCFwTu9so9Kks/<0;1>/*)".to_string(),
+        NetworkKind::Test,
+    )
+    .expect("multipath descriptor parses");
+
+    let error = descriptor.descriptor_id().unwrap_err();
+
+    assert_matches!(error, DescriptorError::MultiPath);
+}
+
+#[test]
+fn test_descriptor_id_hardened_path_error() {
+    let descriptor = Descriptor::new(
+        "wpkh([9a6a2580/84'/1'/0']tpubDDnGNapGEY6AZAdQbfRJgMg9fvz8pUBrLwvyvUqEgcUfgzM6zc2eVK4vY9x9L5FJWdX8WumXuLEDV5zDZnTfbn87vLe9XceCFwTu9so9Kks/0h/*)".to_string(),
+        NetworkKind::Test,
+    )
+    .expect("descriptor with a hardened fixed path parses");
+
+    let error = descriptor.descriptor_id().unwrap_err();
+
+    assert_matches!(error, DescriptorError::HardenedDerivationXpub);
+}
+
+#[test]
+fn test_descriptor_id_hardened_wildcard_error() {
+    let descriptor = Descriptor::new(
+        "wpkh([9a6a2580/84'/1'/0']tpubDDnGNapGEY6AZAdQbfRJgMg9fvz8pUBrLwvyvUqEgcUfgzM6zc2eVK4vY9x9L5FJWdX8WumXuLEDV5zDZnTfbn87vLe9XceCFwTu9so9Kks/*h)".to_string(),
+        NetworkKind::Test,
+    )
+    .expect("descriptor with a hardened wildcard parses");
+
+    let error = descriptor.descriptor_id().unwrap_err();
+
+    assert_matches!(error, DescriptorError::HardenedDerivationXpub);
+}
+
+#[test]
+fn test_descriptor_id_derivable_descriptor() {
+    let descriptor = Descriptor::new(
+        "wpkh([9a6a2580/84'/1'/0']tpubDDnGNapGEY6AZAdQbfRJgMg9fvz8pUBrLwvyvUqEgcUfgzM6zc2eVK4vY9x9L5FJWdX8WumXuLEDV5zDZnTfbn87vLe9XceCFwTu9so9Kks/0/*)".to_string(),
+        NetworkKind::Test,
+    )
+    .expect("descriptor parses");
+
+    assert!(descriptor.descriptor_id().is_ok());
+}


### PR DESCRIPTION
### Description

`Descriptor::descriptor_id` panics for parseable descriptors that cannot be derived
at a concrete index: multipath descriptors, and descriptors retaining hardened
public key derivations or hardened wildcards. It now returns
`DescriptorError::MultiPath` or `DescriptorError::HardenedDerivationXpub` instead.

The signature becomes `Result<Arc<DescriptorId>, DescriptorError>`, which is a
breaking change for Kotlin and Swift callers.

Fixes #1094.

### Notes to the reviewers

- **Scoped to `descriptor_id`.** `derive_address` has the same hardened-derivation
  problem, but that's already covered by #1079, so I've left it untouched.

- **The check has to run before `at_derivation_index`, not via `map_err` on its
  result.** For the hardened cases miniscript panics inside
  `DescriptorPublicKey::at_derivation_index` rather than returning
  `ConversionError`, so there's no `Err` to map. Only multipath returns cleanly.

- **The guard is still required once a fixed Miniscript release is pinned, since
`bdk_chain::DescriptorExt::descriptor_id` unwraps `at_derivation_index(0)`.**
Multipath already shows this: miniscript returns `Err` cleanly and the unwrap
panics regardless.

### Documentation

- [x] [`bdk_wallet`](https://docs.rs/bdk_wallet/latest/bdk_wallet/) — `bdk_chain::DescriptorExt::descriptor_id`, re-exported as `bdk_wallet::chain::DescriptorExt`
- [x] Other: [`rust-miniscript`](https://docs.rs/miniscript/12.3.7/miniscript/) — `DescriptorPublicKey::at_derivation_index`

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
* [x] I've linked the relevant upstream docs or specs above

#### Bugfixes:

* [x] This pull request breaks the existing API
* [x] I've added tests to reproduce the issue which are now passing
* [x] I'm linking the issue being fixed by this PR
