### PR TITLE
Bump bdk_kyoto to 0.17.1

### DIFF
--- a/bdk-ffi/Cargo.lock
+++ b/bdk-ffi/Cargo.lock
@@ -198,9 +198,9 @@ dependencies = [
 
 [[package]]
 name = "bdk_kyoto"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "346c1d502ee4613cf2201db9c3b93a2317772d8eaa372114f34bf5f374be94fd"
+checksum = "8af2d4c542f83e4d20afd49f61b2b5075b24f7d684deb1a3a7652b1fa4105ae8"
 dependencies = [
  "bdk_wallet",
  "bip157",

--- a/bdk-ffi/Cargo.toml
+++ b/bdk-ffi/Cargo.toml
@@ -18,7 +18,7 @@ path = "uniffi-bindgen.rs"
 bdk_wallet = { version = "=3.1.0", features = ["all-keys", "keys-bip39", "rusqlite"] }
 bdk_esplora = { version = "0.22.2", default-features = false, features = ["std", "blocking", "blocking-https-rustls"] }
 bdk_electrum = { version = "0.24.0", default-features = false, features = ["use-rustls-ring"] }
-bdk_kyoto = { version = "0.17.0" }
+bdk_kyoto = { version = "0.17.1" }
 
 uniffi = { version = "=0.31.2", features = ["cli"]}
 thiserror = "2.0.17"


### PR DESCRIPTION
This bumps bdk_kyoto to it's latest release, 0.17.1.

See #1090.