### PR TITLE
fix!: return errors from wallet address methods

### DIFF
--- a/bdk-ffi/src/error.rs
+++ b/bdk-ffi/src/error.rs
@@ -53,6 +53,16 @@ pub enum AddForeignUtxoError {
 
 #[derive(Debug, thiserror::Error, uniffi::Error)]
 #[uniffi::export(Debug, Display)]
+pub enum AddressError {
+    #[error("derivation index {index} is greater than the bip32 maximum index of 2147483647")]
+    IndexOutOfBounds { index: u32 },
+
+    #[error("bare descriptor address")]
+    BareDescriptorAddr,
+}
+
+#[derive(Debug, thiserror::Error, uniffi::Error)]
+#[uniffi::export(Debug, Display)]
 pub enum AddressParseError {
     #[error("base58 address encoding error")]
     Base58,

--- a/bdk-ffi/src/tests/error.rs
+++ b/bdk-ffi/src/tests/error.rs
@@ -1,7 +1,7 @@
 use crate::error::{
-    Bip32Error, Bip39Error, CannotConnectError, DescriptorError, DescriptorKeyError, ElectrumError,
-    EsploraError, ExtractTxError, PsbtError, PsbtParseError, RequestBuilderError, SignerError,
-    TransactionError, TxidParseError,
+    AddressError, Bip32Error, Bip39Error, CannotConnectError, DescriptorError, DescriptorKeyError,
+    ElectrumError, EsploraError, ExtractTxError, PsbtError, PsbtParseError, RequestBuilderError,
+    SignerError, TransactionError, TxidParseError,
 };
 
 #[test]
@@ -634,6 +634,21 @@ fn test_error_txid_parse() {
         },
         "invalid txid: 123abc",
     )];
