### PR TITLE
feat: build bdk-ffi for wasm32-unknown-unknown

### DIFF
--- a/.github/workflows/rust-ci.yaml
+++ b/.github/workflows/rust-ci.yaml
@@ -47,6 +47,39 @@ jobs:
       - name: "Test"
         run: CLASSPATH=./tests/jna/jna-5.14.0.jar cargo test --features uniffi/bindgen-tests
 
+  wasm:
+    name: "Check wasm32"
+    runs-on: ubuntu-24.04
+    defaults:
+      run:
+        working-directory: bdk-ffi
+    env:
+      # secp256k1-sys needs a C compiler with a wasm32 backend
+      CC_wasm32_unknown_unknown: clang
+      AR_wasm32_unknown_unknown: llvm-ar
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache: false
+          components: clippy
+
+      - name: "Install LLVM"
+        run: sudo apt-get install -y llvm
+
+      - name: "Add wasm32 target"
+        run: rustup target add wasm32-unknown-unknown
+
+      - name: "Check wasm32-unknown-unknown"
+        run: cargo check --locked --target wasm32-unknown-unknown
+
+      - name: "Check clippy on wasm32"
+        run: cargo clippy --locked --target wasm32-unknown-unknown
+
   check:
     name: "Run clippy and fmt"
     needs: test

