### PR TITLE
fix: Add DescriptorKeyParseError for as_public

### DIFF
--- a/bdk-ffi/src/keys.rs
+++ b/bdk-ffi/src/keys.rs
@@ -256,11 +256,32 @@ impl DescriptorSecretKey {
         }
     }
 
-    /// Return the descriptor public key corresponding to this secret.
-    pub fn as_public(&self) -> Arc<DescriptorPublicKey> {
+    /// Returns the public version of this key.
+    ///
+    /// If the key is an "XPrv", the hardened derivation steps will be applied
+    /// before converting it to a public key.
+    ///
+    /// It will return an error if the key is a "multi-xpriv", as we wouldn't
+    /// always be able to apply hardened derivation steps if there are multiple
+    /// paths.
+    pub fn as_public(&self) -> Result<Arc<DescriptorPublicKey>, DescriptorKeyError> {
         let secp = Secp256k1::new();
-        let descriptor_public_key = self.0.to_public(&secp).unwrap();
-        Arc::new(DescriptorPublicKey(descriptor_public_key))
+        let descriptor_public_key = self.0.to_public(&secp).map_err(DescriptorKeyError::from)?;
+        Ok(Arc::new(DescriptorPublicKey(descriptor_public_key)))
+    }
+
+    /// Get as many keys as derivation paths in this key.
+    ///
+    /// For raw keys and single-path extended keys it will return the key itself.
+    /// For multipath extended keys it will return a single-path extended key per derivation
+    /// path.
+    pub fn to_single_keys(&self) -> Vec<Arc<Self>> {
+        self.0
+            .clone()
+            .into_single_keys()
+            .into_iter()
+            .map(|key| Arc::new(Self(key)))
+            .collect()
     }
 
     /// Return the bytes of this descriptor secret key.

--- a/bdk-ffi/src/tests/descriptor.rs
+++ b/bdk-ffi/src/tests/descriptor.rs
@@ -1,6 +1,6 @@
 use crate::bitcoin::{Network, NetworkKind};
 use crate::descriptor::Descriptor;
-use crate::error::DescriptorError;
+use crate::error::{DescriptorError, DescriptorKeyError};
 use crate::keys::{DerivationPath, DescriptorSecretKey, Mnemonic};
 use crate::types::KeychainKind;
 
@@ -18,22 +18,26 @@ fn test_descriptor_templates() {
     let handmade_public_44 = master
         .derive(&DerivationPath::new("m/44h/1h/0h".to_string()).unwrap())
         .unwrap()
-        .as_public();
+        .as_public()
+        .unwrap();
     // Public 44: [d1d04177/44'/1'/0']tpubDCoPjomfTqh1e7o1WgGpQtARWtkueXQAepTeNpWiitS3Sdv8RKJ1yvTrGHcwjDXp2SKyMrTEca4LoN7gEUiGCWboyWe2rz99Kf4jK4m2Zmx/*
     let handmade_public_49 = master
         .derive(&DerivationPath::new("m/49h/1h/0h".to_string()).unwrap())
         .unwrap()
-        .as_public();
+        .as_public()
+        .unwrap();
     // Public 49: [d1d04177/49'/1'/0']tpubDC65ZRvk1NDddHrVAUAZrUPJ772QXzooNYmPywYF9tMyNLYKf5wpKE7ZJvK9kvfG3FV7rCsHBNXy1LVKW95jrmC7c7z4hq7a27aD2sRrAhR/*
     let handmade_public_84 = master
         .derive(&DerivationPath::new("m/84h/1h/0h".to_string()).unwrap())
         .unwrap()
-        .as_public();
+        .as_public()
+        .unwrap();
     // Public 84: [d1d04177/84'/1'/0']tpubDDNxbq17egjFk2edjv8oLnzxk52zny9aAYNv9CMqTzA4mQDiQq818sEkNe9Gzmd4QU8558zftqbfoVBDQorG3E4Wq26tB2JeE4KUoahLkx6/*
     let handmade_public_86 = master
         .derive(&DerivationPath::new("m/86h/1h/0h".to_string()).unwrap())
         .unwrap()
-        .as_public();
+        .as_public()
+        .unwrap();
     // Public 86: [d1d04177/86'/1'/0']tpubDCJzjbcGbdEfXMWaL6QmgVmuSfXkrue7m2YNoacWwyc7a2XjXaKojRqNEbo41CFL3PyYmKdhwg2fkGpLX4SQCbQjCGxAkWHJTw9WEeenrJb/*
     let template_private_44 =
         Descriptor::new_bip44(&master, KeychainKind::External, NetworkKind::Test);
@@ -122,7 +126,8 @@ fn test_new_bip84_public_invalid_fingerprint() {
     let public_84 = master
         .derive(&DerivationPath::new("m/84h/1h/0h".to_string()).unwrap())
         .unwrap()
-        .as_public();
+        .as_public()
+        .unwrap();
 
     let error = Descriptor::new_bip84_public(
         &public_84,
@@ -183,4 +188,46 @@ fn test_descriptor_derive_address_multipath_error() {
     let error = descriptor.derive_address(0, Network::Testnet).unwrap_err();
 
     assert_matches!(error, DescriptorError::MultiPath);
+}
+
+/// Build a BIP-389 multipath xpriv (e.g. `tprv.../<0;1>/*`)
+fn generate_multipath_xpriv() -> String {
+    // A valid BIP-32 tprv.
+    let xprv_str = "tprv8ZgxMBicQKsPdWuqM1t1CDRvQtQuBPyfL6GbhQwtxDKgUAVPbxmj71pRA8raTqLrec5LyTs5TqCxdABcZr77bt2KyWA5bizJHnC4g4ysm4h";
+
+    // Construct the secret key from the plain xprv.
+    let secret_key = DescriptorSecretKey::from_string(xprv_str.to_string()).expect("valid xprv");
+
+    // Append a BIP-389 multipath component `<0;1>` and a wildcard. The multipath component
+    // must be separated from the key by a `/`, i.e. `tprv.../<0;1>/*`.
+    format!("{}/<0;1>/*", secret_key)
+}
+
+#[test]
+fn test_descriptor_secret_key_from_string() {
+    let multipath_xpriv = generate_multipath_xpriv();
+    println!("multipath xpriv: {}", multipath_xpriv);
+
+    let key = DescriptorSecretKey::from_string(multipath_xpriv.clone())
+        .expect("multipath secret key parses");
+    assert_eq!(key.to_string(), multipath_xpriv);
+}
+
+#[test]
+fn test_multipath_xpriv_as_public() {
+    // Converting a multipath xpriv directly to a public key is not supported and returns an error
+    let multipath_xpriv = generate_multipath_xpriv();
+    let key =
+        DescriptorSecretKey::from_string(multipath_xpriv).expect("multipath secret key parses");
+
+    assert_matches!(key.as_public(), Err(DescriptorKeyError::Parse { .. }));
+
+    // Splitting into single-path keys first lets each one be converted to a public key.
+    let single_keys = key.to_single_keys();
+    assert_eq!(single_keys.len(), 2);
+    for single_key in single_keys {
+        single_key
+            .as_public()
+            .expect("single-path key converts to public");
+    }
 }

--- a/bdk-ffi/src/tests/keys.rs
+++ b/bdk-ffi/src/tests/keys.rs
@@ -46,7 +46,7 @@ fn extend_dpk(
 fn test_generate_descriptor_secret_key() {
     let master_dsk = get_inner();
     assert_eq!(master_dsk.to_string(), "tprv8ZgxMBicQKsPdWuqM1t1CDRvQtQuBPyfL6GbhQwtxDKgUAVPbxmj71pRA8raTqLrec5LyTs5TqCxdABcZr77bt2KyWA5bizJHnC4g4ysm4h");
-    assert_eq!(master_dsk.as_public().to_string(), "tpubD6NzVbkrYhZ4WywdEfYbbd62yuvqLjAZuPsNyvzCNV85JekAEMbKHWSHLF9h3j45SxewXDcLv328B1SEZrxg4iwGfmdt1pDFjZiTkGiFqGa");
+    assert_eq!(master_dsk.as_public().unwrap().to_string(), "tpubD6NzVbkrYhZ4WywdEfYbbd62yuvqLjAZuPsNyvzCNV85JekAEMbKHWSHLF9h3j45SxewXDcLv328B1SEZrxg4iwGfmdt1pDFjZiTkGiFqGa");
 }
 
 #[test]
@@ -54,7 +54,7 @@ fn test_derive_self() {
     let master_dsk = get_inner();
     let derived_dsk: &DescriptorSecretKey = &derive_dsk(&master_dsk, "m").unwrap();
     assert_eq!(derived_dsk.to_string(), "[d1d04177]tprv8ZgxMBicQKsPdWuqM1t1CDRvQtQuBPyfL6GbhQwtxDKgUAVPbxmj71pRA8raTqLrec5LyTs5TqCxdABcZr77bt2KyWA5bizJHnC4g4ysm4h");
-    let master_dpk: &DescriptorPublicKey = &master_dsk.as_public();
+    let master_dpk: &DescriptorPublicKey = &master_dsk.as_public().unwrap();
     let derived_dpk: &DescriptorPublicKey = &derive_dpk(master_dpk, "m").unwrap();
     assert_eq!(derived_dpk.to_string(), "[d1d04177]tpubD6NzVbkrYhZ4WywdEfYbbd62yuvqLjAZuPsNyvzCNV85JekAEMbKHWSHLF9h3j45SxewXDcLv328B1SEZrxg4iwGfmdt1pDFjZiTkGiFqGa");
 }
@@ -64,7 +64,7 @@ fn test_derive_descriptors_keys() {
     let master_dsk = get_inner();
     let derived_dsk: &DescriptorSecretKey = &derive_dsk(&master_dsk, "m/0").unwrap();
     assert_eq!(derived_dsk.to_string(), "[d1d04177/0]tprv8d7Y4JLmD25jkKbyDZXcdoPHu1YtMHuH21qeN7mFpjfumtSU7eZimFYUCSa3MYzkEYfSNRBV34GEr2QXwZCMYRZ7M1g6PUtiLhbJhBZEGYJ");
-    let master_dpk: &DescriptorPublicKey = &master_dsk.as_public();
+    let master_dpk: &DescriptorPublicKey = &master_dsk.as_public().unwrap();
     let derived_dpk: &DescriptorPublicKey = &derive_dpk(master_dpk, "m/0").unwrap();
     assert_eq!(derived_dpk.to_string(), "[d1d04177/0]tpubD9oaCiP1MPmQdndm7DCD3D3QU34pWd6BbKSRedoZF1UJcNhEk3PJwkALNYkhxeTKL29oGNR7psqvT1KZydCGqUDEKXN6dVQJY2R8ooLPy8m");
 }
@@ -74,7 +74,7 @@ fn test_extend_descriptor_keys() {
     let master_dsk = get_inner();
     let extended_dsk: &DescriptorSecretKey = &extend_dsk(&master_dsk, "m/0").unwrap();
     assert_eq!(extended_dsk.to_string(), "tprv8ZgxMBicQKsPdWuqM1t1CDRvQtQuBPyfL6GbhQwtxDKgUAVPbxmj71pRA8raTqLrec5LyTs5TqCxdABcZr77bt2KyWA5bizJHnC4g4ysm4h/0");
-    let master_dpk: &DescriptorPublicKey = &master_dsk.as_public();
+    let master_dpk: &DescriptorPublicKey = &master_dsk.as_public().unwrap();
     let extended_dpk: &DescriptorPublicKey = &extend_dpk(master_dpk, "m/0").unwrap();
     assert_eq!(extended_dpk.to_string(), "tpubD6NzVbkrYhZ4WywdEfYbbd62yuvqLjAZuPsNyvzCNV85JekAEMbKHWSHLF9h3j45SxewXDcLv328B1SEZrxg4iwGfmdt1pDFjZiTkGiFqGa/0");
     let wif = "L2wTu6hQrnDMiFNWA5na6jB12ErGQqtXwqpSL7aWquJaZG8Ai3ch";
@@ -124,7 +124,7 @@ fn test_derive_and_extend_inner() {
 
 #[test]
 fn test_derive_hardened_path_using_public() {
-    let master_dpk = get_inner().as_public();
+    let master_dpk = get_inner().as_public().unwrap();
     let derived_dpk = &derive_dpk(&master_dpk, "m/84h/1h/0h");
     assert!(derived_dpk.is_err());
 }
@@ -198,7 +198,7 @@ fn test_add_wildcard() {
     ));
 
     // DescriptorPublicKey: add_wildcard() always adds an unhardened wildcard
-    let dpk = extended_key.as_public();
+    let dpk = extended_key.as_public().unwrap();
     let dpk_with_wildcard = dpk.add_wildcard().unwrap();
     assert_eq!(dpk_with_wildcard.to_string(), "[5bc5d243/84/2']tpubDAFG7XHSgRo927vaVKhcJAjuYW6AXJPunmS8So9ipV1xUyAUzEoBoiS5xSgPNBmjPMSnSXKjsJnTHWieJzUVxz8TUdWm8BUqgy4wL9yz5hp/1/*");
 
@@ -209,7 +209,7 @@ fn test_add_wildcard() {
     );
 
     // Calling add_wildcard on a DPK converted from a DSK with a hardened wildcard returns an error
-    let dpk_hardened = dsk_hardened.as_public();
+    let dpk_hardened = dsk_hardened.as_public().unwrap();
     assert!(matches!(
         dpk_hardened.add_wildcard(),
         Err(DescriptorKeyError::CannotChangeWildcardType)

--- a/bdk-swift/Tests/BitcoinDevKitTests/DescriptorTests.swift
+++ b/bdk-swift/Tests/BitcoinDevKitTests/DescriptorTests.swift
@@ -55,7 +55,7 @@ final class DescriptorTests: XCTestCase {
         let mnemonic = try Mnemonic.fromString(mnemonic: "awesome awesome awesome awesome awesome awesome awesome awesome awesome awesome awesome awesome")
         let secretKey = DescriptorSecretKey(networkKind: NetworkKind.test, mnemonic: mnemonic, password: nil)
         let derived = try secretKey.derive(path: DerivationPath(path: "m/86'/1'/0'"))
-        let publicKey = derived.asPublic()
+        let publicKey = try derived.asPublic()
         let withWildcard = try publicKey.addWildcard()
         XCTAssertTrue(withWildcard.description.hasSuffix("/*"))
     }


### PR DESCRIPTION
<!-- Erase any parts of this template not applicable to your Pull Request. -->

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->
Addresses #1093 

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->
- Error is expected for multipath in [rust-miniscript](https://github.com/rust-bitcoin/rust-miniscript/blob/d2ec50453612c8888df0266f871c27011b1c8ecc/src/descriptor/key.rs#L629). Now I return error rather than panic.
- Also, it seems later version of mini-script now handles for multipath [here](https://github.com/rust-bitcoin/rust-miniscript/blob/d2ec50453612c8888df0266f871c27011b1c8ecc/src/descriptor/key.rs#L325) (master)


### Documentation

<!-- Paste the canonical docs/spec for anything this PR wraps or updates. -->

- [ ] [`bdk_wallet`](https://docs.rs/bdk_wallet/latest/bdk_wallet/)
  <!-- Add a link below with the docs.rs page. -->
- [x] [`bitcoin`](https://docs.rs/bitcoin/latest/bitcoin/index.html)
  <!-- Add a link below with the docs.rs page. -->
- [ ] [`uniffi`](https://github.com/mozilla/uniffi-rs) <!-- Add a link below with the version changelog or any other docs. -->
- [ ] Other: <!-- Add a link below with additional references -->

### Changelog

<!-- Add exactly one changelog label to this PR:
`changelog: added`, `changelog: changed`, `changelog: fixed`, `changelog: breaking`, or `changelog: none`.
These labels map to the Keep a Changelog categories used by `CHANGELOG.md` where possible.
GitHub generated release notes use the label plus the PR title to draft the changelog.
-->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
* [ ] I've added exactly one `changelog:*` label
* [x] I've linked the relevant upstream docs or specs above

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [x] This pull request breaks the existing API
* [x] I've added tests to reproduce the issue which are now passing
* [x] I'm linking the issue being fixed by this PR