+
+    for (error, expected_message) in cases {
+        assert_eq!(error.to_string(), expected_message);
+    }
+}
+
+#[test]
+fn test_error_address() {
+    let cases = vec![
+        (
+            AddressError::IndexOutOfBounds { index: 2147483648 },
+            "derivation index 2147483648 is greater than the bip32 maximum index of 2147483647",
+        ),
+        (AddressError::BareDescriptorAddr, "bare descriptor address"),
+    ];
 
     for (error, expected_message) in cases {
         assert_eq!(error.to_string(), expected_message);

--- a/bdk-ffi/src/tests/tx_builder.rs
+++ b/bdk-ffi/src/tests/tx_builder.rs
@@ -28,6 +28,7 @@ fn test_policy_path() {
     let wallet = create_and_sync_wallet();
     let address = wallet
         .next_unused_address(bdk_wallet::KeychainKind::External)
+        .unwrap()
         .address;
     println!("Wallet address: {:?}", address);
 
@@ -115,6 +116,7 @@ fn test_only_witness_utxo_with_finish() {
         // At minimum, verify the builder methods don't panic
         let address = wallet
             .next_unused_address(bdk_wallet::KeychainKind::External)
+            .unwrap()
             .address;
         let _builder = TxBuilder::new()
             .add_recipient(
@@ -129,6 +131,7 @@ fn test_only_witness_utxo_with_finish() {
 
     let address = wallet
         .next_unused_address(bdk_wallet::KeychainKind::External)
+        .unwrap()
         .address;
 
     // Get policy paths for the multisig wallet
@@ -223,6 +226,7 @@ fn test_sighash_sets_psbt_input_sighash_type() {
 
     let address = wallet
         .next_unused_address(bdk_wallet::KeychainKind::External)
+        .unwrap()
         .address;
     let ext_policy = wallet.policies(bdk_wallet::KeychainKind::External);
     let int_policy = wallet.policies(bdk_wallet::KeychainKind::Internal);
@@ -399,6 +403,7 @@ fn test_add_foreign_utxo_with_witness_utxo_succeeds() {
     let wallet = create_and_sync_wallet();
     let address = wallet
         .next_unused_address(bdk_wallet::KeychainKind::External)
+        .unwrap()
         .address;
 
     let outpoint = OutPoint {
@@ -478,6 +483,7 @@ fn test_add_multiple_foreign_utxos_and_finish() {
     let wallet = create_and_sync_wallet();
     let address = wallet
         .next_unused_address(bdk_wallet::KeychainKind::External)
+        .unwrap()
         .address;
 
     // Create first foreign UTXO
@@ -601,6 +607,7 @@ fn test_combined_only_witness_utxo_and_foreign_utxo_with_finish() {
     let wallet = create_and_sync_wallet();
     let address = wallet
         .next_unused_address(bdk_wallet::KeychainKind::External)
+        .unwrap()
         .address;
 
     let outpoint = OutPoint {

--- a/bdk-ffi/src/tests/wallet.rs
+++ b/bdk-ffi/src/tests/wallet.rs
@@ -1,11 +1,12 @@
 use crate::bitcoin::{Amount, BlockHash, FeeRate, Network, NetworkKind};
 use crate::descriptor::Descriptor;
-use crate::error::{CreateTxError, LoadWithPersistError};
+use crate::error::{AddressError, CreateTxError, LoadWithPersistError};
 use crate::signer::SignersContainer;
 use crate::store::Persister;
 use crate::tx_builder::{BumpFeeTxBuilder, TxBuilder};
 use crate::types::{UnconfirmedTx, Update};
 use crate::wallet::{CreateParams, LoadParams, Wallet};
+use assert_matches::assert_matches;
 
 use bdk_wallet::bitcoin::Amount as BdkAmount;
 use bdk_wallet::bitcoin::Transaction as BdkTransaction;
@@ -15,6 +16,10 @@ use bdk_wallet::KeychainKind;
 use std::sync::Arc;
 
 const EXTERNAL_DESCRIPTOR: &str = "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/1h/0/*)";
+const BARE_EXTERNAL_DESCRIPTOR: &str = "pk(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/1h/0/*)";
+const BARE_INTERNAL_DESCRIPTOR: &str = "pk(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/1h/1/*)";
+const NO_WILDCARD_EXTERNAL_DESCRIPTOR: &str = "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/1h/0/0)";
+const NO_WILDCARD_INTERNAL_DESCRIPTOR: &str = "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/1h/1/0)";
 const INTERNAL_DESCRIPTOR: &str = "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/1h/1/*)";
 const TWO_PATH_DESCRIPTOR: &str = "wpkh([9a6a2580/84'/1'/0']tpubDDnGNapGEY6AZAdQbfRJgMg9fvz8pUBrLwvyvUqEgcUfgzM6zc2eVK4vY9x9L5FJWdX8WumXuLEDV5zDZnTfbn87vLe9XceCFwTu9so9Kks/<0;1>/*)";
 const EXPECTED_FIRST_ADDRESS: &str = "tb1qhjys9wxlfykmte7ftryptx975uqgd6kcm6a7z4";
@@ -51,6 +56,17 @@ fn build_wallet() -> Wallet {
     .unwrap()
 }
 
+fn build_wallet_from(external: &str, internal: &str) -> Wallet {
+    Wallet::new(
+        Arc::new(Descriptor::new(external.to_string(), NetworkKind::Test).unwrap()),
+        Arc::new(Descriptor::new(internal.to_string(), NetworkKind::Test).unwrap()),
+        Network::Signet,
+        Arc::new(Persister::new_in_memory().unwrap()),
+        25,
+    )
+    .unwrap()
+}
+
 fn funded_wallet() -> Wallet {
     let wallet = Wallet::new(
         external_descriptor(),
@@ -61,7 +77,10 @@ fn funded_wallet() -> Wallet {
     )
     .unwrap();
 
-    let address = wallet.reveal_next_address(KeychainKind::External).address;
+    let address = wallet
+        .reveal_next_address(KeychainKind::External)
+        .unwrap()
+        .address;
     let funding_tx = BdkTransaction {
         version: transaction::Version::ONE,
         lock_time: absolute::LockTime::ZERO,
@@ -87,6 +106,7 @@ fn test_tx_builder_invalid_current_height_returns_error() {
     let wallet = Arc::new(funded_wallet());
     let recipient_script = wallet
         .next_unused_address(KeychainKind::External)
+        .unwrap()
         .address
         .script_pubkey();
 
@@ -106,6 +126,7 @@ fn test_bump_fee_tx_builder_invalid_current_height_returns_error() {
     let wallet = Arc::new(funded_wallet());
     let recipient_script = wallet
         .next_unused_address(KeychainKind::External)
+        .unwrap()
         .address
         .script_pubkey();
     let original_tx = TxBuilder::new()
@@ -263,11 +284,109 @@ fn test_keychains() {
 fn test_reveal_next_address() {
     let wallet = build_wallet();
 
-    let address_info = wallet.reveal_next_address(KeychainKind::External);
+    let address_info = wallet.reveal_next_address(KeychainKind::External).unwrap();
 
     assert_eq!(address_info.index, 0);
     assert_eq!(address_info.keychain, KeychainKind::External);
     assert_eq!(address_info.address.to_string(), EXPECTED_FIRST_ADDRESS);
+}
+
+#[test]
+fn test_peek_address() {
+    let wallet = build_wallet();
+
+    let address_info = wallet.peek_address(KeychainKind::External, 0).unwrap();
+
+    assert_eq!(address_info.index, 0);
+    assert_eq!(address_info.keychain, KeychainKind::External);
+    assert_eq!(address_info.address.to_string(), EXPECTED_FIRST_ADDRESS);
+}
+
+#[test]
+fn test_peek_address_at_max_index() {
+    let wallet = build_wallet();
+
+    let address_info = wallet
+        .peek_address(KeychainKind::External, 2147483647)
+        .unwrap();
+
+    assert_eq!(address_info.index, 2147483647);
+}
+
+#[test]
+fn test_peek_address_above_max_index_returns_error() {
+    let wallet = build_wallet();
+
+    assert_matches!(
+        wallet.peek_address(KeychainKind::External, 2147483648),
+        Err(AddressError::IndexOutOfBounds { index: 2147483648 })
+    );
+}
+
+#[test]
+fn test_peek_address_non_wildcard_descriptor_ignores_index() {
+    let wallet = build_wallet_from(
+        NO_WILDCARD_EXTERNAL_DESCRIPTOR,
+        NO_WILDCARD_INTERNAL_DESCRIPTOR,
+    );
+
+    let first = wallet.peek_address(KeychainKind::External, 0).unwrap();
+    let out_of_range = wallet
+        .peek_address(KeychainKind::External, u32::MAX)
+        .unwrap();
+
+    assert_eq!(out_of_range.index, 0);
+    assert_eq!(first.address.to_string(), out_of_range.address.to_string());
+}
+
+#[test]
+fn test_peek_address_bare_descriptor_returns_error() {
+    let wallet = build_wallet_from(BARE_EXTERNAL_DESCRIPTOR, BARE_INTERNAL_DESCRIPTOR);
+
+    assert_matches!(
+        wallet.peek_address(KeychainKind::External, 0),
+        Err(AddressError::BareDescriptorAddr)
+    );
+}
+
+#[test]
+fn test_reveal_next_address_bare_descriptor_returns_error() {
+    let wallet = build_wallet_from(BARE_EXTERNAL_DESCRIPTOR, BARE_INTERNAL_DESCRIPTOR);
+
+    assert_matches!(
+        wallet.reveal_next_address(KeychainKind::External),
+        Err(AddressError::BareDescriptorAddr)
+    );
+}
+
+#[test]
+fn test_next_unused_address_bare_descriptor_returns_error() {
+    let wallet = build_wallet_from(BARE_EXTERNAL_DESCRIPTOR, BARE_INTERNAL_DESCRIPTOR);
+
+    assert_matches!(
+        wallet.next_unused_address(KeychainKind::External),
+        Err(AddressError::BareDescriptorAddr)
+    );
+}
+
+#[test]
+fn test_reveal_addresses_to_bare_descriptor_returns_error() {
+    let wallet = build_wallet_from(BARE_EXTERNAL_DESCRIPTOR, BARE_INTERNAL_DESCRIPTOR);
+
+    assert_matches!(
+        wallet.reveal_addresses_to(KeychainKind::External, 3),
+        Err(AddressError::BareDescriptorAddr)
+    );
+}
+
+#[test]
+fn test_list_unused_addresses_bare_descriptor_returns_error() {
+    let wallet = build_wallet_from(BARE_EXTERNAL_DESCRIPTOR, BARE_INTERNAL_DESCRIPTOR);
+
+    assert_matches!(
+        wallet.list_unused_addresses(KeychainKind::External),
+        Err(AddressError::BareDescriptorAddr)
+    );
 }
 
 #[test]
@@ -293,6 +412,7 @@ fn test_sign_with_signers() {
     let wallet = Arc::new(funded_wallet());
     let recipient_script = wallet
         .next_unused_address(KeychainKind::External)
+        .unwrap()
         .address
         .script_pubkey();
     let psbt = TxBuilder::new()
@@ -328,7 +448,10 @@ fn test_sign_with_signers_for_public_wallet() {
         .unwrap(),
     );
 
-    let address = wallet.reveal_next_address(KeychainKind::External).address;
+    let address = wallet
+        .reveal_next_address(KeychainKind::External)
+        .unwrap()
+        .address;
     let funding_tx = BdkTransaction {
         version: transaction::Version::ONE,
         lock_time: absolute::LockTime::ZERO,
@@ -347,6 +470,7 @@ fn test_sign_with_signers_for_public_wallet() {
 
     let recipient_script = wallet
         .next_unused_address(KeychainKind::External)
+        .unwrap()
         .address
         .script_pubkey();
     let psbt = TxBuilder::new()
@@ -391,7 +515,7 @@ fn test_create_single_wallet() {
     assert!(keychains[0].public_descriptor.has_wildcard());
     assert!(!public_descriptor.contains("tprv"));
 
-    let address_info = wallet.reveal_next_address(KeychainKind::External);
+    let address_info = wallet.reveal_next_address(KeychainKind::External).unwrap();
 
     assert_eq!(address_info.index, 0);
     assert_eq!(address_info.keychain, KeychainKind::External);
@@ -413,8 +537,8 @@ fn test_create_two_path_wallet() {
     assert_eq!(wallet.derivation_index(KeychainKind::External), None);
     assert_eq!(wallet.derivation_index(KeychainKind::Internal), None);
 
-    let external_address = wallet.reveal_next_address(KeychainKind::External);
-    let internal_address = wallet.reveal_next_address(KeychainKind::Internal);
+    let external_address = wallet.reveal_next_address(KeychainKind::External).unwrap();
+    let internal_address = wallet.reveal_next_address(KeychainKind::Internal).unwrap();
 
     assert_eq!(external_address.index, 0);
     assert_eq!(external_address.keychain, KeychainKind::External);
@@ -439,8 +563,8 @@ fn test_load_from_two_path_descriptor() {
     )
     .unwrap();
 
-    wallet.reveal_next_address(KeychainKind::External);
-    wallet.reveal_next_address(KeychainKind::Internal);
+    wallet.reveal_next_address(KeychainKind::External).unwrap();
+    wallet.reveal_next_address(KeychainKind::Internal).unwrap();
     assert!(wallet.persist(Arc::clone(&persister)).unwrap());
 
     let loaded_wallet =

--- a/bdk-ffi/src/types.rs
+++ b/bdk-ffi/src/types.rs
@@ -189,7 +189,7 @@ pub struct ScriptAmount {
 }
 
 /// A derived address and the index it was found at.
-#[derive(uniffi::Record)]
+#[derive(Debug, uniffi::Record)]
 pub struct AddressInfo {
     /// Child index of this address
     pub index: u32,

--- a/bdk-ffi/src/wallet.rs
+++ b/bdk-ffi/src/wallet.rs
@@ -3,7 +3,7 @@ use crate::bitcoin::{
 };
 use crate::descriptor::Descriptor;
 use crate::error::{
-    CalculateFeeError, CannotConnectError, CreateWithPersistError, DescriptorError,
+    AddressError, CalculateFeeError, CannotConnectError, CreateWithPersistError, DescriptorError,
     LoadWithPersistError, PersistenceError, SignerError, TxidParseError,
 };
 use crate::signer::SignersContainer;
@@ -14,8 +14,11 @@ use crate::types::{
     SyncRequestBuilder, UnconfirmedTx, Update, WalletEvent, WalletKeychain,
 };
 
+use bdk_wallet::bitcoin::bip32::ChildNumber;
 use bdk_wallet::bitcoin::Network;
+use bdk_wallet::descriptor::ExtendedDescriptor;
 use bdk_wallet::keys::KeyMap;
+use bdk_wallet::miniscript::Descriptor as BdkDescriptor;
 #[allow(deprecated)]
 use bdk_wallet::signer::SignOptions as BdkSignOptions;
 use bdk_wallet::{
@@ -442,22 +445,40 @@ impl Wallet {
     ///
     /// This will increment the keychain's derivation index. If the keychain's descriptor doesn't
     /// contain a wildcard or every address is already revealed up to the maximum derivation
+    ///
+    /// Returns an error when the keychain's descriptor is a bare descriptor, which has
+    /// no address form.
+    ///
     /// index defined in [BIP32](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki),
     /// then the last revealed address will be returned.
-    pub fn reveal_next_address(&self, keychain: KeychainKind) -> AddressInfo {
-        self.get_wallet().reveal_next_address(keychain).into()
+    pub fn reveal_next_address(&self, keychain: KeychainKind) -> Result<AddressInfo, AddressError> {
+        let mut wallet = self.get_wallet();
+        check_address_form(wallet.public_descriptor(keychain))?;
+        Ok(wallet.reveal_next_address(keychain).into())
     }
 
     /// Peek an address of the given `keychain` at `index` without revealing it.
     ///
     /// For non-wildcard descriptors this returns the same address at every provided index.
     ///
-    /// # Panics
-    ///
-    /// This panics when the caller requests for an address of derivation index greater than the
-    /// [BIP32](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki) max index.
-    pub fn peek_address(&self, keychain: KeychainKind, index: u32) -> AddressInfo {
-        self.get_wallet().peek_address(keychain, index).into()
+    /// Returns an error when the `index` is greater than the
+    /// [BIP32](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki) maximum
+    /// derivation index, or when the keychain's descriptor is a bare descriptor, which has
+    /// no address form.
+    pub fn peek_address(
+        &self,
+        keychain: KeychainKind,
+        index: u32,
+    ) -> Result<AddressInfo, AddressError> {
+        let wallet = self.get_wallet();
+        let descriptor = wallet.public_descriptor(keychain);
+
+        if descriptor.has_wildcard() && ChildNumber::from_normal_idx(index).is_err() {
+            return Err(AddressError::IndexOutOfBounds { index });
+        }
+        check_address_form(descriptor)?;
+
+        Ok(wallet.peek_address(keychain, index).into())
     }
 
     /// The index of the next address that you would get if you were to ask the wallet for a new
@@ -472,10 +493,15 @@ impl Wallet {
     /// This will attempt to reveal a new address if all previously revealed addresses have
     /// been used, in which case the returned address will be the same as calling [`Wallet::reveal_next_address`].
     ///
+    /// Returns an error when the keychain's descriptor is a bare descriptor, which has
+    /// no address form.
+    ///
     /// **WARNING**: To avoid address reuse you must persist the changes resulting from one or more
     /// calls to this method before closing the wallet. See [`Wallet::reveal_next_address`].
-    pub fn next_unused_address(&self, keychain: KeychainKind) -> AddressInfo {
-        self.get_wallet().next_unused_address(keychain).into()
+    pub fn next_unused_address(&self, keychain: KeychainKind) -> Result<AddressInfo, AddressError> {
+        let mut wallet = self.get_wallet();
+        check_address_form(wallet.public_descriptor(keychain))?;
+        Ok(wallet.next_unused_address(keychain).into())
     }
 
     /// Marks an address used of the given `keychain` at `index`.
@@ -504,13 +530,22 @@ impl Wallet {
     /// possible index. If all addresses up to the given `index` are already revealed, then
     /// no new addresses are returned.
     ///
+    /// Returns an error when the keychain's descriptor is a bare descriptor, which has
+    /// no address form.
+    ///
     /// **WARNING**: To avoid address reuse you must persist the changes resulting from one or more
     /// calls to this method before closing the wallet. See [`Wallet::reveal_next_address`].
-    pub fn reveal_addresses_to(&self, keychain: KeychainKind, index: u32) -> Vec<AddressInfo> {
-        self.get_wallet()
+    pub fn reveal_addresses_to(
+        &self,
+        keychain: KeychainKind,
+        index: u32,
+    ) -> Result<Vec<AddressInfo>, AddressError> {
+        let mut wallet = self.get_wallet();
+        check_address_form(wallet.public_descriptor(keychain))?;
+        Ok(wallet
             .reveal_addresses_to(keychain, index)
             .map(|address_info| address_info.into())
-            .collect()
+            .collect())
     }
 
     /// List addresses that are revealed but unused.
@@ -518,11 +553,19 @@ impl Wallet {
     /// Note if the returned iterator is empty you can reveal more addresses
     /// by using [`reveal_next_address`](Self::reveal_next_address) or
     /// [`reveal_addresses_to`](Self::reveal_addresses_to).
-    pub fn list_unused_addresses(&self, keychain: KeychainKind) -> Vec<AddressInfo> {
-        self.get_wallet()
+    ///
+    /// Returns an error when the keychain's descriptor is a bare descriptor, which has
+    /// no address form.
+    pub fn list_unused_addresses(
+        &self,
+        keychain: KeychainKind,
+    ) -> Result<Vec<AddressInfo>, AddressError> {
+        let wallet = self.get_wallet();
+        check_address_form(wallet.public_descriptor(keychain))?;
+        Ok(wallet
             .list_unused_addresses(keychain)
             .map(|address_info| address_info.into())
-            .collect()
+            .collect())
     }
 
     /// Applies an update to the wallet and stages the changes (but does not persist them).
@@ -1000,4 +1043,15 @@ impl Wallet {
     pub(crate) fn get_wallet(&self) -> MutexGuard<'_, PersistedWallet<PersistenceType>> {
         self.inner_mutex.lock().expect("wallet")
     }
+}
+
+/// Checks that `descriptor` can produce an address.
+///
+/// Bare descriptors, e.g `pk(...)` and top-level and `multi(...)`, commit the spending
+/// condition directly to the output, and no address encoding exists for that shape.
+fn check_address_form(descriptor: &ExtendedDescriptor) -> Result<(), AddressError> {
+    if matches!(descriptor, BdkDescriptor::Bare(_)) {
+        return Err(AddressError::BareDescriptorAddr);
+    }
+    Ok(())
 }

--- a/bdk-swift/Tests/BitcoinDevKitTests/PersistenceTests.swift
+++ b/bdk-swift/Tests/BitcoinDevKitTests/PersistenceTests.swift
@@ -32,7 +32,7 @@ final class PersistenceTests: XCTestCase {
             changeDescriptor: changeDescriptor,
             persister: persister
         )
-        let nextAddress: AddressInfo = wallet.revealNextAddress(keychain: KeychainKind.external)
+        let nextAddress: AddressInfo = try wallet.revealNextAddress(keychain: KeychainKind.external)
         print("Address: \(nextAddress)")
 
         XCTAssertTrue(nextAddress.address.description == "tb1qan3lldunh37ma6c0afeywgjyjgnyc8uz975zl2")
@@ -56,7 +56,7 @@ final class PersistenceTests: XCTestCase {
             changeDescriptor: changeDescriptorPub,
             persister: persister
         )
-        let nextAddress: AddressInfo = wallet.revealNextAddress(keychain: KeychainKind.external)
+        let nextAddress: AddressInfo = try wallet.revealNextAddress(keychain: KeychainKind.external)
         print("Address: \(nextAddress)")
 
         XCTAssertEqual(nextAddress.index, 7)

--- a/bdk-swift/Tests/BitcoinDevKitTests/WalletTests.swift
+++ b/bdk-swift/Tests/BitcoinDevKitTests/WalletTests.swift
@@ -19,7 +19,7 @@ final class WalletTests: XCTestCase {
             network: .signet,
             persister: persister
         )
-        let addressInfo: AddressInfo = wallet.revealNextAddress(keychain: KeychainKind.external)
+        let addressInfo: AddressInfo = try wallet.revealNextAddress(keychain: KeychainKind.external)
 
         XCTAssertTrue(addressInfo.address.isValidForNetwork(network: Network.testnet),
                      "Address is not valid for testnet network")


### PR DESCRIPTION
### Description

Fixes #1105

`Wallet::peek_address` reached two upstream `expect` calls in bdk_wallet that panic: derivation
indexes in the BIP32 hardened range, and descriptors with no address form, i.e.
bare descriptors such as `pk(...)` and top-level `multi(...)`.

Per the discussion on the issue, the same `must have address form` panic is
reachable from `reveal_next_address`, `next_unused_address`, `reveal_addresses_to`
and `list_unused_addresses`, so all five address methods now return
`Result<_, AddressError>`.

The guard runs before delegating to `bdk_wallet`, which panics rather than
returning an error, so there is nothing to `map_err`. It also means the three
mutating methods no longer stage a derivation index change before failing.

### Notes to the reviewers

`AddressError` is shared across all five, though only `peek_address` can return
`IndexOutOfBounds`. 

`list_unused_addresses` is a behaviour change rather than a panic fix: it
previously returned an empty list on a bare descriptor wallet, because nothing
can be revealed on one. It now returns an error, for consistency with the other
four.

Swift needs `try` at three call sites. Kotlin and Python are source-compatible.


### Changelog

`changelog: breaking`

### Documentation

- [x] [`bdk_wallet`](https://docs.rs/bdk_wallet/3.1.0/bdk_wallet/struct.Wallet.html#method.peek_address)

### Checklists

#### All Submissions:
* [x] I've signed all my commits
* [x] I followed the contribution guidelines
* [x] I ran `cargo fmt` and `cargo clippy` before committing
* [x] I've added exactly one `changelog:*` label
* [x] I've linked the relevant upstream docs or specs above

#### Bugfixes:
* [x] This pull request breaks the existing API
* [x] I've added tests to reproduce the issue which are now passing
* [x] I'm linking the issue being fixed by this PR