--- a/bdk-ffi/Cargo.lock
+++ b/bdk-ffi/Cargo.lock
@@ -81,6 +81,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
+name = "async-trait"
+version = "0.1.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
+]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -148,8 +165,13 @@ dependencies = [
  "bdk_esplora",
  "bdk_kyoto",
  "bdk_wallet",
+ "futures-channel",
+ "getrandom 0.2.17",
+ "js-sys",
  "thiserror",
  "uniffi",
+ "uniffi-runtime-wasm",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -192,8 +214,10 @@ version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83986307ea92997c3d051e8c306af8115a05add601e22acb7c1903008e6b614e"
 dependencies = [
+ "async-trait",
  "bdk_core",
  "esplora-client",
+ "futures",
 ]
 
 [[package]]
@@ -396,6 +420,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -512,6 +542,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "displaydoc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
+]
+
+[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -560,8 +617,10 @@ dependencies = [
  "hex-conservative 0.2.3",
  "log",
  "minreq",
+ "reqwest",
  "serde",
  "serde_json",
+ "tokio",
 ]
 
 [[package]]
@@ -589,6 +648,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
 name = "fs-err"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -604,14 +687,104 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
+name = "futures"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a31d2a3fbaaeb2af2368bbdd904aa8e812d3c04a1ee10d3171f52d556e5d0a3"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f9e3d69d39e4862ffed03ed071a76f9a13ba1d9109d355b0f0aa6b15e393c4"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "031b47cf1a3c6cc8bc2fc76cd437f521619387907d469316e7c0bc278f1f5432"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1944426bf7d03f1d14f708785e4b33efd750b36d48a157b836b3efc15ede8e1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
+
+[[package]]
+name = "futures-util"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -707,6 +880,208 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3011d1213f159867b13cfd6ac92d2cd5f1345762c63be3554e84092d85a50bbd"
 
 [[package]]
+name = "http"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23169fe34a5fbcdd3f3862e78fb9b6fccd5f02a6dc6f732547005d45631ce71c"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hyper"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b501faa50e7a26c3d3560ca625132f4078a17771f4810baf70475ae48cbe43"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa68d21081c4a05d5a901a1c62add574c77048b6a1c67be3b50ce0b60d4ca513"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56e28588da92eee5c3201a6eff33fabdd49b62269c8938d4ff050ce4d900deb"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f9cf5f235641ed274641dd81c3f28d870e276763d0797aeeab72317b1c646f"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1563da1ed3e0b3bf3d74c9b85917ac9c56464d2f57242270c09c9e752f8021a0"
+
+[[package]]
+name = "icu_properties"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e7ca276ad3145661a65914e6daf131ca5120cd3dcee8f8f3214b8875184a148"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
+
+[[package]]
+name = "icu_provider"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d27bbb9d3abbefac45d55f647c9de1d44aafcd1186eb91879afef17c396c3e73"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -717,6 +1092,12 @@ dependencies = [
  "serde",
  "serde_core",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "791930b43c0d5973160d90a8f3894509f2b273430f5c5c73b668636d0287c5c0"
 
 [[package]]
 name = "itoa"
@@ -732,6 +1113,17 @@ checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
 dependencies = [
  "getrandom 0.4.3",
  "libc",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.105"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce57d20d1ea864ce2ac172ab472d409214f4fd359f0b2a2775abdf522e2af99e"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -756,6 +1148,12 @@ name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litemap"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
 
 [[package]]
 name = "log"
@@ -812,6 +1210,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -826,6 +1241,49 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "openssl"
+version = "0.10.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -850,6 +1308,15 @@ name = "plain"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d83eb9bc6d8e5cf568e7a1101d60ee05e81ed50ea106026f3d18deeb046d7661"
+dependencies = [
+ "zerovec",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -912,6 +1379,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-tls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "native-tls",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-native-tls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]
@@ -1021,6 +1524,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scroll"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1069,6 +1593,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4387882333d3aa8cb20530a17c69a3752e97837832f34f6dccc760e715001d9"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -1134,6 +1681,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1144,6 +1703,12 @@ name = "siphasher"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
@@ -1166,6 +1731,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "static_assertions"
@@ -1205,6 +1776,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1250,6 +1841,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1e27c91459209c2986af3dcf603a5a74a4368754ce37414f59acc971167f643"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1288,6 +1889,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 3.0.4",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]
@@ -1330,6 +1941,76 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "url",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1360,6 +2041,12 @@ dependencies = [
  "uniffi_macros",
  "uniffi_pipeline",
 ]
+
+[[package]]
+name = "uniffi-runtime-wasm"
+version = "0.31.0-5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb05d9a7313e50a448bbf2e28804c3acf477c379f25199476a7fff231b67f2f1"
 
 [[package]]
 name = "uniffi_bindgen"
@@ -1498,6 +2185,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1510,10 +2215,84 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.128"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aecb87a33d3b0c5e3b7aa46336eaf486cffafbd281b195e4c8b80d50df2351bf"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ef4c5d3d2cdf5c54f4231181768f5510842e350db025faf1f7163b1030ed928"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.128"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a690d511e3c1a8b3a55e33511e3c2c00c78415cd23650f32b808627f5696b9ed"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.128"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "411e4887f0071ef2d2164a9d5fdf2d20efbef78fccd3a78b0c10a1dc5295e48a"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.128"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81941cd78d0c92026c33e5e01312845a4cb1e9af3407f9134b100dd03144103e"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.105"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fbddc4a036f00ec4f18c83445bd3115cb306a91da554919a099d9222fe4a7f8"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "webpki-roots"
@@ -1656,6 +2435,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 
 [[package]]
+name = "writeable"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
+
+[[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "synstructure",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1676,10 +2484,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "synstructure",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ea269c3bd32f0a32c321907a2ae912ba6f4649bb0fc764a15627e99a7095a3f"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0464e17806c1d976d5cba29399c7f08e516e279e2ba493f63123b5fca67dd8"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
+]
 
 [[package]]
 name = "zmij"

--- a/bdk-ffi/Cargo.toml
+++ b/bdk-ffi/Cargo.toml
@@ -4,6 +4,7 @@ version = "3.2.0-alpha.0"
 homepage = "https://bitcoindevkit.org"
 repository = "https://github.com/bitcoindevkit/bdk"
 edition = "2018"
+resolver = "2"
 license = "MIT OR Apache-2.0"
 
 [lib]
@@ -15,13 +16,25 @@ name = "uniffi-bindgen"
 path = "uniffi-bindgen.rs"
 
 [dependencies]
-bdk_wallet = { version = "=3.1.0", features = ["all-keys", "keys-bip39", "rusqlite"] }
+bdk_wallet = { version = "=3.1.0", features = ["all-keys", "keys-bip39"] }
+
+uniffi = { version = "=0.31.2", features = ["cli"]}
+thiserror = "2.0.17"
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+bdk_wallet = { version = "=3.1.0", features = ["rusqlite"] }
 bdk_esplora = { version = "0.22.2", default-features = false, features = ["std", "blocking", "blocking-https-rustls"] }
 bdk_electrum = { version = "0.24.0", default-features = false, features = ["use-rustls-ring"] }
 bdk_kyoto = { version = "0.17.1" }
 
-uniffi = { version = "=0.31.2", features = ["cli"]}
-thiserror = "2.0.17"
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+bdk_esplora = { version = "0.22.2", default-features = false, features = ["std", "async-https"] }
+getrandom = { version = "0.2", features = ["js"] }
+uniffi = { version = "=0.31.2", features = ["cli", "wasm-unstable-single-threaded"] }
+uniffi-runtime-wasm = "0.31.0-5"
+futures-channel = "0.3"
+js-sys = "0.3"
+wasm-bindgen = "0.2"
 
 [build-dependencies]
 uniffi = { version = "=0.31.2", features = ["build"] }

--- a/bdk-ffi/src/error.rs
+++ b/bdk-ffi/src/error.rs
@@ -1,5 +1,6 @@
 use crate::OutPoint;
 
+#[cfg(not(target_arch = "wasm32"))]
 use bdk_electrum::electrum_client::Error as BdkElectrumError;
 use bdk_esplora::esplora_client::Error as BdkEsploraError;
 use bdk_wallet::bitcoin::address::ParseError as BdkParseError;
@@ -13,21 +14,25 @@ use bdk_wallet::bitcoin::psbt::Error as BdkPsbtError;
 use bdk_wallet::bitcoin::psbt::ExtractTxError as BdkExtractTxError;
 use bdk_wallet::bitcoin::psbt::PsbtParseError as BdkPsbtParseError;
 use bdk_wallet::bitcoin::script::PushBytesError;
+#[cfg(not(target_arch = "wasm32"))]
+use bdk_wallet::chain;
 use bdk_wallet::chain::local_chain::CannotConnectError as BdkCannotConnectError;
+#[cfg(not(target_arch = "wasm32"))]
 use bdk_wallet::chain::rusqlite::Error as BdkSqliteError;
 use bdk_wallet::chain::tx_graph::CalculateFeeError as BdkCalculateFeeError;
 use bdk_wallet::descriptor::DescriptorError as BdkDescriptorError;
 use bdk_wallet::error::BuildFeeBumpError;
 use bdk_wallet::error::CreateTxError as BdkCreateTxError;
 use bdk_wallet::keys::bip39::Error as BdkBip39Error;
+#[cfg(not(target_arch = "wasm32"))]
 use bdk_wallet::migration::PreV1MigrationError as BdkPreV1MigrationError;
 use bdk_wallet::miniscript::descriptor::DescriptorKeyParseError as BdkDescriptorKeyParseError;
 use bdk_wallet::miniscript::psbt::Error as BdkPsbtFinalizeError;
 use bdk_wallet::signer::SignerError as BdkSignerError;
 use bdk_wallet::tx_builder::AddForeignUtxoError as BdkAddForeignUtxoError;
 use bdk_wallet::tx_builder::AddUtxoError;
+use bdk_wallet::CreateWithPersistError as BdkCreateWithPersistError;
 use bdk_wallet::LoadWithPersistError as BdkLoadWithPersistError;
-use bdk_wallet::{chain, CreateWithPersistError as BdkCreateWithPersistError};
 
 use std::convert::TryInto;
 
@@ -368,6 +373,9 @@ pub enum ElectrumError {
 pub enum EsploraError {
     #[error("minreq error: {error_message}")]
     Minreq { error_message: String },
+
+    #[error("reqwest error: {error_message}")]
+    Reqwest { error_message: String },
 
     #[error("http error with status code {status} and message {error_message}")]
     HttpResponse { status: u16, error_message: String },
@@ -901,6 +909,7 @@ impl From<BdkAddForeignUtxoError> for AddForeignUtxoError {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl From<BdkElectrumError> for ElectrumError {
     fn from(error: BdkElectrumError) -> Self {
         match error {
@@ -1111,6 +1120,7 @@ impl From<PushBytesError> for CreateTxError {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl From<BdkCreateWithPersistError<chain::rusqlite::Error>> for CreateWithPersistError {
     fn from(error: BdkCreateWithPersistError<chain::rusqlite::Error>) -> Self {
         match error {
@@ -1241,7 +1251,12 @@ impl From<BdkBip32Error> for DescriptorKeyError {
 impl From<BdkEsploraError> for EsploraError {
     fn from(error: BdkEsploraError) -> Self {
         match error {
+            #[cfg(not(target_arch = "wasm32"))]
             BdkEsploraError::Minreq(e) => EsploraError::Minreq {
+                error_message: e.to_string(),
+            },
+            #[cfg(target_arch = "wasm32")]
+            BdkEsploraError::Reqwest(e) => EsploraError::Reqwest {
                 error_message: e.to_string(),
             },
             BdkEsploraError::HttpResponse { status, message } => EsploraError::HttpResponse {
@@ -1282,7 +1297,12 @@ impl From<BdkEsploraError> for EsploraError {
 impl From<Box<BdkEsploraError>> for EsploraError {
     fn from(error: Box<BdkEsploraError>) -> Self {
         match *error {
+            #[cfg(not(target_arch = "wasm32"))]
             BdkEsploraError::Minreq(e) => EsploraError::Minreq {
+                error_message: e.to_string(),
+            },
+            #[cfg(target_arch = "wasm32")]
+            BdkEsploraError::Reqwest(e) => EsploraError::Reqwest {
                 error_message: e.to_string(),
             },
             BdkEsploraError::HttpResponse { status, message } => EsploraError::HttpResponse {
@@ -1359,6 +1379,7 @@ impl From<BdkFromScriptError> for FromScriptError {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl From<BdkLoadWithPersistError<chain::rusqlite::Error>> for LoadWithPersistError {
     fn from(error: BdkLoadWithPersistError<chain::rusqlite::Error>) -> Self {
         match error {
@@ -1389,6 +1410,7 @@ impl From<BdkLoadWithPersistError<PersistenceError>> for LoadWithPersistError {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl From<BdkSqliteError> for PersistenceError {
     fn from(error: BdkSqliteError) -> Self {
         PersistenceError::Reason {
@@ -1397,6 +1419,7 @@ impl From<BdkSqliteError> for PersistenceError {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl From<BdkPreV1MigrationError> for PreV1MigrationError {
     fn from(error: BdkPreV1MigrationError) -> Self {
         match error {
@@ -1688,6 +1711,7 @@ impl From<BdkEncodeError> for TransactionError {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl From<bdk_kyoto::bip157::ClientError> for CbfError {
     fn from(_value: bdk_kyoto::bip157::ClientError) -> Self {
         CbfError::NodeStopped

--- a/bdk-ffi/src/esplora.rs
+++ b/bdk-ffi/src/esplora.rs
@@ -11,7 +11,14 @@ use crate::types::TxStatus;
 use crate::types::Update;
 use crate::types::{FullScanRequest, MerkleProof, OutputStatus, SyncRequest};
 
-use bdk_esplora::esplora_client::{BlockingClient, Builder};
+#[cfg(target_arch = "wasm32")]
+use bdk_esplora::esplora_client::AsyncClient;
+#[cfg(not(target_arch = "wasm32"))]
+use bdk_esplora::esplora_client::BlockingClient;
+use bdk_esplora::esplora_client::Builder;
+#[cfg(target_arch = "wasm32")]
+use bdk_esplora::EsploraAsyncExt;
+#[cfg(not(target_arch = "wasm32"))]
 use bdk_esplora::EsploraExt;
 use bdk_wallet::bitcoin::Transaction as BdkTransaction;
 use bdk_wallet::chain::spk_client::FullScanRequest as BdkFullScanRequest;
@@ -25,9 +32,108 @@ use std::sync::Arc;
 
 /// Wrapper around an esplora_client::BlockingClient which includes an internal in-memory transaction
 /// cache to avoid re-fetching already downloaded transactions.
+#[cfg(not(target_arch = "wasm32"))]
 #[derive(uniffi::Object)]
 pub struct EsploraClient(BlockingClient);
 
+/// Wrapper around an esplora_client::AsyncClient which includes an internal in-memory transaction
+/// cache to avoid re-fetching already downloaded transactions.
+#[cfg(target_arch = "wasm32")]
+#[derive(uniffi::Object)]
+pub struct EsploraClient(AsyncClient<web_sleeper::WebSleeper>);
+
+/// `Sleeper` implementation for wasm32 using the JavaScript `setTimeout` function.
+#[cfg(target_arch = "wasm32")]
+mod web_sleeper {
+    use bdk_esplora::esplora_client::Sleeper;
+    use futures_channel::oneshot::{channel, Receiver};
+    use js_sys::{Function, Reflect};
+    use std::future::Future;
+    use std::pin::Pin;
+    use std::task::{Context, Poll};
+    use std::time::Duration;
+    use wasm_bindgen::closure::Closure;
+    use wasm_bindgen::{JsCast, JsValue};
+
+    /// A oneshot receiver is used instead of a `JsFuture` because the `Sleep` future must be `Send`
+    pub struct WebSleep(Receiver<()>);
+
+    impl Future for WebSleep {
+        type Output = ();
+
+        fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
+            Pin::new(&mut self.0).poll(cx).map(|_| ())
+        }
+    }
+
+    #[derive(Debug, Clone, Copy)]
+    pub struct WebSleeper;
+
+    impl Sleeper for WebSleeper {
+        type Sleep = WebSleep;
+
+        fn sleep(dur: Duration) -> Self::Sleep {
+            let (sender, receiver) = channel::<()>();
+            let callback = Closure::once_into_js(move || {
+                let _ = sender.send(());
+            });
+            let global = js_sys::global();
+            let set_timeout: Function = Reflect::get(&global, &JsValue::from_str("setTimeout"))
+                .expect("setTimeout is defined on the global object")
+                .unchecked_into();
+            set_timeout
+                .call2(
+                    &global,
+                    &callback,
+                    &JsValue::from_f64(dur.as_millis() as f64),
+                )
+                .expect("setTimeout accepts a callback and a delay");
+            WebSleep(receiver)
+        }
+    }
+}
+
+fn take_full_scan_request(
+    request: &FullScanRequest,
+) -> Result<BdkFullScanRequest<KeychainKind>, EsploraError> {
+    // using option and take is not ideal but the only way to take full ownership of the request
+    request
+        .0
+        .lock()
+        .unwrap()
+        .take()
+        .ok_or(EsploraError::RequestAlreadyConsumed)
+}
+
+fn take_sync_request(
+    request: &SyncRequest,
+) -> Result<BdkSyncRequest<(KeychainKind, u32)>, EsploraError> {
+    // using option and take is not ideal but the only way to take full ownership of the request
+    request
+        .0
+        .lock()
+        .unwrap()
+        .take()
+        .ok_or(EsploraError::RequestAlreadyConsumed)
+}
+
+fn full_scan_update(result: BdkFullScanResponse<KeychainKind>) -> Arc<Update> {
+    Arc::new(Update(BdkUpdate {
+        last_active_indices: result.last_active_indices,
+        tx_update: result.tx_update,
+        chain: result.chain_update,
+    }))
+}
+
+fn sync_update(result: BdkSyncResponse) -> Arc<Update> {
+    Arc::new(Update(BdkUpdate {
+        last_active_indices: BTreeMap::default(),
+        tx_update: result.tx_update,
+        chain: result.chain_update,
+    }))
+}
+
+#[cfg(not(target_arch = "wasm32"))]
 #[uniffi::export]
 impl EsploraClient {
     /// Creates a new bdk client from an esplora_client::BlockingClient.
@@ -54,25 +160,11 @@ impl EsploraClient {
         stop_gap: u64,
         parallel_requests: u64,
     ) -> Result<Arc<Update>, EsploraError> {
-        // using option and take is not ideal but the only way to take full ownership of the request
-        let request: BdkFullScanRequest<KeychainKind> = request
-            .0
-            .lock()
-            .unwrap()
-            .take()
-            .ok_or(EsploraError::RequestAlreadyConsumed)?;
-
+        let request = take_full_scan_request(&request)?;
         let result: BdkFullScanResponse<KeychainKind> =
             self.0
                 .full_scan(request, stop_gap as usize, parallel_requests as usize)?;
-
-        let update = BdkUpdate {
-            last_active_indices: result.last_active_indices,
-            tx_update: result.tx_update,
-            chain: result.chain_update,
-        };
-
-        Ok(Arc::new(Update(update)))
+        Ok(full_scan_update(result))
     }
 
     /// Sync a set of scripts, txids, and/or outpoints against Esplora.
@@ -85,23 +177,9 @@ impl EsploraClient {
         request: Arc<SyncRequest>,
         parallel_requests: u64,
     ) -> Result<Arc<Update>, EsploraError> {
-        // using option and take is not ideal but the only way to take full ownership of the request
-        let request: BdkSyncRequest<(KeychainKind, u32)> = request
-            .0
-            .lock()
-            .unwrap()
-            .take()
-            .ok_or(EsploraError::RequestAlreadyConsumed)?;
-
+        let request = take_sync_request(&request)?;
         let result: BdkSyncResponse = self.0.sync(request, parallel_requests as usize)?;
-
-        let update = BdkUpdate {
-            last_active_indices: BTreeMap::default(),
-            tx_update: result.tx_update,
-            chain: result.chain_update,
-        };
-
-        Ok(Arc::new(Update(update)))
+        Ok(sync_update(result))
     }
 
     /// Broadcast a [`Transaction`] to Esplora.
@@ -234,6 +312,210 @@ impl EsploraClient {
     ) -> Result<Option<OutputStatus>, EsploraError> {
         self.0
             .get_output_status(&txid.0, vout)
+            .map(|status| status.map(OutputStatus::from))
+            .map_err(EsploraError::from)
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+#[uniffi::export]
+impl EsploraClient {
+    /// Creates a new bdk client from an esplora_client::AsyncClient.
+    /// Optional: Set the proxy of the builder. The proxy is ignored on wasm32.
+    #[uniffi::constructor(default(proxy = None))]
+    pub fn new(url: String, proxy: Option<String>) -> Result<Self, EsploraError> {
+        let mut builder = Builder::new(url.as_str());
+        if let Some(proxy) = proxy {
+            builder = builder.proxy(proxy.as_str());
+        }
+        Ok(Self(
+            builder.build_async_with_sleeper::<web_sleeper::WebSleeper>()?,
+        ))
+    }
+
+    /// Scan keychain scripts for transactions against Esplora, returning an update that can be
+    /// applied to the receiving structures.
+    ///
+    /// `request` provides the data required to perform a script-pubkey-based full scan
+    /// (see [`FullScanRequest`]). The full scan for each keychain (`K`) stops after a gap of
+    /// `stop_gap` script pubkeys with no associated transactions. `parallel_requests` specifies
+    /// the maximum number of HTTP requests to make in parallel.
+    pub async fn full_scan(
+        &self,
+        request: Arc<FullScanRequest>,
+        stop_gap: u64,
+        parallel_requests: u64,
+    ) -> Result<Arc<Update>, EsploraError> {
+        let request = take_full_scan_request(&request)?;
+        let result: BdkFullScanResponse<KeychainKind> = self
+            .0
+            .full_scan(request, stop_gap as usize, parallel_requests as usize)
+            .await?;
+        Ok(full_scan_update(result))
+    }
+
+    /// Sync a set of scripts, txids, and/or outpoints against Esplora.
+    ///
+    /// `request` provides the data required to perform a script-pubkey-based sync (see
+    /// [`SyncRequest`]). `parallel_requests` specifies the maximum number of HTTP requests to make
+    /// in parallel.
+    pub async fn sync(
+        &self,
+        request: Arc<SyncRequest>,
+        parallel_requests: u64,
+    ) -> Result<Arc<Update>, EsploraError> {
+        let request = take_sync_request(&request)?;
+        let result: BdkSyncResponse = self.0.sync(request, parallel_requests as usize).await?;
+        Ok(sync_update(result))
+    }
+
+    /// Broadcast a [`Transaction`] to Esplora.
+    pub async fn broadcast(&self, transaction: &Transaction) -> Result<(), EsploraError> {
+        let bdk_transaction: BdkTransaction = transaction.into();
+        self.0
+            .broadcast(&bdk_transaction)
+            .await
+            .map_err(EsploraError::from)
+    }
+
+    /// Get a [`Transaction`] option given its [`Txid`].
+    pub async fn get_tx(&self, txid: Arc<Txid>) -> Result<Option<Arc<Transaction>>, EsploraError> {
+        let tx_opt = self.0.get_tx(&txid.0).await?;
+        Ok(tx_opt.map(|inner| Arc::new(Transaction::from(inner))))
+    }
+
+    /// Get a `Transaction` given its `Txid`.
+    pub async fn get_tx_no_opt(&self, txid: Arc<Txid>) -> Result<Arc<Transaction>, EsploraError> {
+        self.0
+            .get_tx_no_opt(&txid.0)
+            .await
+            .map(Transaction::from)
+            .map(Arc::new)
+            .map_err(EsploraError::from)
+    }
+
+    /// Get the height of the current blockchain tip.
+    pub async fn get_height(&self) -> Result<u32, EsploraError> {
+        self.0.get_height().await.map_err(EsploraError::from)
+    }
+
+    /// Get the `BlockHash` of the current blockchain tip.
+    pub async fn get_tip_hash(&self) -> Result<Arc<BlockHash>, EsploraError> {
+        self.0
+            .get_tip_hash()
+            .await
+            .map(|hash| Arc::new(BlockHash(hash)))
+            .map_err(EsploraError::from)
+    }
+
+    /// Get a map where the key is the confirmation target (in number of
+    /// blocks) and the value is the estimated feerate (in sat/vB).
+    pub async fn get_fee_estimates(&self) -> Result<HashMap<u16, f64>, EsploraError> {
+        self.0.get_fee_estimates().await.map_err(EsploraError::from)
+    }
+
+    /// Get the [`BlockHash`] of a specific block height.
+    pub async fn get_block_hash(&self, block_height: u32) -> Result<Arc<BlockHash>, EsploraError> {
+        self.0
+            .get_block_hash(block_height)
+            .await
+            .map(|hash| Arc::new(BlockHash(hash)))
+            .map_err(EsploraError::from)
+    }
+
+    /// Get a Block given a particular BlockHash.
+    pub async fn get_block_by_hash(
+        &self,
+        block_hash: Arc<BlockHash>,
+    ) -> Result<Option<Block>, EsploraError> {
+        self.0
+            .get_block_by_hash(&block_hash.0)
+            .await
+            .map(|block| block.map(|block| block.into()))
+            .map_err(EsploraError::from)
+    }
+
+    /// Get a `Txid` of a transaction given its index in a block with a given hash.
+    pub async fn get_txid_at_block_index(
+        &self,
+        block_hash: Arc<BlockHash>,
+        index: u64,
+    ) -> Result<Option<Arc<Txid>>, EsploraError> {
+        self.0
+            .get_txid_at_block_index(&block_hash.0, index as usize)
+            .await
+            .map(|txid| txid.map(Txid).map(Arc::new))
+            .map_err(EsploraError::from)
+    }
+
+    /// Get a `Header` given a particular block hash.
+    pub async fn get_header_by_hash(
+        &self,
+        block_hash: Arc<BlockHash>,
+    ) -> Result<Header, EsploraError> {
+        self.0
+            .get_header_by_hash(&block_hash.0)
+            .await
+            .map(Header::from)
+            .map_err(EsploraError::from)
+    }
+
+    /// Get the status of a [`Transaction`] given its [`Txid`].
+    pub async fn get_tx_status(&self, txid: Arc<Txid>) -> Result<TxStatus, EsploraError> {
+        self.0
+            .get_tx_status(&txid.0)
+            .await
+            .map(TxStatus::from)
+            .map_err(EsploraError::from)
+    }
+
+    /// Get transaction info given its [`Txid`].
+    pub async fn get_tx_info(&self, txid: Arc<Txid>) -> Result<Option<Tx>, EsploraError> {
+        self.0
+            .get_tx_info(&txid.0)
+            .await
+            .map(|tx| tx.map(Tx::from))
+            .map_err(EsploraError::from)
+    }
+
+    /// Get transaction history for the specified address, sorted with newest first.
+    ///
+    /// Returns up to 50 mempool transactions plus the first 25 confirmed transactions.
+    /// More can be requested by specifying the last txid seen by the previous query.
+    pub async fn get_address_txs(
+        &self,
+        address: Arc<Address>,
+        last_seen: Option<Arc<Txid>>,
+    ) -> Result<Vec<Tx>, EsploraError> {
+        let last_seen = last_seen.as_ref().map(|txid| txid.0);
+        let txs = self
+            .0
+            .get_address_txs(&address.as_ref().0, last_seen)
+            .await?;
+
+        Ok(txs.into_iter().map(Tx::from).collect())
+    }
+
+    /// Get a merkle inclusion proof for a [`Transaction`] with the given
+    /// [`Txid`].
+    pub async fn get_merkle_proof(&self, txid: &Txid) -> Result<Option<MerkleProof>, EsploraError> {
+        self.0
+            .get_merkle_proof(&txid.0)
+            .await
+            .map(|proof| proof.map(MerkleProof::from))
+            .map_err(EsploraError::from)
+    }
+
+    /// Get the spending status of an output given a `Txid` and the output
+    /// index.
+    pub async fn get_output_status(
+        &self,
+        txid: Arc<Txid>,
+        vout: u64,
+    ) -> Result<Option<OutputStatus>, EsploraError> {
+        self.0
+            .get_output_status(&txid.0, vout)
+            .await
             .map(|status| status.map(OutputStatus::from))
             .map_err(EsploraError::from)
     }

--- a/bdk-ffi/src/lib.rs
+++ b/bdk-ffi/src/lib.rs
@@ -1,9 +1,11 @@
 mod bitcoin;
 mod descriptor;
+#[cfg(not(target_arch = "wasm32"))]
 mod electrum;
 mod error;
 mod esplora;
 mod keys;
+#[cfg(not(target_arch = "wasm32"))]
 mod kyoto;
 mod macros;
 mod signer;
@@ -15,7 +17,12 @@ mod wallet;
 #[cfg(test)]
 mod tests;
 
+#[cfg(not(target_arch = "wasm32"))]
 use crate::bitcoin::FeeRate;
 use crate::bitcoin::OutPoint;
+
+// This is required because the wasm runtime exports are otherwise dropped by the linker
+#[cfg(target_arch = "wasm32")]
+extern crate uniffi_runtime_wasm as _;
 
 uniffi::setup_scaffolding!("bdk");

--- a/bdk-ffi/src/store.rs
+++ b/bdk-ffi/src/store.rs
@@ -1,12 +1,18 @@
-use crate::error::{PersistenceError, PreV1MigrationError};
+use crate::error::PersistenceError;
+#[cfg(not(target_arch = "wasm32"))]
+use crate::error::PreV1MigrationError;
 use crate::types::{ChangeSet, KeychainKind};
 
+#[cfg(not(target_arch = "wasm32"))]
 use bdk_wallet::migration::{
     get_pre_v1_wallet_keychains as bdk_get_pre_v1_wallet_keychains,
     PreV1WalletKeychain as BdkPreV1WalletKeychain,
 };
-use bdk_wallet::{rusqlite::Connection as BdkConnection, WalletPersister};
+#[cfg(not(target_arch = "wasm32"))]
+use bdk_wallet::rusqlite::Connection as BdkConnection;
+use bdk_wallet::WalletPersister;
 
+#[cfg(not(target_arch = "wasm32"))]
 use std::ops::DerefMut;
 use std::sync::{Arc, Mutex};
 
@@ -22,6 +28,7 @@ pub trait Persistence: Send + Sync {
 
 pub(crate) enum PersistenceType {
     Custom(Arc<dyn Persistence>),
+    #[cfg(not(target_arch = "wasm32"))]
     Sql(Mutex<BdkConnection>),
 }
 
@@ -46,6 +53,18 @@ pub struct Persister {
 
 #[uniffi::export]
 impl Persister {
+    /// Use a native persistence layer.
+    #[uniffi::constructor]
+    pub fn custom(persistence: Arc<dyn Persistence>) -> Self {
+        Self {
+            inner: PersistenceType::Custom(persistence).into(),
+        }
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[uniffi::export]
+impl Persister {
     /// Create a new Sqlite connection at the specified file path.
     #[uniffi::constructor]
     pub fn new_sqlite(path: String) -> Result<Self, PersistenceError> {
@@ -62,14 +81,6 @@ impl Persister {
         Ok(Self {
             inner: PersistenceType::Sql(conn.into()).into(),
         })
-    }
-
-    /// Use a native persistence layer.
-    #[uniffi::constructor]
-    pub fn custom(persistence: Arc<dyn Persistence>) -> Self {
-        Self {
-            inner: PersistenceType::Custom(persistence).into(),
-        }
     }
 
     /// Retrieve keychain metadata from a pre-v1 BDK SQLite wallet database.
@@ -89,6 +100,7 @@ impl Persister {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl From<BdkPreV1WalletKeychain> for PreV1WalletKeychain {
     fn from(value: BdkPreV1WalletKeychain) -> Self {
         Self {
@@ -104,6 +116,7 @@ impl WalletPersister for PersistenceType {
 
     fn initialize(persister: &mut Self) -> Result<bdk_wallet::ChangeSet, Self::Error> {
         match persister {
+            #[cfg(not(target_arch = "wasm32"))]
             PersistenceType::Sql(ref conn) => {
                 let mut lock = conn.lock().unwrap();
                 let deref = lock.deref_mut();
@@ -117,6 +130,7 @@ impl WalletPersister for PersistenceType {
 
     fn persist(persister: &mut Self, changeset: &bdk_wallet::ChangeSet) -> Result<(), Self::Error> {
         match persister {
+            #[cfg(not(target_arch = "wasm32"))]
             PersistenceType::Sql(ref conn) => {
                 let mut lock = conn.lock().unwrap();
                 let deref = lock.deref_mut();


### PR DESCRIPTION
### Description

Make the crate compile for `wasm32-unknown-unknown`, so that a UniFFI binding generator such as `uniffi-bindgen-react-native` (`wasm2` flavor) can produce browser and Node bindings from the same API the native bindings use. Native targets are unchanged.

How the wasm package gets built and published is still open. That discussion lives in this gist: https://gist.github.com/bennyhodl/e290b7de4ee8c746ee28f19695ab7bd2. Whatever is decided there, the `cfg` splits in this PR are required for any wasm build, because `rusqlite`, `minreq`, `bdk_electrum` and `bdk_kyoto` have no wasm32 support and cannot be replaced from a downstream package.

What changes:

- `Cargo.toml`: `rusqlite`, the blocking Esplora client, `bdk_electrum` and `bdk_kyoto` move to a `cfg(not(target_arch = "wasm32"))` table. A wasm32 table adds the async Esplora client, `getrandom/js`, UniFFI's `wasm-unstable-single-threaded` feature, `uniffi-runtime-wasm`, and `wasm-bindgen`/`js-sys`/`futures-channel` for the sleeper. `resolver = "2"` stops features from unifying across target tables.
- `esplora.rs`: on wasm32 `EsploraClient` wraps `AsyncClient`. Every method keeps its name, arguments and result but is `async`. The constructor returns a `Result` because building the reqwest client can fail. Retry backoff sleeps through the host's global `setTimeout`, so it works in browsers, workers and Node. The request/update helpers are shared by both implementations.
- `store.rs`: `Persister::custom` is available on every target. The SQLite constructors and the pre-v1 migration helper are native only.
- `error.rs`: `EsploraError` gains a `Reqwest` variant. It exists on every target so the generated API is identical, but native never produces it. Electrum, SQLite, migration and Kyoto conversions are native only.
- `lib.rs`: the `electrum` and `kyoto` modules are not compiled on wasm32. An `extern crate uniffi_runtime_wasm` line keeps the runtime exports from being dropped by the linker.
- CI: a new `wasm` job runs `cargo check --locked` and `cargo clippy --locked` for `wasm32-unknown-unknown`.

### Notes to the reviewers

- `wasm-unstable-single-threaded` is not a threading model choice. It only removes the `Send + Sync` bounds UniFFI requires on native, where foreign threads call in. `wasm32-unknown-unknown` has no threads. The `Persistence` trait keeps its `Send + Sync` bounds and compiles as is.
- `secp256k1-sys` needs a C compiler with a wasm32 backend. Ubuntu's clang has one, so CI sets `CC_wasm32_unknown_unknown=clang`. Apple's clang does not, so on macOS point that variable at an LLVM clang (for example Homebrew's `llvm`).
- Feature isolation was verified with `cargo tree`: native has no `reqwest` or `wasm-bindgen`, and wasm32 has no `rusqlite` or `minreq`.
- The `proxy` argument on the wasm32 `EsploraClient` constructor is kept for API parity and does nothing on that target.
- No `CHANGELOG.md` edit in this PR, following the release flow where entries come from the `changelog:` label.

### Documentation

- [x] Other:
  - esplora-client `AsyncClient`: https://docs.rs/esplora-client/0.12.3/esplora_client/async/struct.AsyncClient.html
  - esplora-client `Sleeper` trait: https://docs.rs/esplora-client/0.12.3/esplora_client/async/trait.Sleeper.html
  - bdk_esplora `EsploraAsyncExt`: https://docs.rs/bdk_esplora/0.22.2/bdk_esplora/trait.EsploraAsyncExt.html
  - `uniffi-runtime-wasm`: https://docs.rs/uniffi-runtime-wasm/0.31.0-5/uniffi_runtime_wasm/
  - uniffi-bindgen-react-native `wasm2` reference: https://github.com/jhugman/uniffi-bindgen-react-native/tree/main/docs/src/reference/wasm2
  - Build and publish proposal: https://gist.github.com/bennyhodl/e290b7de4ee8c746ee28f19695ab7bd2

### Changelog

`changelog: added`

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
* [ ] I've added exactly one `changelog:*` label (needs a maintainer: `changelog: added`)
* [x] I've linked the relevant upstream docs or specs above

#### New Features:

* [ ] I've added tests for the new feature. The CI job checks and lints the wasm32 target. A runtime test needs a JavaScript host and lives with the binding generator, not in this crate. The native test suite is unchanged.
* [x] I've added docs for the new feature
